### PR TITLE
feature/contributions-attestations-flow-ux

### DIFF
--- a/apps/protocol-frontend/src/components/AttestationsTable.tsx
+++ b/apps/protocol-frontend/src/components/AttestationsTable.tsx
@@ -135,7 +135,6 @@ const AttestationsTable = ({
 
   useEffect(() => {
     setSelectedContributions(selectedFlatRows);
-    console.log(selectedFlatRows);
   }, [selectedFlatRows, selectedRowIds]);
 
   return (

--- a/apps/protocol-frontend/src/components/AttestationsTable.tsx
+++ b/apps/protocol-frontend/src/components/AttestationsTable.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo } from 'react';
+import * as _ from 'lodash';
 import { format } from 'date-fns';
 import {
   Table,
@@ -21,6 +22,7 @@ import {
   useRowSelect,
 } from 'react-table';
 import { ModalWrapper } from '@govrn/protocol-ui';
+import { useUser } from '../contexts/UserContext';
 import { useOverlay } from '../contexts/OverlayContext';
 import IndeterminateCheckbox from './IndeterminateCheckbox';
 import GlobalFilter from './GlobalFilter';
@@ -32,6 +34,7 @@ const AttestationsTable = ({
 }: any) => {
   const localOverlay = useOverlay();
   const { setModals } = useOverlay();
+  const { userData } = useUser();
   const [selectedContribution, setSelectedContribution] = useState<any>();
 
   const handleAddAttestationFormModal = (id: number) => {
@@ -39,9 +42,13 @@ const AttestationsTable = ({
     setModals({ addAttestationFormModal: true });
   };
 
+  const unattestedContributions = _.filter(contributionsData, function (a) {
+    return a.attestations.every((b: any) => b.user_id !== userData.id);
+  });
+
   const data = useMemo(
     () =>
-      contributionsData.map((contribution: any) => ({
+      unattestedContributions.map((contribution: any) => ({
         id: contribution.id,
         submissionDate: format(new Date(contribution.date_of_submission), 'P'),
         engagementDate: format(new Date(contribution.date_of_engagement), 'P'),

--- a/apps/protocol-frontend/src/components/AttestationsTable.tsx
+++ b/apps/protocol-frontend/src/components/AttestationsTable.tsx
@@ -57,7 +57,6 @@ const AttestationsTable = ({
         //   contribution.attestations !== null
         //     ? Object.keys(contribution.attestations).length
         //     : 0,
-        verificationLevel: contribution.verificationLevel,
         guilds: contribution.attestations || null,
         status: contribution.status.name,
         action: '',

--- a/apps/protocol-frontend/src/components/AttestationsTableShell.tsx
+++ b/apps/protocol-frontend/src/components/AttestationsTableShell.tsx
@@ -8,7 +8,6 @@ import {
   useBreakpointValue,
   ButtonGroup,
   Button,
-  useDisclosure,
 } from '@chakra-ui/react';
 import { useUser } from '../contexts/UserContext';
 import { useOverlay } from '../contexts/OverlayContext';
@@ -19,7 +18,7 @@ import { ModalWrapper } from '@govrn/protocol-ui';
 import BulkAttestationModal from './BulkAttestationModal';
 
 const AttestationsTableShell = () => {
-  const { userContributions } = useUser();
+  const { daoContributions } = useUser();
   const localOverlay = useOverlay();
   const { setModals } = useOverlay();
   const [selectedContributions, setSelectedContributions] = useState<any>();
@@ -27,6 +26,14 @@ const AttestationsTableShell = () => {
   const attestationsModalHandler = () => {
     setModals({ bulkAttestationModal: true });
   };
+
+  console.log('all contributions', daoContributions);
+  // console.log(
+  //   'not my attestations',
+  //   daoContributions
+  //     ?.filter((c) => c.attestations.length > 0)
+  //     .filter((c) => c.attestations.filter((a) => a.user_id !== 2))
+  // );
 
   const isMobile = useBreakpointValue({ base: true, md: false });
   return (
@@ -38,7 +45,7 @@ const AttestationsTableShell = () => {
         maxWidth="1200px"
       >
         <PageHeading>Attestations</PageHeading>
-        {userContributions && userContributions.length > 0 ? (
+        {daoContributions && daoContributions.length > 0 ? (
           <Box
             background="white"
             boxShadow="sm"
@@ -69,7 +76,7 @@ const AttestationsTableShell = () => {
               </Box>
               <Box overflowX="auto">
                 <AttestationsTable
-                  contributionsData={userContributions}
+                  contributionsData={daoContributions}
                   setSelectedContributions={setSelectedContributions}
                 />
               </Box>

--- a/apps/protocol-frontend/src/components/AttestationsTableShell.tsx
+++ b/apps/protocol-frontend/src/components/AttestationsTableShell.tsx
@@ -11,91 +11,100 @@ import {
   useDisclosure,
 } from '@chakra-ui/react';
 import { useUser } from '../contexts/UserContext';
+import { useOverlay } from '../contexts/OverlayContext';
 import PageHeading from './PageHeading';
 import AttestationsTable from './AttestationsTable';
 import EmptyContributions from './EmptyContributions';
+import { ModalWrapper } from '@govrn/protocol-ui';
+import BulkAttestationModal from './BulkAttestationModal';
 
 const AttestationsTableShell = () => {
   const { userContributions } = useUser();
+  const localOverlay = useOverlay();
+  const { setModals } = useOverlay();
   const [selectedContributions, setSelectedContributions] = useState<any>();
-  const { isOpen, onOpen, onClose } = useDisclosure();
 
-  const attestationsHandler = () => {
-    selectedContributions.map(
-      (contribution, idx) =>
-        console.log(`attesatations: ${idx}`, contribution.original)
-      // mint logic
-    );
+  const attestationsModalHandler = () => {
+    setModals({ bulkAttestationModal: true });
   };
 
   const isMobile = useBreakpointValue({ base: true, md: false });
   return (
-    <Container
-      paddingY={{ base: '4', md: '8' }}
-      paddingX={{ base: '0', md: '8' }}
-      color="gray.700"
-      maxWidth="1200px"
-    >
-      <PageHeading>Attestations</PageHeading>
-      {userContributions && userContributions.length > 0 ? (
-        <Box
-          background="white"
-          boxShadow="sm"
-          borderRadius={{ base: 'none', md: 'lg' }}
-        >
-          <Stack spacing="5">
-            <Box paddingX={{ base: '4', md: '6' }} paddingTop="5">
-              <Stack
-                direction={{ base: 'column', md: 'row' }}
-                justify="space-between"
-              >
-                <Text fontSize="lg" fontWeight="medium">
-                  DAO Contributions
-                </Text>
-                <Button
-                  bgColor="brand.primary.50"
-                  color="brand.primary.600"
-                  transition="all 100ms ease-in-out"
-                  _hover={{ bgColor: 'brand.primary.100' }}
-                  flexBasis="10%"
-                  colorScheme="brand.primary"
-                  disabled={selectedContributions?.length === 0}
-                  onClick={attestationsHandler}
+    <>
+      <Container
+        paddingY={{ base: '4', md: '8' }}
+        paddingX={{ base: '0', md: '8' }}
+        color="gray.700"
+        maxWidth="1200px"
+      >
+        <PageHeading>Attestations</PageHeading>
+        {userContributions && userContributions.length > 0 ? (
+          <Box
+            background="white"
+            boxShadow="sm"
+            borderRadius={{ base: 'none', md: 'lg' }}
+          >
+            <Stack spacing="5">
+              <Box paddingX={{ base: '4', md: '6' }} paddingTop="5">
+                <Stack
+                  direction={{ base: 'column', md: 'row' }}
+                  justify="space-between"
                 >
-                  Vouch
-                </Button>
-              </Stack>
-            </Box>
-            <Box overflowX="auto">
-              <AttestationsTable
-                contributionsData={userContributions}
-                setSelectedContributions={setSelectedContributions}
-              />
-            </Box>
-            <Box px={{ base: '4', md: '6' }} pb="5">
-              <HStack spacing="3" justify="space-between">
-                {!isMobile && (
-                  <Text color="muted" fontSize="sm">
-                    Showing 1 to (x) of (y) results
+                  <Text fontSize="lg" fontWeight="medium">
+                    DAO Contributions
                   </Text>
-                )}
-                <ButtonGroup
-                  spacing="3"
-                  justifyContent="space-between"
-                  width={{ base: 'full', md: 'auto' }}
-                  variant="secondary"
-                >
-                  <Button>Previous</Button>
-                  <Button>Next</Button>
-                </ButtonGroup>
-              </HStack>
-            </Box>
-          </Stack>
-        </Box>
-      ) : (
-        <EmptyContributions />
-      )}
-    </Container>
+                  <Button
+                    bgColor="brand.primary.50"
+                    color="brand.primary.600"
+                    transition="all 100ms ease-in-out"
+                    _hover={{ bgColor: 'brand.primary.100' }}
+                    flexBasis="10%"
+                    colorScheme="brand.primary"
+                    disabled={selectedContributions?.length === 0}
+                    onClick={attestationsModalHandler}
+                  >
+                    Attest
+                  </Button>
+                </Stack>
+              </Box>
+              <Box overflowX="auto">
+                <AttestationsTable
+                  contributionsData={userContributions}
+                  setSelectedContributions={setSelectedContributions}
+                />
+              </Box>
+              <Box px={{ base: '4', md: '6' }} pb="5">
+                <HStack spacing="3" justify="space-between">
+                  {!isMobile && (
+                    <Text color="muted" fontSize="sm">
+                      Showing 1 to (x) of (y) results
+                    </Text>
+                  )}
+                  <ButtonGroup
+                    spacing="3"
+                    justifyContent="space-between"
+                    width={{ base: 'full', md: 'auto' }}
+                    variant="secondary"
+                  >
+                    <Button>Previous</Button>
+                    <Button>Next</Button>
+                  </ButtonGroup>
+                </HStack>
+              </Box>
+            </Stack>
+          </Box>
+        ) : (
+          <EmptyContributions />
+        )}
+      </Container>
+      <ModalWrapper
+        name="bulkAttestationModal"
+        title="Attest to DAO Contributions"
+        localOverlay={localOverlay}
+        size="3xl"
+        content={<BulkAttestationModal contributions={selectedContributions} />}
+      />
+    </>
   );
 };
 

--- a/apps/protocol-frontend/src/components/AttestationsTableShell.tsx
+++ b/apps/protocol-frontend/src/components/AttestationsTableShell.tsx
@@ -20,10 +20,10 @@ const AttestationsTableShell = () => {
   const [selectedContributions, setSelectedContributions] = useState<any>();
   const { isOpen, onOpen, onClose } = useDisclosure();
 
-  const handleAddAttestation = () => {
+  const attestationsHandler = () => {
     selectedContributions.map(
       (contribution, idx) =>
-        console.log(`contribution: ${idx}`, contribution.original)
+        console.log(`attesatations: ${idx}`, contribution.original)
       // mint logic
     );
   };
@@ -60,6 +60,7 @@ const AttestationsTableShell = () => {
                   flexBasis="10%"
                   colorScheme="brand.primary"
                   disabled={selectedContributions?.length === 0}
+                  onClick={attestationsHandler}
                 >
                   Vouch
                 </Button>

--- a/apps/protocol-frontend/src/components/AttestationsTableShell.tsx
+++ b/apps/protocol-frontend/src/components/AttestationsTableShell.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+
 import {
   Container,
   Stack,
@@ -26,14 +27,6 @@ const AttestationsTableShell = () => {
   const attestationsModalHandler = () => {
     setModals({ bulkAttestationModal: true });
   };
-
-  console.log('all contributions', daoContributions);
-  // console.log(
-  //   'not my attestations',
-  //   daoContributions
-  //     ?.filter((c) => c.attestations.length > 0)
-  //     .filter((c) => c.attestations.filter((a) => a.user_id !== 2))
-  // );
 
   const isMobile = useBreakpointValue({ base: true, md: false });
   return (

--- a/apps/protocol-frontend/src/components/BulkAttestationModal.tsx
+++ b/apps/protocol-frontend/src/components/BulkAttestationModal.tsx
@@ -1,0 +1,43 @@
+import { Stack, Flex, Button, Text } from '@chakra-ui/react';
+
+import { useUser } from '../contexts/UserContext';
+
+interface BulkAttestationModalProps {
+  contributions: any;
+}
+
+const createAttestationsHandler = (contributions) => {
+  contributions.map(
+    (contribution, idx) =>
+      console.log(`attesatations: ${idx}`, contribution.original)
+    // mint logic
+  );
+};
+
+const BulkAttestationModal = ({ contributions }: BulkAttestationModalProps) => {
+  const { userData } = useUser();
+
+  return (
+    <Stack spacing="4" width="100%" color="gray.800">
+      <Text paddingBottom={2}>Attesting as: {userData.name}</Text>
+      <Text paddingBottom={2}>
+        Attesting to {contributions.length} Contributions
+      </Text>
+      <Flex align="flex-end" marginTop={4}>
+        <Button
+          type="submit"
+          width="100%"
+          color="brand.primary.600"
+          backgroundColor="brand.primary.50"
+          transition="all 100ms ease-in-out"
+          _hover={{ bgColor: 'brand.primary.100' }}
+          onClick={() => createAttestationsHandler(contributions)}
+        >
+          Add Attestations
+        </Button>
+      </Flex>
+    </Stack>
+  );
+};
+
+export default BulkAttestationModal;

--- a/apps/protocol-frontend/src/components/BulkAttestationModal.tsx
+++ b/apps/protocol-frontend/src/components/BulkAttestationModal.tsx
@@ -1,28 +1,40 @@
-import { Stack, Flex, Button, Text } from '@chakra-ui/react';
-
+import { useState } from 'react';
+import { Stack, Flex, Button, Text, Progress } from '@chakra-ui/react';
 import { useUser } from '../contexts/UserContext';
 
 interface BulkAttestationModalProps {
   contributions: any;
 }
 
-const createAttestationsHandler = (contributions) => {
-  contributions.map(
-    (contribution, idx) =>
-      console.log(`attesatations: ${idx}`, contribution.original)
-    // mint logic
-  );
-};
-
 const BulkAttestationModal = ({ contributions }: BulkAttestationModalProps) => {
-  const { userData } = useUser();
+  const { userData, createAttestation } = useUser();
+  const [attesting, setAttesting] = useState(false);
+  const [currentAttestation, setCurrentAttestation] = useState(1);
+
+  console.log('contributions', contributions);
+  const createAttestationsHandler = (contributions) => {
+    setAttesting(true);
+    contributions.map((contribution, idx) => {
+      // mint and attest logic
+      createAttestation(contribution.original);
+      console.log(`contribution: ${idx}`, contribution.original);
+      setAttesting(false);
+    });
+  };
 
   return (
     <Stack spacing="4" width="100%" color="gray.800">
       <Text paddingBottom={2}>Attesting as: {userData.name}</Text>
       <Text paddingBottom={2}>
-        Attesting to {contributions.length} Contributions
+        Attesting to {contributions.length}{' '}
+        {contributions.length === 1 ? 'Contribution' : 'Contributions'}
       </Text>
+      {attesting ? (
+        <Progress
+          color="brand.primary"
+          value={currentAttestation % contributions.length}
+        />
+      ) : null}
       <Flex align="flex-end" marginTop={4}>
         <Button
           type="submit"
@@ -32,6 +44,7 @@ const BulkAttestationModal = ({ contributions }: BulkAttestationModalProps) => {
           transition="all 100ms ease-in-out"
           _hover={{ bgColor: 'brand.primary.100' }}
           onClick={() => createAttestationsHandler(contributions)}
+          isLoading={attesting}
         >
           Add Attestations
         </Button>

--- a/apps/protocol-frontend/src/components/ConnectWallet.tsx
+++ b/apps/protocol-frontend/src/components/ConnectWallet.tsx
@@ -25,7 +25,11 @@ const ConnectWallet = () => {
           color="brand.primary.600"
           backgroundColor="brand.primary.50"
           transition="all 100ms ease-in-out"
-          _hover={{ bgColor: 'brand.primary.100' }}
+          _hover={{
+            bgColor: 'brand.primary.100',
+            borderWidth: '2px',
+            borderColor: 'brand.primary.600',
+          }}
           // width="100%"
           leftIcon={<FiKey />}
           disabled={isConnecting}

--- a/apps/protocol-frontend/src/components/ContributionTypesTable.tsx
+++ b/apps/protocol-frontend/src/components/ContributionTypesTable.tsx
@@ -86,13 +86,14 @@ const ContributionTypesTable = ({ contributionTypesData }: any) => {
         },
       },
       {
-        Header: 'Name',
-        accessor: 'name',
-      },
-      {
         Header: 'Last Occurrence',
         accessor: 'engagementDate',
       },
+      {
+        Header: 'Name',
+        accessor: 'name',
+      },
+
       { Header: 'DAOs', accessor: 'guilds' },
     ],
     []

--- a/apps/protocol-frontend/src/components/ContributionTypesTable.tsx
+++ b/apps/protocol-frontend/src/components/ContributionTypesTable.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { format } from 'date-fns';
-import { Table, Tbody, Td, Th, Thead, Tr, chakra } from '@chakra-ui/react';
+import { Box, Table, Tbody, Td, Th, Thead, Tr, chakra } from '@chakra-ui/react';
 import { IoArrowDown, IoArrowUp } from 'react-icons/io5';
 import { useTable, useSortBy } from 'react-table';
 import { isAfter } from 'date-fns';
@@ -56,10 +56,34 @@ const ContributionTypesTable = ({ contributionTypesData }: any) => {
       {
         Header: 'Activity Type',
         accessor: 'activityType',
+        Cell: ({ value }) => {
+          return (
+            <Box
+              bgColor="blue.50"
+              width="fit-content"
+              padding={2}
+              borderRadius="md"
+            >
+              {value}
+            </Box>
+          );
+        },
       },
       {
         Header: 'Total',
         accessor: 'total',
+        Cell: ({ value }) => {
+          return (
+            <Box
+              bgColor="blue.50"
+              width="fit-content"
+              padding={2}
+              borderRadius="md"
+            >
+              {value}
+            </Box>
+          );
+        },
       },
       {
         Header: 'Name',

--- a/apps/protocol-frontend/src/components/ContributionsTable.tsx
+++ b/apps/protocol-frontend/src/components/ContributionsTable.tsx
@@ -52,7 +52,7 @@ const ContributionsTable = ({
         id: contribution.id,
         submissionDate: format(new Date(contribution.date_of_submission), 'P'),
         engagementDate: format(new Date(contribution.date_of_engagement), 'P'),
-        attestations: contribution.attestations?.length,
+        attestations: contribution.attestations || null,
         user: contribution.user.id,
         activityTypeId: contribution.activity_type.id,
         status: contribution.status.name,
@@ -89,6 +89,9 @@ const ContributionsTable = ({
       {
         Header: 'Attestations',
         accessor: 'attestations',
+        Cell: ({ value }) => {
+          return <Text textTransform="capitalize">{value.length}</Text>;
+        },
       },
     ],
     []

--- a/apps/protocol-frontend/src/components/ContributionsTable.tsx
+++ b/apps/protocol-frontend/src/components/ContributionsTable.tsx
@@ -55,7 +55,6 @@ const ContributionsTable = ({
         attestations: contribution.attestations?.length,
         user: contribution.user.id,
         activityTypeId: contribution.activity_type.id,
-        verificationLevel: contribution.verificationLevel,
         status: contribution.status.name,
         action: '',
       })),
@@ -90,10 +89,6 @@ const ContributionsTable = ({
       {
         Header: 'Attestations',
         accessor: 'attestations',
-      },
-      {
-        Header: 'Verification Level',
-        accessor: 'verificationLevel',
       },
     ],
     []

--- a/apps/protocol-frontend/src/components/ContributionsTableShell.tsx
+++ b/apps/protocol-frontend/src/components/ContributionsTableShell.tsx
@@ -15,27 +15,25 @@ import {
   TabPanel,
   Alert,
   AlertDescription,
-  useDisclosure,
 } from '@chakra-ui/react';
+import { useOverlay } from '../contexts/OverlayContext';
 import { useUser } from '../contexts/UserContext';
+import { ModalWrapper } from '@govrn/protocol-ui';
+import MintModal from './MintModal';
 import PageHeading from './PageHeading';
-import MintInfoDialog from './MintInfoDialog';
 import ContributionsTable from './ContributionsTable';
 import ContributionTypesTable from './ContributionTypesTable';
 import EmptyContributions from './EmptyContributions';
 
 const ContributionsTableShell = () => {
   const { userContributions } = useUser();
+  const localOverlay = useOverlay();
+  const { setModals } = useOverlay();
   const [selectedContributions, setSelectedContributions] = useState<any>();
   const isMobile = useBreakpointValue({ base: true, md: false });
-  const { isOpen, onOpen, onClose } = useDisclosure();
 
-  const handleMintContributions = () => {
-    selectedContributions.map(
-      (contribution, idx) =>
-        console.log(`contribution: ${idx}`, contribution.original)
-      // mint logic
-    );
+  const mintModalHandler = () => {
+    setModals({ mintModal: true });
   };
 
   return (
@@ -92,7 +90,7 @@ const ContributionsTableShell = () => {
                             _hover={{ bgColor: 'brand.primary.100' }}
                             flexBasis="10%"
                             colorScheme="brand.primary"
-                            onClick={onOpen}
+                            onClick={mintModalHandler}
                             disabled={selectedContributions?.length === 0}
                           >
                             Mint
@@ -180,13 +178,12 @@ const ContributionsTableShell = () => {
           <EmptyContributions />
         )}
       </Container>
-      <MintInfoDialog
-        isOpen={isOpen}
-        onClose={onClose}
-        totalContributions={
-          selectedContributions && selectedContributions?.length
-        }
-        mintHandler={handleMintContributions}
+      <ModalWrapper
+        name="mintModal"
+        title="Mint Your DAO Contributions"
+        localOverlay={localOverlay}
+        size="3xl"
+        content={<MintModal contributions={selectedContributions} />}
       />
     </>
   );

--- a/apps/protocol-frontend/src/components/MintModal.tsx
+++ b/apps/protocol-frontend/src/components/MintModal.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+import { Stack, Flex, Button, Text, Progress } from '@chakra-ui/react';
+import { useUser } from '../contexts/UserContext';
+
+interface MintModalProps {
+  contributions: any;
+}
+
+const MintModal = ({ contributions }: MintModalProps) => {
+  const { userData } = useUser();
+  const [minting, setMinting] = useState(false);
+  const [currentContribution, setCurrentContribution] = useState(1);
+
+  console.log('contributions', contributions);
+  const mintHandler = (contributions) => {
+    setMinting(true);
+    contributions.map((contribution, idx) => {
+      // mint logic
+      console.log(`contribution: ${idx}`, contribution.original);
+      setMinting(false);
+    });
+  };
+
+  return (
+    <Stack spacing="4" width="100%" color="gray.800">
+      <Text paddingBottom={2}>
+        Minting {contributions.length}{' '}
+        {contributions.length === 1 ? 'Contribution' : 'Contributions'}
+      </Text>
+      {minting ? <Progress color="brand.primary" /> : null}
+      <Flex align="flex-end" marginTop={4}>
+        <Button
+          type="submit"
+          width="100%"
+          color="brand.primary.600"
+          backgroundColor="brand.primary.50"
+          transition="all 100ms ease-in-out"
+          _hover={{ bgColor: 'brand.primary.100' }}
+          onClick={() => mintHandler(contributions)}
+          isLoading={minting}
+        >
+          Mint Contributions
+        </Button>
+      </Flex>
+    </Stack>
+  );
+};
+
+export default MintModal;

--- a/apps/protocol-frontend/src/components/ReportForm.tsx
+++ b/apps/protocol-frontend/src/components/ReportForm.tsx
@@ -119,7 +119,7 @@ const ReportForm = () => {
           name="engagementDate"
           localForm={localForm}
           label="Date of Contribution Engagement (UTC)"
-          defaultValue={engagementDateValue}
+          defaultValue={new Date()}
           onChange={(date) => {
             setEngagementDateValue(date);
             setValue('engagementDate', date);

--- a/apps/protocol-frontend/src/contexts/OverlayContext.tsx
+++ b/apps/protocol-frontend/src/contexts/OverlayContext.tsx
@@ -13,6 +13,7 @@ export const OverlayContextProvider: React.FC<OverlayProviderProps> = ({
     reportingFormModal: false,
     editContributionFormModal: false,
     addAttestationFormModal: false,
+    bulkAttestationModal: false,
   });
 
   return (

--- a/apps/protocol-frontend/src/contexts/OverlayContext.tsx
+++ b/apps/protocol-frontend/src/contexts/OverlayContext.tsx
@@ -14,6 +14,7 @@ export const OverlayContextProvider: React.FC<OverlayProviderProps> = ({
     editContributionFormModal: false,
     addAttestationFormModal: false,
     bulkAttestationModal: false,
+    mintModal: false,
   });
 
   return (

--- a/apps/protocol-frontend/src/contexts/UserContext.tsx
+++ b/apps/protocol-frontend/src/contexts/UserContext.tsx
@@ -233,6 +233,7 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
         position: 'top-right',
       });
       console.log('response', response);
+      getDaoContributions();
     } catch (error) {
       console.log(error);
       toast({

--- a/apps/protocol-frontend/src/contexts/UserContext.tsx
+++ b/apps/protocol-frontend/src/contexts/UserContext.tsx
@@ -25,6 +25,7 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
   const [userDataByAddress, setUserDataByAddress] = useState<any>(null);
   const [userData, setUserData] = useState<any>(null);
   const [userContributions, setUserContributions] = useState<any>(null);
+  const [daoContributions, setDaoContributions] = useState<any>(null);
   const [userAttestations, setUserAttestations] = useState<any>(null);
   const [userActivityTypes, setUserActivityTypes] = useState<any>(null);
 
@@ -35,6 +36,7 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
   const getUser = async () => {
     try {
       const userDataResponse = await govrn.user.get(userDataByAddress.id);
+
       setUserData(userDataResponse);
       return userDataResponse;
     } catch (error) {
@@ -51,6 +53,7 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
       if (userDataByAddressResponse.length > 0) {
         setUserDataByAddress(userDataByAddressResponse[0]);
       }
+
       return userDataByAddress;
     } catch (error) {
       console.error(error);
@@ -61,12 +64,27 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
     try {
       const userContributionsResponse = await govrn.contribution.list({
         where: {
-          user_id: { equals: userAddress?.id },
+          user_id: { equals: userData?.id },
         },
         first: 1000,
       });
       setUserContributions(userContributionsResponse);
       return userContributionsResponse;
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const getDaoContributions = async () => {
+    try {
+      const daoContributionsResponse = await govrn.contribution.list({
+        // where: {
+        //   user_id: { equals: userData?.id },
+        // },
+        first: 1000,
+      });
+      setDaoContributions(daoContributionsResponse);
+      return daoContributionsResponse;
     } catch (error) {
       console.error(error);
     }
@@ -170,7 +188,6 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
   };
 
   const createAttestation = async (contribution: any, values: any) => {
-    console.log('contribution incoming', contribution);
     try {
       const response = await govrn.attestation.create({
         data: {
@@ -404,12 +421,19 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
   }, [userData]);
 
   useEffect(() => {
+    if (userData !== null) {
+      getDaoContributions();
+    }
+  }, [userData]);
+
+  useEffect(() => {
     getUserActivityTypes();
   }, [userData]);
 
   useEffect(() => {
     getUserAttestations();
   }, [userData]);
+
   return (
     <UserContext.Provider
       value={{
@@ -421,6 +445,8 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
         setUserDataByAddress,
         userContributions,
         setUserContributions,
+        daoContributions,
+        setDaoContributions,
         userAttestations,
         setUserAttestations,
         userActivityTypes,
@@ -447,6 +473,8 @@ export const useUser = () => {
     setUserData,
     userContributions,
     setUserContributions,
+    daoContributions,
+    setDaoContributions,
     userAttestations,
     setUserAttestations,
     userActivityTypes,
@@ -466,6 +494,8 @@ export const useUser = () => {
     setUserData,
     userContributions,
     setUserContributions,
+    daoContributions,
+    setDaoContributions,
     userAttestations,
     setUserAttestations,
     userActivityTypes,

--- a/apps/protocol-frontend/src/contexts/UserContext.tsx
+++ b/apps/protocol-frontend/src/contexts/UserContext.tsx
@@ -169,6 +169,48 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
     }
   };
 
+  const createAttestation = async (contribution: any, values: any) => {
+    try {
+      await govrn.attestation.create({
+        data: {
+          user: {
+            connectOrCreate: {
+              create: {
+                address: userData.address,
+                chain_type: {
+                  create: {
+                    name: 'Ethereum Mainnet', //unsure about this -- TODO: check
+                  },
+                },
+              },
+              where: {
+                id: userData.id,
+              },
+            },
+          },
+          date_of_attestation: new Date(Date.now()).toISOString(),
+          contribution: {
+            connect: {
+              id: contribution.id,
+            },
+          },
+          confidence: {
+            connectOrCreate: {
+              create: {
+                name: `${values.confidenceLevel}: ${userData.name}`,
+              },
+              where: {
+                name: `${values.confidenceLevel}: ${userData.name}`,
+              },
+            },
+          },
+        },
+      });
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
   const updateContribution = async (contribution: any, values: any) => {
     try {
       if (userData.id !== contribution.user.id) {

--- a/apps/protocol-frontend/src/contexts/UserContext.tsx
+++ b/apps/protocol-frontend/src/contexts/UserContext.tsx
@@ -170,8 +170,9 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
   };
 
   const createAttestation = async (contribution: any, values: any) => {
+    console.log('contribution incoming', contribution);
     try {
-      await govrn.attestation.create({
+      const response = await govrn.attestation.create({
         data: {
           user: {
             connectOrCreate: {
@@ -197,17 +198,34 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
           confidence: {
             connectOrCreate: {
               create: {
-                name: `${values.confidenceLevel}: ${userData.name}`,
+                name: '0',
               },
               where: {
-                name: `${values.confidenceLevel}: ${userData.name}`,
+                name: '0',
               },
             },
           },
         },
       });
+      toast({
+        title: 'Contribution Report Updated',
+        description: 'Your Contribution report has been updated.',
+        status: 'success',
+        duration: 3000,
+        isClosable: true,
+        position: 'top-right',
+      });
+      console.log('response', response);
     } catch (error) {
       console.log(error);
+      toast({
+        title: 'Unable to Add Attestation',
+        description: `Something went wrong. Please try again: ${error}`,
+        status: 'error',
+        duration: 3000,
+        isClosable: true,
+        position: 'top-right',
+      });
     }
   };
 
@@ -408,6 +426,7 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
         userActivityTypes,
         setUserActivityTypes,
         createContribution,
+        createAttestation,
         updateContribution,
         updateProfile,
         updateLinearEmail,
@@ -432,6 +451,7 @@ export const useUser = () => {
     setUserAttestations,
     userActivityTypes,
     setUserActivityTypes,
+    createAttestation,
     createContribution,
     updateContribution,
     updateProfile,
@@ -450,6 +470,7 @@ export const useUser = () => {
     setUserAttestations,
     userActivityTypes,
     setUserActivityTypes,
+    createAttestation,
     createContribution,
     updateContribution,
     updateProfile,

--- a/apps/protocol-frontend/src/main.tsx
+++ b/apps/protocol-frontend/src/main.tsx
@@ -37,7 +37,7 @@ ReactDOM.render(
         web3modalOptions={web3modalOptions}
         networks={networks}
         // Optional if you want to auto switch the network
-        defaultChainId={'0x1'}
+        // defaultChainId={'0x1'}
         // Optional but useful to handle events.
         handleModalEvents={(eventName, error) => {
           if (error) {

--- a/apps/protocol-frontend/src/main.tsx
+++ b/apps/protocol-frontend/src/main.tsx
@@ -1,5 +1,6 @@
 import { StrictMode } from 'react';
 import * as ReactDOM from 'react-dom';
+import 'regenerator-runtime/runtime';
 import { WalletProvider } from '@raidguild/quiver';
 import WalletConnectProvider from '@walletconnect/ethereum-provider';
 import { IProviderOptions } from 'web3modal';

--- a/apps/protocol-frontend/src/pages/Attestations.tsx
+++ b/apps/protocol-frontend/src/pages/Attestations.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import { Container, Box, Stack, Text } from '@chakra-ui/react';
 import { useWallet } from '@raidguild/quiver';
+import { useUser } from '../contexts/UserContext';
 import SiteLayout from '../components/SiteLayout';
 import ConnectWallet from '../components/ConnectWallet';
 import AttestationsTableShell from '../components/AttestationsTableShell';
-
-const isUser = true;
 
 const UserView = () => {
   return (
@@ -35,6 +34,7 @@ const NotUserView = () => {
 
 const Attestations = () => {
   const { isConnected } = useWallet();
+  const { userData } = useUser();
   return (
     <SiteLayout>
       {isConnected ? (
@@ -51,7 +51,7 @@ const Attestations = () => {
             boxShadow="sm"
             borderRadius={{ base: 'none', md: 'lg' }}
           >
-            {isUser ? <UserView /> : <NotUserView />}
+            {userData ? <UserView /> : <NotUserView />}
           </Box>
         </Container>
       )}

--- a/apps/protocol-frontend/src/pages/Contributions.tsx
+++ b/apps/protocol-frontend/src/pages/Contributions.tsx
@@ -52,7 +52,7 @@ const Contributions = () => {
             boxShadow="sm"
             borderRadius={{ base: 'none', md: 'lg' }}
           >
-            {userData ? <UserView /> : <NotUserView />}
+            {isConnected && userData ? <UserView /> : <NotUserView />}
           </Box>
         </Container>
       )}

--- a/apps/protocol-frontend/src/pages/Profile.tsx
+++ b/apps/protocol-frontend/src/pages/Profile.tsx
@@ -5,8 +5,6 @@ import SiteLayout from '../components/SiteLayout';
 import ConnectWallet from '../components/ConnectWallet';
 import ProfileShell from '../components/ProfileShell';
 
-const isUser = true;
-
 const UserView = () => {
   return (
     <Stack spacing="4" justify="center" align="center" minHeight="50vh">

--- a/apps/protocol-frontend/src/utils/networks.ts
+++ b/apps/protocol-frontend/src/utils/networks.ts
@@ -13,12 +13,9 @@ type Network = {
   chainId: string;
   chainNumber: number;
   name: ChainLabel;
-  litName: ChainName;
   symbol: string;
   explorer: string;
   rpc: string;
-  unlockSubgraph: string;
-  unlockAddress: string;
 };
 
 export const networks: { [key: string]: Network } = {
@@ -26,77 +23,54 @@ export const networks: { [key: string]: Network } = {
     chainId: '0x1',
     chainNumber: 1,
     name: 'Mainnet',
-    litName: 'ethereum',
     symbol: 'ETH',
     explorer: 'https://etherscan.io',
-    unlockAddress: '0x3d5409cce1d45233de1d4ebdee74b8e004abdd13',
     rpc: 'https://eth-mainnet.alchemyapi.io/v2/6idtzGwDtRbzil3s6QbYHr2Q_WBfn100',
-    unlockSubgraph:
-      'https://api.thegraph.com/subgraphs/name/unlock-protocol/unlock',
   },
   '0x4': {
     chainId: '0x4',
     chainNumber: 4,
     name: 'Rinkeby',
-    litName: 'rinkeby',
     symbol: 'ETH',
     explorer: 'https://rinkeby.etherscan.io',
-    unlockAddress: '0xd8c88be5e8eb88e38e6ff5ce186d764676012b0b',
     rpc: 'https://eth-rinkeby.alchemyapi.io/v2/n0NXRSZ9olpkJUPDLBC00Es75jaqysyT',
-    unlockSubgraph:
-      'https://api.thegraph.com/subgraphs/name/unlock-protocol/unlock-rinkeby',
   },
   '0x64': {
     chainId: '0x64',
     chainNumber: 100,
     name: 'Gnosis Chain',
-    litName: 'xdai',
     symbol: 'xDAI',
     explorer: 'https://blockscout.com/xdai/mainnet',
-    unlockAddress: '0x1bc53f4303c711cc693F6Ec3477B83703DcB317f',
     rpc: 'https://rpc.xdaichain.com/',
-    unlockSubgraph:
-      'https://api.thegraph.com/subgraphs/name/unlock-protocol/xdai',
   },
   '0xa': {
     chainId: '0xa',
     chainNumber: 100,
     name: 'Optimism',
-    litName: 'optimism',
     symbol: 'Eth',
     explorer: 'https://optimistic.etherscan.io/address/',
-    unlockAddress: '0x99b1348a9129ac49c6de7F11245773dE2f51fB0c',
     rpc: 'https://mainnet.optimism.io',
-    unlockSubgraph:
-      'https://api.thegraph.com/subgraphs/name/unlock-protocol/optimism',
   },
   '0x89': {
     chainId: '0x89',
     chainNumber: 137,
     name: 'Polygon',
-    litName: 'polygon',
     symbol: 'Matic',
     explorer: 'https://polygonscan.com/',
-    unlockAddress: '0xE8E5cd156f89F7bdB267EabD5C43Af3d5AF2A78f',
     rpc: 'https://polygon-rpc.com/',
-    unlockSubgraph:
-      'https://api.thegraph.com/subgraphs/name/unlock-protocol/polygon',
   },
   '0x38': {
     chainId: '0x38',
     chainNumber: 56,
     name: 'Binance Smart Chain',
-    litName: 'bsc',
     symbol: 'BSC',
     explorer: 'https://bscscan.com/',
-    unlockAddress: '0xeC83410DbC48C7797D2f2AFe624881674c65c856',
     rpc: 'https://bsc-dataseed.binance.org/',
-    unlockSubgraph:
-      'https://api.thegraph.com/subgraphs/name/unlock-protocol/bsc',
   },
   '0x7a69': {
     chainId: '0x7a69',
     chainNumber: 31337,
+    explorer: '',
     name: 'Localhost',
     symbol: 'ETH',
     rpc: '127.0.0.1:8545',

--- a/apps/protocol-frontend/src/utils/networks.ts
+++ b/apps/protocol-frontend/src/utils/networks.ts
@@ -6,7 +6,8 @@ type ChainLabel =
   | 'Gnosis Chain'
   | 'Polygon'
   | 'Binance Smart Chain'
-  | 'Optimism';
+  | 'Optimism'
+  | 'Localhost';
 
 type Network = {
   chainId: string;
@@ -92,6 +93,13 @@ export const networks: { [key: string]: Network } = {
     rpc: 'https://bsc-dataseed.binance.org/',
     unlockSubgraph:
       'https://api.thegraph.com/subgraphs/name/unlock-protocol/bsc',
+  },
+  '0x7a69': {
+    chainId: '0x7a69',
+    chainNumber: 31337,
+    name: 'Localhost',
+    symbol: 'ETH',
+    rpc: '127.0.0.1:8545',
   },
 };
 

--- a/libs/protocol-client/src/lib/protocol-types.ts
+++ b/libs/protocol-client/src/lib/protocol-types.ts
@@ -3,9 +3,15 @@ import * as Dom from 'graphql-request/dist/types.dom';
 import gql from 'graphql-tag';
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
-export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+export type Exact<T extends { [key: string]: unknown }> = {
+  [K in keyof T]: T[K];
+};
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
+  [SubKey in K]?: Maybe<T[SubKey]>;
+};
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
+  [SubKey in K]: Maybe<T[SubKey]>;
+};
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -33,7 +39,6 @@ export type ActivityType = {
   users: Array<UserActivity>;
 };
 
-
 export type ActivityTypeCategoryActivityArgs = {
   cursor?: InputMaybe<CategoryActivityTypeWhereUniqueInput>;
   distinct?: InputMaybe<Array<CategoryActivityTypeScalarFieldEnum>>;
@@ -42,7 +47,6 @@ export type ActivityTypeCategoryActivityArgs = {
   take?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<CategoryActivityTypeWhereInput>;
 };
-
 
 export type ActivityTypeContributionsArgs = {
   cursor?: InputMaybe<ContributionWhereUniqueInput>;
@@ -53,7 +57,6 @@ export type ActivityTypeContributionsArgs = {
   where?: InputMaybe<ContributionWhereInput>;
 };
 
-
 export type ActivityTypeGuildsArgs = {
   cursor?: InputMaybe<GuildActivityTypeWhereUniqueInput>;
   distinct?: InputMaybe<Array<GuildActivityTypeScalarFieldEnum>>;
@@ -62,7 +65,6 @@ export type ActivityTypeGuildsArgs = {
   take?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<GuildActivityTypeWhereInput>;
 };
-
 
 export type ActivityTypeUsersArgs = {
   cursor?: InputMaybe<UserActivityWhereUniqueInput>;
@@ -304,7 +306,7 @@ export enum ActivityTypeScalarFieldEnum {
   Default = 'default',
   Id = 'id',
   Name = 'name',
-  UpdatedAt = 'updatedAt'
+  UpdatedAt = 'updatedAt',
 }
 
 export type ActivityTypeScalarWhereWithAggregatesInput = {
@@ -704,7 +706,6 @@ export type AttestationConfidence = {
   updatedAt: Scalars['DateTime'];
 };
 
-
 export type AttestationConfidenceAttestationsArgs = {
   cursor?: InputMaybe<AttestationWhereUniqueInput>;
   distinct?: InputMaybe<Array<AttestationScalarFieldEnum>>;
@@ -841,7 +842,7 @@ export enum AttestationConfidenceScalarFieldEnum {
   CreatedAt = 'createdAt',
   Id = 'id',
   Name = 'name',
-  UpdatedAt = 'updatedAt'
+  UpdatedAt = 'updatedAt',
 }
 
 export type AttestationConfidenceScalarWhereWithAggregatesInput = {
@@ -994,21 +995,27 @@ export type AttestationCreateManyUserInputEnvelope = {
 
 export type AttestationCreateNestedManyWithoutConfidenceInput = {
   connect?: InputMaybe<Array<AttestationWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<AttestationCreateOrConnectWithoutConfidenceInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<AttestationCreateOrConnectWithoutConfidenceInput>
+  >;
   create?: InputMaybe<Array<AttestationCreateWithoutConfidenceInput>>;
   createMany?: InputMaybe<AttestationCreateManyConfidenceInputEnvelope>;
 };
 
 export type AttestationCreateNestedManyWithoutContributionInput = {
   connect?: InputMaybe<Array<AttestationWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<AttestationCreateOrConnectWithoutContributionInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<AttestationCreateOrConnectWithoutContributionInput>
+  >;
   create?: InputMaybe<Array<AttestationCreateWithoutContributionInput>>;
   createMany?: InputMaybe<AttestationCreateManyContributionInputEnvelope>;
 };
 
 export type AttestationCreateNestedManyWithoutUserInput = {
   connect?: InputMaybe<Array<AttestationWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<AttestationCreateOrConnectWithoutUserInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<AttestationCreateOrConnectWithoutUserInput>
+  >;
   create?: InputMaybe<Array<AttestationCreateWithoutUserInput>>;
   createMany?: InputMaybe<AttestationCreateManyUserInputEnvelope>;
 };
@@ -1152,7 +1159,7 @@ export enum AttestationScalarFieldEnum {
   DateOfAttestation = 'date_of_attestation',
   Id = 'id',
   UpdatedAt = 'updatedAt',
-  UserId = 'user_id'
+  UserId = 'user_id',
 }
 
 export type AttestationScalarWhereInput = {
@@ -1227,35 +1234,53 @@ export type AttestationUpdateManyWithWhereWithoutUserInput = {
 
 export type AttestationUpdateManyWithoutConfidenceInput = {
   connect?: InputMaybe<Array<AttestationWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<AttestationCreateOrConnectWithoutConfidenceInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<AttestationCreateOrConnectWithoutConfidenceInput>
+  >;
   create?: InputMaybe<Array<AttestationCreateWithoutConfidenceInput>>;
   createMany?: InputMaybe<AttestationCreateManyConfidenceInputEnvelope>;
   delete?: InputMaybe<Array<AttestationWhereUniqueInput>>;
   deleteMany?: InputMaybe<Array<AttestationScalarWhereInput>>;
   disconnect?: InputMaybe<Array<AttestationWhereUniqueInput>>;
   set?: InputMaybe<Array<AttestationWhereUniqueInput>>;
-  update?: InputMaybe<Array<AttestationUpdateWithWhereUniqueWithoutConfidenceInput>>;
-  updateMany?: InputMaybe<Array<AttestationUpdateManyWithWhereWithoutConfidenceInput>>;
-  upsert?: InputMaybe<Array<AttestationUpsertWithWhereUniqueWithoutConfidenceInput>>;
+  update?: InputMaybe<
+    Array<AttestationUpdateWithWhereUniqueWithoutConfidenceInput>
+  >;
+  updateMany?: InputMaybe<
+    Array<AttestationUpdateManyWithWhereWithoutConfidenceInput>
+  >;
+  upsert?: InputMaybe<
+    Array<AttestationUpsertWithWhereUniqueWithoutConfidenceInput>
+  >;
 };
 
 export type AttestationUpdateManyWithoutContributionInput = {
   connect?: InputMaybe<Array<AttestationWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<AttestationCreateOrConnectWithoutContributionInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<AttestationCreateOrConnectWithoutContributionInput>
+  >;
   create?: InputMaybe<Array<AttestationCreateWithoutContributionInput>>;
   createMany?: InputMaybe<AttestationCreateManyContributionInputEnvelope>;
   delete?: InputMaybe<Array<AttestationWhereUniqueInput>>;
   deleteMany?: InputMaybe<Array<AttestationScalarWhereInput>>;
   disconnect?: InputMaybe<Array<AttestationWhereUniqueInput>>;
   set?: InputMaybe<Array<AttestationWhereUniqueInput>>;
-  update?: InputMaybe<Array<AttestationUpdateWithWhereUniqueWithoutContributionInput>>;
-  updateMany?: InputMaybe<Array<AttestationUpdateManyWithWhereWithoutContributionInput>>;
-  upsert?: InputMaybe<Array<AttestationUpsertWithWhereUniqueWithoutContributionInput>>;
+  update?: InputMaybe<
+    Array<AttestationUpdateWithWhereUniqueWithoutContributionInput>
+  >;
+  updateMany?: InputMaybe<
+    Array<AttestationUpdateManyWithWhereWithoutContributionInput>
+  >;
+  upsert?: InputMaybe<
+    Array<AttestationUpsertWithWhereUniqueWithoutContributionInput>
+  >;
 };
 
 export type AttestationUpdateManyWithoutUserInput = {
   connect?: InputMaybe<Array<AttestationWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<AttestationCreateOrConnectWithoutUserInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<AttestationCreateOrConnectWithoutUserInput>
+  >;
   create?: InputMaybe<Array<AttestationCreateWithoutUserInput>>;
   createMany?: InputMaybe<AttestationCreateManyUserInputEnvelope>;
   delete?: InputMaybe<Array<AttestationWhereUniqueInput>>;
@@ -1263,7 +1288,9 @@ export type AttestationUpdateManyWithoutUserInput = {
   disconnect?: InputMaybe<Array<AttestationWhereUniqueInput>>;
   set?: InputMaybe<Array<AttestationWhereUniqueInput>>;
   update?: InputMaybe<Array<AttestationUpdateWithWhereUniqueWithoutUserInput>>;
-  updateMany?: InputMaybe<Array<AttestationUpdateManyWithWhereWithoutUserInput>>;
+  updateMany?: InputMaybe<
+    Array<AttestationUpdateManyWithWhereWithoutUserInput>
+  >;
   upsert?: InputMaybe<Array<AttestationUpsertWithWhereUniqueWithoutUserInput>>;
 };
 
@@ -1451,7 +1478,6 @@ export type CategoryActivity = {
   updatedAt: Scalars['DateTime'];
 };
 
-
 export type CategoryActivityActivityTypesArgs = {
   cursor?: InputMaybe<CategoryActivityTypeWhereUniqueInput>;
   distinct?: InputMaybe<Array<CategoryActivityTypeScalarFieldEnum>>;
@@ -1588,7 +1614,7 @@ export enum CategoryActivityScalarFieldEnum {
   CreatedAt = 'createdAt',
   Id = 'id',
   Name = 'name',
-  UpdatedAt = 'updatedAt'
+  UpdatedAt = 'updatedAt',
 }
 
 export type CategoryActivityScalarWhereWithAggregatesInput = {
@@ -1631,10 +1657,11 @@ export type CategoryActivityTypeAvgOrderByAggregateInput = {
   id?: InputMaybe<SortOrder>;
 };
 
-export type CategoryActivityTypeCategory_Activity_IdActivity_Type_IdCompoundUniqueInput = {
-  activity_type_id: Scalars['Int'];
-  category_activity_id: Scalars['Int'];
-};
+export type CategoryActivityTypeCategory_Activity_IdActivity_Type_IdCompoundUniqueInput =
+  {
+    activity_type_id: Scalars['Int'];
+    category_activity_id: Scalars['Int'];
+  };
 
 export type CategoryActivityTypeCountAggregate = {
   _all: Scalars['Int'];
@@ -1694,17 +1721,26 @@ export type CategoryActivityTypeCreateManyInput = {
 
 export type CategoryActivityTypeCreateNestedManyWithoutActivity_TypeInput = {
   connect?: InputMaybe<Array<CategoryActivityTypeWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<CategoryActivityTypeCreateOrConnectWithoutActivity_TypeInput>>;
-  create?: InputMaybe<Array<CategoryActivityTypeCreateWithoutActivity_TypeInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<CategoryActivityTypeCreateOrConnectWithoutActivity_TypeInput>
+  >;
+  create?: InputMaybe<
+    Array<CategoryActivityTypeCreateWithoutActivity_TypeInput>
+  >;
   createMany?: InputMaybe<CategoryActivityTypeCreateManyActivity_TypeInputEnvelope>;
 };
 
-export type CategoryActivityTypeCreateNestedManyWithoutCategory_ActivityInput = {
-  connect?: InputMaybe<Array<CategoryActivityTypeWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<CategoryActivityTypeCreateOrConnectWithoutCategory_ActivityInput>>;
-  create?: InputMaybe<Array<CategoryActivityTypeCreateWithoutCategory_ActivityInput>>;
-  createMany?: InputMaybe<CategoryActivityTypeCreateManyCategory_ActivityInputEnvelope>;
-};
+export type CategoryActivityTypeCreateNestedManyWithoutCategory_ActivityInput =
+  {
+    connect?: InputMaybe<Array<CategoryActivityTypeWhereUniqueInput>>;
+    connectOrCreate?: InputMaybe<
+      Array<CategoryActivityTypeCreateOrConnectWithoutCategory_ActivityInput>
+    >;
+    create?: InputMaybe<
+      Array<CategoryActivityTypeCreateWithoutCategory_ActivityInput>
+    >;
+    createMany?: InputMaybe<CategoryActivityTypeCreateManyCategory_ActivityInputEnvelope>;
+  };
 
 export type CategoryActivityTypeCreateOrConnectWithoutActivity_TypeInput = {
   create: CategoryActivityTypeCreateWithoutActivity_TypeInput;
@@ -1811,7 +1847,7 @@ export enum CategoryActivityTypeScalarFieldEnum {
   CategoryActivityId = 'category_activity_id',
   CreatedAt = 'createdAt',
   Id = 'id',
-  UpdatedAt = 'updatedAt'
+  UpdatedAt = 'updatedAt',
 }
 
 export type CategoryActivityTypeScalarWhereInput = {
@@ -1865,48 +1901,71 @@ export type CategoryActivityTypeUpdateManyWithWhereWithoutActivity_TypeInput = {
   where: CategoryActivityTypeScalarWhereInput;
 };
 
-export type CategoryActivityTypeUpdateManyWithWhereWithoutCategory_ActivityInput = {
-  data: CategoryActivityTypeUpdateManyMutationInput;
-  where: CategoryActivityTypeScalarWhereInput;
-};
+export type CategoryActivityTypeUpdateManyWithWhereWithoutCategory_ActivityInput =
+  {
+    data: CategoryActivityTypeUpdateManyMutationInput;
+    where: CategoryActivityTypeScalarWhereInput;
+  };
 
 export type CategoryActivityTypeUpdateManyWithoutActivity_TypeInput = {
   connect?: InputMaybe<Array<CategoryActivityTypeWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<CategoryActivityTypeCreateOrConnectWithoutActivity_TypeInput>>;
-  create?: InputMaybe<Array<CategoryActivityTypeCreateWithoutActivity_TypeInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<CategoryActivityTypeCreateOrConnectWithoutActivity_TypeInput>
+  >;
+  create?: InputMaybe<
+    Array<CategoryActivityTypeCreateWithoutActivity_TypeInput>
+  >;
   createMany?: InputMaybe<CategoryActivityTypeCreateManyActivity_TypeInputEnvelope>;
   delete?: InputMaybe<Array<CategoryActivityTypeWhereUniqueInput>>;
   deleteMany?: InputMaybe<Array<CategoryActivityTypeScalarWhereInput>>;
   disconnect?: InputMaybe<Array<CategoryActivityTypeWhereUniqueInput>>;
   set?: InputMaybe<Array<CategoryActivityTypeWhereUniqueInput>>;
-  update?: InputMaybe<Array<CategoryActivityTypeUpdateWithWhereUniqueWithoutActivity_TypeInput>>;
-  updateMany?: InputMaybe<Array<CategoryActivityTypeUpdateManyWithWhereWithoutActivity_TypeInput>>;
-  upsert?: InputMaybe<Array<CategoryActivityTypeUpsertWithWhereUniqueWithoutActivity_TypeInput>>;
+  update?: InputMaybe<
+    Array<CategoryActivityTypeUpdateWithWhereUniqueWithoutActivity_TypeInput>
+  >;
+  updateMany?: InputMaybe<
+    Array<CategoryActivityTypeUpdateManyWithWhereWithoutActivity_TypeInput>
+  >;
+  upsert?: InputMaybe<
+    Array<CategoryActivityTypeUpsertWithWhereUniqueWithoutActivity_TypeInput>
+  >;
 };
 
 export type CategoryActivityTypeUpdateManyWithoutCategory_ActivityInput = {
   connect?: InputMaybe<Array<CategoryActivityTypeWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<CategoryActivityTypeCreateOrConnectWithoutCategory_ActivityInput>>;
-  create?: InputMaybe<Array<CategoryActivityTypeCreateWithoutCategory_ActivityInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<CategoryActivityTypeCreateOrConnectWithoutCategory_ActivityInput>
+  >;
+  create?: InputMaybe<
+    Array<CategoryActivityTypeCreateWithoutCategory_ActivityInput>
+  >;
   createMany?: InputMaybe<CategoryActivityTypeCreateManyCategory_ActivityInputEnvelope>;
   delete?: InputMaybe<Array<CategoryActivityTypeWhereUniqueInput>>;
   deleteMany?: InputMaybe<Array<CategoryActivityTypeScalarWhereInput>>;
   disconnect?: InputMaybe<Array<CategoryActivityTypeWhereUniqueInput>>;
   set?: InputMaybe<Array<CategoryActivityTypeWhereUniqueInput>>;
-  update?: InputMaybe<Array<CategoryActivityTypeUpdateWithWhereUniqueWithoutCategory_ActivityInput>>;
-  updateMany?: InputMaybe<Array<CategoryActivityTypeUpdateManyWithWhereWithoutCategory_ActivityInput>>;
-  upsert?: InputMaybe<Array<CategoryActivityTypeUpsertWithWhereUniqueWithoutCategory_ActivityInput>>;
+  update?: InputMaybe<
+    Array<CategoryActivityTypeUpdateWithWhereUniqueWithoutCategory_ActivityInput>
+  >;
+  updateMany?: InputMaybe<
+    Array<CategoryActivityTypeUpdateManyWithWhereWithoutCategory_ActivityInput>
+  >;
+  upsert?: InputMaybe<
+    Array<CategoryActivityTypeUpsertWithWhereUniqueWithoutCategory_ActivityInput>
+  >;
 };
 
-export type CategoryActivityTypeUpdateWithWhereUniqueWithoutActivity_TypeInput = {
-  data: CategoryActivityTypeUpdateWithoutActivity_TypeInput;
-  where: CategoryActivityTypeWhereUniqueInput;
-};
+export type CategoryActivityTypeUpdateWithWhereUniqueWithoutActivity_TypeInput =
+  {
+    data: CategoryActivityTypeUpdateWithoutActivity_TypeInput;
+    where: CategoryActivityTypeWhereUniqueInput;
+  };
 
-export type CategoryActivityTypeUpdateWithWhereUniqueWithoutCategory_ActivityInput = {
-  data: CategoryActivityTypeUpdateWithoutCategory_ActivityInput;
-  where: CategoryActivityTypeWhereUniqueInput;
-};
+export type CategoryActivityTypeUpdateWithWhereUniqueWithoutCategory_ActivityInput =
+  {
+    data: CategoryActivityTypeUpdateWithoutCategory_ActivityInput;
+    where: CategoryActivityTypeWhereUniqueInput;
+  };
 
 export type CategoryActivityTypeUpdateWithoutActivity_TypeInput = {
   category_activity?: InputMaybe<CategoryActivityUpdateOneRequiredWithoutActivityTypesInput>;
@@ -1920,17 +1979,19 @@ export type CategoryActivityTypeUpdateWithoutCategory_ActivityInput = {
   updatedAt?: InputMaybe<DateTimeFieldUpdateOperationsInput>;
 };
 
-export type CategoryActivityTypeUpsertWithWhereUniqueWithoutActivity_TypeInput = {
-  create: CategoryActivityTypeCreateWithoutActivity_TypeInput;
-  update: CategoryActivityTypeUpdateWithoutActivity_TypeInput;
-  where: CategoryActivityTypeWhereUniqueInput;
-};
+export type CategoryActivityTypeUpsertWithWhereUniqueWithoutActivity_TypeInput =
+  {
+    create: CategoryActivityTypeCreateWithoutActivity_TypeInput;
+    update: CategoryActivityTypeUpdateWithoutActivity_TypeInput;
+    where: CategoryActivityTypeWhereUniqueInput;
+  };
 
-export type CategoryActivityTypeUpsertWithWhereUniqueWithoutCategory_ActivityInput = {
-  create: CategoryActivityTypeCreateWithoutCategory_ActivityInput;
-  update: CategoryActivityTypeUpdateWithoutCategory_ActivityInput;
-  where: CategoryActivityTypeWhereUniqueInput;
-};
+export type CategoryActivityTypeUpsertWithWhereUniqueWithoutCategory_ActivityInput =
+  {
+    create: CategoryActivityTypeCreateWithoutCategory_ActivityInput;
+    update: CategoryActivityTypeUpdateWithoutCategory_ActivityInput;
+    where: CategoryActivityTypeWhereUniqueInput;
+  };
 
 export type CategoryActivityTypeWhereInput = {
   AND?: InputMaybe<Array<CategoryActivityTypeWhereInput>>;
@@ -2006,7 +2067,6 @@ export type ChainType = {
   updatedAt: Scalars['DateTime'];
   users: Array<User>;
 };
-
 
 export type ChainTypeUsersArgs = {
   cursor?: InputMaybe<UserWhereUniqueInput>;
@@ -2144,7 +2204,7 @@ export enum ChainTypeScalarFieldEnum {
   CreatedAt = 'createdAt',
   Id = 'id',
   Name = 'name',
-  UpdatedAt = 'updatedAt'
+  UpdatedAt = 'updatedAt',
 }
 
 export type ChainTypeScalarWhereWithAggregatesInput = {
@@ -2236,7 +2296,6 @@ export type Contribution = {
   user_id: Scalars['Int'];
 };
 
-
 export type ContributionAttestationsArgs = {
   cursor?: InputMaybe<AttestationWhereUniqueInput>;
   distinct?: InputMaybe<Array<AttestationScalarFieldEnum>>;
@@ -2246,7 +2305,6 @@ export type ContributionAttestationsArgs = {
   where?: InputMaybe<AttestationWhereInput>;
 };
 
-
 export type ContributionGuildsArgs = {
   cursor?: InputMaybe<GuildContributionWhereUniqueInput>;
   distinct?: InputMaybe<Array<GuildContributionScalarFieldEnum>>;
@@ -2255,7 +2313,6 @@ export type ContributionGuildsArgs = {
   take?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<GuildContributionWhereInput>;
 };
-
 
 export type ContributionPartnersArgs = {
   cursor?: InputMaybe<PartnerWhereUniqueInput>;
@@ -2405,21 +2462,27 @@ export type ContributionCreateManyUserInputEnvelope = {
 
 export type ContributionCreateNestedManyWithoutActivity_TypeInput = {
   connect?: InputMaybe<Array<ContributionWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<ContributionCreateOrConnectWithoutActivity_TypeInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<ContributionCreateOrConnectWithoutActivity_TypeInput>
+  >;
   create?: InputMaybe<Array<ContributionCreateWithoutActivity_TypeInput>>;
   createMany?: InputMaybe<ContributionCreateManyActivity_TypeInputEnvelope>;
 };
 
 export type ContributionCreateNestedManyWithoutStatusInput = {
   connect?: InputMaybe<Array<ContributionWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<ContributionCreateOrConnectWithoutStatusInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<ContributionCreateOrConnectWithoutStatusInput>
+  >;
   create?: InputMaybe<Array<ContributionCreateWithoutStatusInput>>;
   createMany?: InputMaybe<ContributionCreateManyStatusInputEnvelope>;
 };
 
 export type ContributionCreateNestedManyWithoutUserInput = {
   connect?: InputMaybe<Array<ContributionWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<ContributionCreateOrConnectWithoutUserInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<ContributionCreateOrConnectWithoutUserInput>
+  >;
   create?: InputMaybe<Array<ContributionCreateWithoutUserInput>>;
   createMany?: InputMaybe<ContributionCreateManyUserInputEnvelope>;
 };
@@ -2772,7 +2835,7 @@ export enum ContributionScalarFieldEnum {
   Proof = 'proof',
   StatusId = 'status_id',
   UpdatedAt = 'updatedAt',
-  UserId = 'user_id'
+  UserId = 'user_id',
 }
 
 export type ContributionScalarWhereInput = {
@@ -2817,7 +2880,6 @@ export type ContributionStatus = {
   name: Scalars['String'];
   updatedAt: Scalars['DateTime'];
 };
-
 
 export type ContributionStatusContributionsArgs = {
   cursor?: InputMaybe<ContributionWhereUniqueInput>;
@@ -2955,7 +3017,7 @@ export enum ContributionStatusScalarFieldEnum {
   CreatedAt = 'createdAt',
   Id = 'id',
   Name = 'name',
-  UpdatedAt = 'updatedAt'
+  UpdatedAt = 'updatedAt',
 }
 
 export type ContributionStatusScalarWhereWithAggregatesInput = {
@@ -3085,35 +3147,53 @@ export type ContributionUpdateManyWithWhereWithoutUserInput = {
 
 export type ContributionUpdateManyWithoutActivity_TypeInput = {
   connect?: InputMaybe<Array<ContributionWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<ContributionCreateOrConnectWithoutActivity_TypeInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<ContributionCreateOrConnectWithoutActivity_TypeInput>
+  >;
   create?: InputMaybe<Array<ContributionCreateWithoutActivity_TypeInput>>;
   createMany?: InputMaybe<ContributionCreateManyActivity_TypeInputEnvelope>;
   delete?: InputMaybe<Array<ContributionWhereUniqueInput>>;
   deleteMany?: InputMaybe<Array<ContributionScalarWhereInput>>;
   disconnect?: InputMaybe<Array<ContributionWhereUniqueInput>>;
   set?: InputMaybe<Array<ContributionWhereUniqueInput>>;
-  update?: InputMaybe<Array<ContributionUpdateWithWhereUniqueWithoutActivity_TypeInput>>;
-  updateMany?: InputMaybe<Array<ContributionUpdateManyWithWhereWithoutActivity_TypeInput>>;
-  upsert?: InputMaybe<Array<ContributionUpsertWithWhereUniqueWithoutActivity_TypeInput>>;
+  update?: InputMaybe<
+    Array<ContributionUpdateWithWhereUniqueWithoutActivity_TypeInput>
+  >;
+  updateMany?: InputMaybe<
+    Array<ContributionUpdateManyWithWhereWithoutActivity_TypeInput>
+  >;
+  upsert?: InputMaybe<
+    Array<ContributionUpsertWithWhereUniqueWithoutActivity_TypeInput>
+  >;
 };
 
 export type ContributionUpdateManyWithoutStatusInput = {
   connect?: InputMaybe<Array<ContributionWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<ContributionCreateOrConnectWithoutStatusInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<ContributionCreateOrConnectWithoutStatusInput>
+  >;
   create?: InputMaybe<Array<ContributionCreateWithoutStatusInput>>;
   createMany?: InputMaybe<ContributionCreateManyStatusInputEnvelope>;
   delete?: InputMaybe<Array<ContributionWhereUniqueInput>>;
   deleteMany?: InputMaybe<Array<ContributionScalarWhereInput>>;
   disconnect?: InputMaybe<Array<ContributionWhereUniqueInput>>;
   set?: InputMaybe<Array<ContributionWhereUniqueInput>>;
-  update?: InputMaybe<Array<ContributionUpdateWithWhereUniqueWithoutStatusInput>>;
-  updateMany?: InputMaybe<Array<ContributionUpdateManyWithWhereWithoutStatusInput>>;
-  upsert?: InputMaybe<Array<ContributionUpsertWithWhereUniqueWithoutStatusInput>>;
+  update?: InputMaybe<
+    Array<ContributionUpdateWithWhereUniqueWithoutStatusInput>
+  >;
+  updateMany?: InputMaybe<
+    Array<ContributionUpdateManyWithWhereWithoutStatusInput>
+  >;
+  upsert?: InputMaybe<
+    Array<ContributionUpsertWithWhereUniqueWithoutStatusInput>
+  >;
 };
 
 export type ContributionUpdateManyWithoutUserInput = {
   connect?: InputMaybe<Array<ContributionWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<ContributionCreateOrConnectWithoutUserInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<ContributionCreateOrConnectWithoutUserInput>
+  >;
   create?: InputMaybe<Array<ContributionCreateWithoutUserInput>>;
   createMany?: InputMaybe<ContributionCreateManyUserInputEnvelope>;
   delete?: InputMaybe<Array<ContributionWhereUniqueInput>>;
@@ -3121,7 +3201,9 @@ export type ContributionUpdateManyWithoutUserInput = {
   disconnect?: InputMaybe<Array<ContributionWhereUniqueInput>>;
   set?: InputMaybe<Array<ContributionWhereUniqueInput>>;
   update?: InputMaybe<Array<ContributionUpdateWithWhereUniqueWithoutUserInput>>;
-  updateMany?: InputMaybe<Array<ContributionUpdateManyWithWhereWithoutUserInput>>;
+  updateMany?: InputMaybe<
+    Array<ContributionUpdateManyWithWhereWithoutUserInput>
+  >;
   upsert?: InputMaybe<Array<ContributionUpsertWithWhereUniqueWithoutUserInput>>;
 };
 
@@ -3520,7 +3602,9 @@ export type DiscordUserCreateManyUserInputEnvelope = {
 
 export type DiscordUserCreateNestedManyWithoutUserInput = {
   connect?: InputMaybe<Array<DiscordUserWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<DiscordUserCreateOrConnectWithoutUserInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<DiscordUserCreateOrConnectWithoutUserInput>
+  >;
   create?: InputMaybe<Array<DiscordUserCreateWithoutUserInput>>;
   createMany?: InputMaybe<DiscordUserCreateManyUserInputEnvelope>;
 };
@@ -3627,7 +3711,7 @@ export enum DiscordUserScalarFieldEnum {
   DisplayName = 'display_name',
   Id = 'id',
   UpdatedAt = 'updatedAt',
-  UserId = 'user_id'
+  UserId = 'user_id',
 }
 
 export type DiscordUserScalarWhereInput = {
@@ -3688,7 +3772,9 @@ export type DiscordUserUpdateManyWithWhereWithoutUserInput = {
 
 export type DiscordUserUpdateManyWithoutUserInput = {
   connect?: InputMaybe<Array<DiscordUserWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<DiscordUserCreateOrConnectWithoutUserInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<DiscordUserCreateOrConnectWithoutUserInput>
+  >;
   create?: InputMaybe<Array<DiscordUserCreateWithoutUserInput>>;
   createMany?: InputMaybe<DiscordUserCreateManyUserInputEnvelope>;
   delete?: InputMaybe<Array<DiscordUserWhereUniqueInput>>;
@@ -3696,7 +3782,9 @@ export type DiscordUserUpdateManyWithoutUserInput = {
   disconnect?: InputMaybe<Array<DiscordUserWhereUniqueInput>>;
   set?: InputMaybe<Array<DiscordUserWhereUniqueInput>>;
   update?: InputMaybe<Array<DiscordUserUpdateWithWhereUniqueWithoutUserInput>>;
-  updateMany?: InputMaybe<Array<DiscordUserUpdateManyWithWhereWithoutUserInput>>;
+  updateMany?: InputMaybe<
+    Array<DiscordUserUpdateManyWithWhereWithoutUserInput>
+  >;
   upsert?: InputMaybe<Array<DiscordUserUpsertWithWhereUniqueWithoutUserInput>>;
 };
 
@@ -3778,7 +3866,6 @@ export type Guild = {
   users: Array<GuildUser>;
 };
 
-
 export type GuildActivity_TypeArgs = {
   cursor?: InputMaybe<GuildActivityTypeWhereUniqueInput>;
   distinct?: InputMaybe<Array<GuildActivityTypeScalarFieldEnum>>;
@@ -3788,7 +3875,6 @@ export type GuildActivity_TypeArgs = {
   where?: InputMaybe<GuildActivityTypeWhereInput>;
 };
 
-
 export type GuildContributionsArgs = {
   cursor?: InputMaybe<GuildContributionWhereUniqueInput>;
   distinct?: InputMaybe<Array<GuildContributionScalarFieldEnum>>;
@@ -3797,7 +3883,6 @@ export type GuildContributionsArgs = {
   take?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<GuildContributionWhereInput>;
 };
-
 
 export type GuildUsersArgs = {
   cursor?: InputMaybe<GuildUserWhereUniqueInput>;
@@ -3888,14 +3973,18 @@ export type GuildActivityTypeCreateManyInput = {
 
 export type GuildActivityTypeCreateNestedManyWithoutActivity_TypeInput = {
   connect?: InputMaybe<Array<GuildActivityTypeWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<GuildActivityTypeCreateOrConnectWithoutActivity_TypeInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<GuildActivityTypeCreateOrConnectWithoutActivity_TypeInput>
+  >;
   create?: InputMaybe<Array<GuildActivityTypeCreateWithoutActivity_TypeInput>>;
   createMany?: InputMaybe<GuildActivityTypeCreateManyActivity_TypeInputEnvelope>;
 };
 
 export type GuildActivityTypeCreateNestedManyWithoutGuildInput = {
   connect?: InputMaybe<Array<GuildActivityTypeWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<GuildActivityTypeCreateOrConnectWithoutGuildInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<GuildActivityTypeCreateOrConnectWithoutGuildInput>
+  >;
   create?: InputMaybe<Array<GuildActivityTypeCreateWithoutGuildInput>>;
   createMany?: InputMaybe<GuildActivityTypeCreateManyGuildInputEnvelope>;
 };
@@ -4010,7 +4099,7 @@ export enum GuildActivityTypeScalarFieldEnum {
   CreatedAt = 'createdAt',
   GuildId = 'guild_id',
   Id = 'id',
-  UpdatedAt = 'updatedAt'
+  UpdatedAt = 'updatedAt',
 }
 
 export type GuildActivityTypeScalarWhereInput = {
@@ -4071,30 +4160,46 @@ export type GuildActivityTypeUpdateManyWithWhereWithoutGuildInput = {
 
 export type GuildActivityTypeUpdateManyWithoutActivity_TypeInput = {
   connect?: InputMaybe<Array<GuildActivityTypeWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<GuildActivityTypeCreateOrConnectWithoutActivity_TypeInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<GuildActivityTypeCreateOrConnectWithoutActivity_TypeInput>
+  >;
   create?: InputMaybe<Array<GuildActivityTypeCreateWithoutActivity_TypeInput>>;
   createMany?: InputMaybe<GuildActivityTypeCreateManyActivity_TypeInputEnvelope>;
   delete?: InputMaybe<Array<GuildActivityTypeWhereUniqueInput>>;
   deleteMany?: InputMaybe<Array<GuildActivityTypeScalarWhereInput>>;
   disconnect?: InputMaybe<Array<GuildActivityTypeWhereUniqueInput>>;
   set?: InputMaybe<Array<GuildActivityTypeWhereUniqueInput>>;
-  update?: InputMaybe<Array<GuildActivityTypeUpdateWithWhereUniqueWithoutActivity_TypeInput>>;
-  updateMany?: InputMaybe<Array<GuildActivityTypeUpdateManyWithWhereWithoutActivity_TypeInput>>;
-  upsert?: InputMaybe<Array<GuildActivityTypeUpsertWithWhereUniqueWithoutActivity_TypeInput>>;
+  update?: InputMaybe<
+    Array<GuildActivityTypeUpdateWithWhereUniqueWithoutActivity_TypeInput>
+  >;
+  updateMany?: InputMaybe<
+    Array<GuildActivityTypeUpdateManyWithWhereWithoutActivity_TypeInput>
+  >;
+  upsert?: InputMaybe<
+    Array<GuildActivityTypeUpsertWithWhereUniqueWithoutActivity_TypeInput>
+  >;
 };
 
 export type GuildActivityTypeUpdateManyWithoutGuildInput = {
   connect?: InputMaybe<Array<GuildActivityTypeWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<GuildActivityTypeCreateOrConnectWithoutGuildInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<GuildActivityTypeCreateOrConnectWithoutGuildInput>
+  >;
   create?: InputMaybe<Array<GuildActivityTypeCreateWithoutGuildInput>>;
   createMany?: InputMaybe<GuildActivityTypeCreateManyGuildInputEnvelope>;
   delete?: InputMaybe<Array<GuildActivityTypeWhereUniqueInput>>;
   deleteMany?: InputMaybe<Array<GuildActivityTypeScalarWhereInput>>;
   disconnect?: InputMaybe<Array<GuildActivityTypeWhereUniqueInput>>;
   set?: InputMaybe<Array<GuildActivityTypeWhereUniqueInput>>;
-  update?: InputMaybe<Array<GuildActivityTypeUpdateWithWhereUniqueWithoutGuildInput>>;
-  updateMany?: InputMaybe<Array<GuildActivityTypeUpdateManyWithWhereWithoutGuildInput>>;
-  upsert?: InputMaybe<Array<GuildActivityTypeUpsertWithWhereUniqueWithoutGuildInput>>;
+  update?: InputMaybe<
+    Array<GuildActivityTypeUpdateWithWhereUniqueWithoutGuildInput>
+  >;
+  updateMany?: InputMaybe<
+    Array<GuildActivityTypeUpdateManyWithWhereWithoutGuildInput>
+  >;
+  upsert?: InputMaybe<
+    Array<GuildActivityTypeUpsertWithWhereUniqueWithoutGuildInput>
+  >;
 };
 
 export type GuildActivityTypeUpdateWithWhereUniqueWithoutActivity_TypeInput = {
@@ -4241,14 +4346,18 @@ export type GuildContributionCreateManyInput = {
 
 export type GuildContributionCreateNestedManyWithoutContributionInput = {
   connect?: InputMaybe<Array<GuildContributionWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<GuildContributionCreateOrConnectWithoutContributionInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<GuildContributionCreateOrConnectWithoutContributionInput>
+  >;
   create?: InputMaybe<Array<GuildContributionCreateWithoutContributionInput>>;
   createMany?: InputMaybe<GuildContributionCreateManyContributionInputEnvelope>;
 };
 
 export type GuildContributionCreateNestedManyWithoutGuildInput = {
   connect?: InputMaybe<Array<GuildContributionWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<GuildContributionCreateOrConnectWithoutGuildInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<GuildContributionCreateOrConnectWithoutGuildInput>
+  >;
   create?: InputMaybe<Array<GuildContributionCreateWithoutGuildInput>>;
   createMany?: InputMaybe<GuildContributionCreateManyGuildInputEnvelope>;
 };
@@ -4363,7 +4472,7 @@ export enum GuildContributionScalarFieldEnum {
   CreatedAt = 'createdAt',
   GuildId = 'guild_id',
   Id = 'id',
-  UpdatedAt = 'updatedAt'
+  UpdatedAt = 'updatedAt',
 }
 
 export type GuildContributionScalarWhereInput = {
@@ -4424,30 +4533,46 @@ export type GuildContributionUpdateManyWithWhereWithoutGuildInput = {
 
 export type GuildContributionUpdateManyWithoutContributionInput = {
   connect?: InputMaybe<Array<GuildContributionWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<GuildContributionCreateOrConnectWithoutContributionInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<GuildContributionCreateOrConnectWithoutContributionInput>
+  >;
   create?: InputMaybe<Array<GuildContributionCreateWithoutContributionInput>>;
   createMany?: InputMaybe<GuildContributionCreateManyContributionInputEnvelope>;
   delete?: InputMaybe<Array<GuildContributionWhereUniqueInput>>;
   deleteMany?: InputMaybe<Array<GuildContributionScalarWhereInput>>;
   disconnect?: InputMaybe<Array<GuildContributionWhereUniqueInput>>;
   set?: InputMaybe<Array<GuildContributionWhereUniqueInput>>;
-  update?: InputMaybe<Array<GuildContributionUpdateWithWhereUniqueWithoutContributionInput>>;
-  updateMany?: InputMaybe<Array<GuildContributionUpdateManyWithWhereWithoutContributionInput>>;
-  upsert?: InputMaybe<Array<GuildContributionUpsertWithWhereUniqueWithoutContributionInput>>;
+  update?: InputMaybe<
+    Array<GuildContributionUpdateWithWhereUniqueWithoutContributionInput>
+  >;
+  updateMany?: InputMaybe<
+    Array<GuildContributionUpdateManyWithWhereWithoutContributionInput>
+  >;
+  upsert?: InputMaybe<
+    Array<GuildContributionUpsertWithWhereUniqueWithoutContributionInput>
+  >;
 };
 
 export type GuildContributionUpdateManyWithoutGuildInput = {
   connect?: InputMaybe<Array<GuildContributionWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<GuildContributionCreateOrConnectWithoutGuildInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<GuildContributionCreateOrConnectWithoutGuildInput>
+  >;
   create?: InputMaybe<Array<GuildContributionCreateWithoutGuildInput>>;
   createMany?: InputMaybe<GuildContributionCreateManyGuildInputEnvelope>;
   delete?: InputMaybe<Array<GuildContributionWhereUniqueInput>>;
   deleteMany?: InputMaybe<Array<GuildContributionScalarWhereInput>>;
   disconnect?: InputMaybe<Array<GuildContributionWhereUniqueInput>>;
   set?: InputMaybe<Array<GuildContributionWhereUniqueInput>>;
-  update?: InputMaybe<Array<GuildContributionUpdateWithWhereUniqueWithoutGuildInput>>;
-  updateMany?: InputMaybe<Array<GuildContributionUpdateManyWithWhereWithoutGuildInput>>;
-  upsert?: InputMaybe<Array<GuildContributionUpsertWithWhereUniqueWithoutGuildInput>>;
+  update?: InputMaybe<
+    Array<GuildContributionUpdateWithWhereUniqueWithoutGuildInput>
+  >;
+  updateMany?: InputMaybe<
+    Array<GuildContributionUpdateManyWithWhereWithoutGuildInput>
+  >;
+  upsert?: InputMaybe<
+    Array<GuildContributionUpsertWithWhereUniqueWithoutGuildInput>
+  >;
 };
 
 export type GuildContributionUpdateWithWhereUniqueWithoutContributionInput = {
@@ -4740,7 +4865,7 @@ export enum GuildScalarFieldEnum {
   Id = 'id',
   Logo = 'logo',
   Name = 'name',
-  UpdatedAt = 'updatedAt'
+  UpdatedAt = 'updatedAt',
 }
 
 export type GuildScalarWhereWithAggregatesInput = {
@@ -4972,7 +5097,9 @@ export type GuildUserCreateManyUserInputEnvelope = {
 
 export type GuildUserCreateNestedManyWithoutGuildInput = {
   connect?: InputMaybe<Array<GuildUserWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<GuildUserCreateOrConnectWithoutGuildInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<GuildUserCreateOrConnectWithoutGuildInput>
+  >;
   create?: InputMaybe<Array<GuildUserCreateWithoutGuildInput>>;
   createMany?: InputMaybe<GuildUserCreateManyGuildInputEnvelope>;
 };
@@ -5089,7 +5216,7 @@ export enum GuildUserScalarFieldEnum {
   GuildId = 'guild_id',
   Id = 'id',
   UpdatedAt = 'updatedAt',
-  UserId = 'user_id'
+  UserId = 'user_id',
 }
 
 export type GuildUserScalarWhereInput = {
@@ -5150,7 +5277,9 @@ export type GuildUserUpdateManyWithWhereWithoutUserInput = {
 
 export type GuildUserUpdateManyWithoutGuildInput = {
   connect?: InputMaybe<Array<GuildUserWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<GuildUserCreateOrConnectWithoutGuildInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<GuildUserCreateOrConnectWithoutGuildInput>
+  >;
   create?: InputMaybe<Array<GuildUserCreateWithoutGuildInput>>;
   createMany?: InputMaybe<GuildUserCreateManyGuildInputEnvelope>;
   delete?: InputMaybe<Array<GuildUserWhereUniqueInput>>;
@@ -5449,7 +5578,7 @@ export enum JobRunScalarFieldEnum {
   Id = 'id',
   Name = 'name',
   StartDate = 'startDate',
-  UpdatedAt = 'updatedAt'
+  UpdatedAt = 'updatedAt',
 }
 
 export type JobRunScalarWhereWithAggregatesInput = {
@@ -5513,7 +5642,6 @@ export type LinearCycle = {
   number: Scalars['Int'];
   startsAt: Scalars['DateTime'];
 };
-
 
 export type LinearCycleIssuesArgs = {
   cursor?: InputMaybe<LinearIssueWhereUniqueInput>;
@@ -5666,7 +5794,7 @@ export enum LinearCycleScalarFieldEnum {
   Id = 'id',
   LinearId = 'linear_id',
   Number = 'number',
-  StartsAt = 'startsAt'
+  StartsAt = 'startsAt',
 }
 
 export type LinearCycleScalarWhereWithAggregatesInput = {
@@ -6144,35 +6272,45 @@ export type LinearIssueCreateManyTeamInputEnvelope = {
 
 export type LinearIssueCreateNestedManyWithoutAssigneeInput = {
   connect?: InputMaybe<Array<LinearIssueWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<LinearIssueCreateOrConnectWithoutAssigneeInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<LinearIssueCreateOrConnectWithoutAssigneeInput>
+  >;
   create?: InputMaybe<Array<LinearIssueCreateWithoutAssigneeInput>>;
   createMany?: InputMaybe<LinearIssueCreateManyAssigneeInputEnvelope>;
 };
 
 export type LinearIssueCreateNestedManyWithoutCreatorInput = {
   connect?: InputMaybe<Array<LinearIssueWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<LinearIssueCreateOrConnectWithoutCreatorInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<LinearIssueCreateOrConnectWithoutCreatorInput>
+  >;
   create?: InputMaybe<Array<LinearIssueCreateWithoutCreatorInput>>;
   createMany?: InputMaybe<LinearIssueCreateManyCreatorInputEnvelope>;
 };
 
 export type LinearIssueCreateNestedManyWithoutCycleInput = {
   connect?: InputMaybe<Array<LinearIssueWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<LinearIssueCreateOrConnectWithoutCycleInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<LinearIssueCreateOrConnectWithoutCycleInput>
+  >;
   create?: InputMaybe<Array<LinearIssueCreateWithoutCycleInput>>;
   createMany?: InputMaybe<LinearIssueCreateManyCycleInputEnvelope>;
 };
 
 export type LinearIssueCreateNestedManyWithoutProjectInput = {
   connect?: InputMaybe<Array<LinearIssueWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<LinearIssueCreateOrConnectWithoutProjectInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<LinearIssueCreateOrConnectWithoutProjectInput>
+  >;
   create?: InputMaybe<Array<LinearIssueCreateWithoutProjectInput>>;
   createMany?: InputMaybe<LinearIssueCreateManyProjectInputEnvelope>;
 };
 
 export type LinearIssueCreateNestedManyWithoutTeamInput = {
   connect?: InputMaybe<Array<LinearIssueWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<LinearIssueCreateOrConnectWithoutTeamInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<LinearIssueCreateOrConnectWithoutTeamInput>
+  >;
   create?: InputMaybe<Array<LinearIssueCreateWithoutTeamInput>>;
   createMany?: InputMaybe<LinearIssueCreateManyTeamInputEnvelope>;
 };
@@ -6705,7 +6843,7 @@ export enum LinearIssueScalarFieldEnum {
   Title = 'title',
   Trashed = 'trashed',
   UpdatedAt = 'updatedAt',
-  Url = 'url'
+  Url = 'url',
 }
 
 export type LinearIssueScalarWhereInput = {
@@ -6901,35 +7039,53 @@ export type LinearIssueUpdateManyWithWhereWithoutTeamInput = {
 
 export type LinearIssueUpdateManyWithoutAssigneeInput = {
   connect?: InputMaybe<Array<LinearIssueWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<LinearIssueCreateOrConnectWithoutAssigneeInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<LinearIssueCreateOrConnectWithoutAssigneeInput>
+  >;
   create?: InputMaybe<Array<LinearIssueCreateWithoutAssigneeInput>>;
   createMany?: InputMaybe<LinearIssueCreateManyAssigneeInputEnvelope>;
   delete?: InputMaybe<Array<LinearIssueWhereUniqueInput>>;
   deleteMany?: InputMaybe<Array<LinearIssueScalarWhereInput>>;
   disconnect?: InputMaybe<Array<LinearIssueWhereUniqueInput>>;
   set?: InputMaybe<Array<LinearIssueWhereUniqueInput>>;
-  update?: InputMaybe<Array<LinearIssueUpdateWithWhereUniqueWithoutAssigneeInput>>;
-  updateMany?: InputMaybe<Array<LinearIssueUpdateManyWithWhereWithoutAssigneeInput>>;
-  upsert?: InputMaybe<Array<LinearIssueUpsertWithWhereUniqueWithoutAssigneeInput>>;
+  update?: InputMaybe<
+    Array<LinearIssueUpdateWithWhereUniqueWithoutAssigneeInput>
+  >;
+  updateMany?: InputMaybe<
+    Array<LinearIssueUpdateManyWithWhereWithoutAssigneeInput>
+  >;
+  upsert?: InputMaybe<
+    Array<LinearIssueUpsertWithWhereUniqueWithoutAssigneeInput>
+  >;
 };
 
 export type LinearIssueUpdateManyWithoutCreatorInput = {
   connect?: InputMaybe<Array<LinearIssueWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<LinearIssueCreateOrConnectWithoutCreatorInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<LinearIssueCreateOrConnectWithoutCreatorInput>
+  >;
   create?: InputMaybe<Array<LinearIssueCreateWithoutCreatorInput>>;
   createMany?: InputMaybe<LinearIssueCreateManyCreatorInputEnvelope>;
   delete?: InputMaybe<Array<LinearIssueWhereUniqueInput>>;
   deleteMany?: InputMaybe<Array<LinearIssueScalarWhereInput>>;
   disconnect?: InputMaybe<Array<LinearIssueWhereUniqueInput>>;
   set?: InputMaybe<Array<LinearIssueWhereUniqueInput>>;
-  update?: InputMaybe<Array<LinearIssueUpdateWithWhereUniqueWithoutCreatorInput>>;
-  updateMany?: InputMaybe<Array<LinearIssueUpdateManyWithWhereWithoutCreatorInput>>;
-  upsert?: InputMaybe<Array<LinearIssueUpsertWithWhereUniqueWithoutCreatorInput>>;
+  update?: InputMaybe<
+    Array<LinearIssueUpdateWithWhereUniqueWithoutCreatorInput>
+  >;
+  updateMany?: InputMaybe<
+    Array<LinearIssueUpdateManyWithWhereWithoutCreatorInput>
+  >;
+  upsert?: InputMaybe<
+    Array<LinearIssueUpsertWithWhereUniqueWithoutCreatorInput>
+  >;
 };
 
 export type LinearIssueUpdateManyWithoutCycleInput = {
   connect?: InputMaybe<Array<LinearIssueWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<LinearIssueCreateOrConnectWithoutCycleInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<LinearIssueCreateOrConnectWithoutCycleInput>
+  >;
   create?: InputMaybe<Array<LinearIssueCreateWithoutCycleInput>>;
   createMany?: InputMaybe<LinearIssueCreateManyCycleInputEnvelope>;
   delete?: InputMaybe<Array<LinearIssueWhereUniqueInput>>;
@@ -6937,27 +7093,39 @@ export type LinearIssueUpdateManyWithoutCycleInput = {
   disconnect?: InputMaybe<Array<LinearIssueWhereUniqueInput>>;
   set?: InputMaybe<Array<LinearIssueWhereUniqueInput>>;
   update?: InputMaybe<Array<LinearIssueUpdateWithWhereUniqueWithoutCycleInput>>;
-  updateMany?: InputMaybe<Array<LinearIssueUpdateManyWithWhereWithoutCycleInput>>;
+  updateMany?: InputMaybe<
+    Array<LinearIssueUpdateManyWithWhereWithoutCycleInput>
+  >;
   upsert?: InputMaybe<Array<LinearIssueUpsertWithWhereUniqueWithoutCycleInput>>;
 };
 
 export type LinearIssueUpdateManyWithoutProjectInput = {
   connect?: InputMaybe<Array<LinearIssueWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<LinearIssueCreateOrConnectWithoutProjectInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<LinearIssueCreateOrConnectWithoutProjectInput>
+  >;
   create?: InputMaybe<Array<LinearIssueCreateWithoutProjectInput>>;
   createMany?: InputMaybe<LinearIssueCreateManyProjectInputEnvelope>;
   delete?: InputMaybe<Array<LinearIssueWhereUniqueInput>>;
   deleteMany?: InputMaybe<Array<LinearIssueScalarWhereInput>>;
   disconnect?: InputMaybe<Array<LinearIssueWhereUniqueInput>>;
   set?: InputMaybe<Array<LinearIssueWhereUniqueInput>>;
-  update?: InputMaybe<Array<LinearIssueUpdateWithWhereUniqueWithoutProjectInput>>;
-  updateMany?: InputMaybe<Array<LinearIssueUpdateManyWithWhereWithoutProjectInput>>;
-  upsert?: InputMaybe<Array<LinearIssueUpsertWithWhereUniqueWithoutProjectInput>>;
+  update?: InputMaybe<
+    Array<LinearIssueUpdateWithWhereUniqueWithoutProjectInput>
+  >;
+  updateMany?: InputMaybe<
+    Array<LinearIssueUpdateManyWithWhereWithoutProjectInput>
+  >;
+  upsert?: InputMaybe<
+    Array<LinearIssueUpsertWithWhereUniqueWithoutProjectInput>
+  >;
 };
 
 export type LinearIssueUpdateManyWithoutTeamInput = {
   connect?: InputMaybe<Array<LinearIssueWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<LinearIssueCreateOrConnectWithoutTeamInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<LinearIssueCreateOrConnectWithoutTeamInput>
+  >;
   create?: InputMaybe<Array<LinearIssueCreateWithoutTeamInput>>;
   createMany?: InputMaybe<LinearIssueCreateManyTeamInputEnvelope>;
   delete?: InputMaybe<Array<LinearIssueWhereUniqueInput>>;
@@ -6965,7 +7133,9 @@ export type LinearIssueUpdateManyWithoutTeamInput = {
   disconnect?: InputMaybe<Array<LinearIssueWhereUniqueInput>>;
   set?: InputMaybe<Array<LinearIssueWhereUniqueInput>>;
   update?: InputMaybe<Array<LinearIssueUpdateWithWhereUniqueWithoutTeamInput>>;
-  updateMany?: InputMaybe<Array<LinearIssueUpdateManyWithWhereWithoutTeamInput>>;
+  updateMany?: InputMaybe<
+    Array<LinearIssueUpdateManyWithWhereWithoutTeamInput>
+  >;
   upsert?: InputMaybe<Array<LinearIssueUpsertWithWhereUniqueWithoutTeamInput>>;
 };
 
@@ -7288,7 +7458,6 @@ export type LinearProject = {
   name: Scalars['String'];
 };
 
-
 export type LinearProjectIssuesArgs = {
   cursor?: InputMaybe<LinearIssueWhereUniqueInput>;
   distinct?: InputMaybe<Array<LinearIssueScalarFieldEnum>>;
@@ -7412,7 +7581,7 @@ export type LinearProjectRelationFilter = {
 export enum LinearProjectScalarFieldEnum {
   Id = 'id',
   LinearId = 'linear_id',
-  Name = 'name'
+  Name = 'name',
 }
 
 export type LinearProjectScalarWhereWithAggregatesInput = {
@@ -7486,7 +7655,6 @@ export type LinearTeam = {
   linear_id: Scalars['String'];
   name: Scalars['String'];
 };
-
 
 export type LinearTeamIssuesArgs = {
   cursor?: InputMaybe<LinearIssueWhereUniqueInput>;
@@ -7624,7 +7792,7 @@ export enum LinearTeamScalarFieldEnum {
   Id = 'id',
   Key = 'key',
   LinearId = 'linear_id',
-  Name = 'name'
+  Name = 'name',
 }
 
 export type LinearTeamScalarWhereWithAggregatesInput = {
@@ -7711,7 +7879,6 @@ export type LinearUser = {
   user_id?: Maybe<Scalars['Int']>;
 };
 
-
 export type LinearUserAssigned_IssuesArgs = {
   cursor?: InputMaybe<LinearIssueWhereUniqueInput>;
   distinct?: InputMaybe<Array<LinearIssueScalarFieldEnum>>;
@@ -7720,7 +7887,6 @@ export type LinearUserAssigned_IssuesArgs = {
   take?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<LinearIssueWhereInput>;
 };
-
 
 export type LinearUserCreated_IssuesArgs = {
   cursor?: InputMaybe<LinearIssueWhereUniqueInput>;
@@ -7814,7 +7980,9 @@ export type LinearUserCreateManyUserInputEnvelope = {
 
 export type LinearUserCreateNestedManyWithoutUserInput = {
   connect?: InputMaybe<Array<LinearUserWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<LinearUserCreateOrConnectWithoutUserInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<LinearUserCreateOrConnectWithoutUserInput>
+  >;
   create?: InputMaybe<Array<LinearUserCreateWithoutUserInput>>;
   createMany?: InputMaybe<LinearUserCreateManyUserInputEnvelope>;
 };
@@ -8003,7 +8171,7 @@ export enum LinearUserScalarFieldEnum {
   LinearId = 'linear_id',
   Name = 'name',
   Url = 'url',
-  UserId = 'user_id'
+  UserId = 'user_id',
 }
 
 export type LinearUserScalarWhereInput = {
@@ -8076,7 +8244,9 @@ export type LinearUserUpdateManyWithWhereWithoutUserInput = {
 
 export type LinearUserUpdateManyWithoutUserInput = {
   connect?: InputMaybe<Array<LinearUserWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<LinearUserCreateOrConnectWithoutUserInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<LinearUserCreateOrConnectWithoutUserInput>
+  >;
   create?: InputMaybe<Array<LinearUserCreateWithoutUserInput>>;
   createMany?: InputMaybe<LinearUserCreateManyUserInputEnvelope>;
   delete?: InputMaybe<Array<LinearUserWhereUniqueInput>>;
@@ -8366,831 +8536,680 @@ export type Mutation = {
   upsertUserActivity: UserActivity;
 };
 
-
 export type MutationCreateActivityTypeArgs = {
   data: ActivityTypeCreateInput;
 };
-
 
 export type MutationCreateAttestationArgs = {
   data: AttestationCreateInput;
 };
 
-
 export type MutationCreateAttestationConfidenceArgs = {
   data: AttestationConfidenceCreateInput;
 };
-
 
 export type MutationCreateCategoryActivityArgs = {
   data: CategoryActivityCreateInput;
 };
 
-
 export type MutationCreateCategoryActivityTypeArgs = {
   data: CategoryActivityTypeCreateInput;
 };
-
 
 export type MutationCreateChainTypeArgs = {
   data: ChainTypeCreateInput;
 };
 
-
 export type MutationCreateContributionArgs = {
   data: ContributionCreateInput;
 };
-
 
 export type MutationCreateContributionStatusArgs = {
   data: ContributionStatusCreateInput;
 };
 
-
 export type MutationCreateDiscordUserArgs = {
   data: DiscordUserCreateInput;
 };
-
 
 export type MutationCreateGuildArgs = {
   data: GuildCreateInput;
 };
 
-
 export type MutationCreateGuildActivityTypeArgs = {
   data: GuildActivityTypeCreateInput;
 };
-
 
 export type MutationCreateGuildContributionArgs = {
   data: GuildContributionCreateInput;
 };
 
-
 export type MutationCreateGuildUserArgs = {
   data: GuildUserCreateInput;
 };
-
 
 export type MutationCreateJobRunArgs = {
   data: JobRunCreateInput;
 };
 
-
 export type MutationCreateLinearCycleArgs = {
   data: LinearCycleCreateInput;
 };
-
 
 export type MutationCreateLinearIssueArgs = {
   data: LinearIssueCreateInput;
 };
 
-
 export type MutationCreateLinearProjectArgs = {
   data: LinearProjectCreateInput;
 };
-
 
 export type MutationCreateLinearTeamArgs = {
   data: LinearTeamCreateInput;
 };
 
-
 export type MutationCreateLinearUserArgs = {
   data: LinearUserCreateInput;
 };
-
 
 export type MutationCreateManyActivityTypeArgs = {
   data: Array<ActivityTypeCreateManyInput>;
   skipDuplicates?: InputMaybe<Scalars['Boolean']>;
 };
 
-
 export type MutationCreateManyAttestationArgs = {
   data: Array<AttestationCreateManyInput>;
   skipDuplicates?: InputMaybe<Scalars['Boolean']>;
 };
-
 
 export type MutationCreateManyAttestationConfidenceArgs = {
   data: Array<AttestationConfidenceCreateManyInput>;
   skipDuplicates?: InputMaybe<Scalars['Boolean']>;
 };
 
-
 export type MutationCreateManyCategoryActivityArgs = {
   data: Array<CategoryActivityCreateManyInput>;
   skipDuplicates?: InputMaybe<Scalars['Boolean']>;
 };
-
 
 export type MutationCreateManyCategoryActivityTypeArgs = {
   data: Array<CategoryActivityTypeCreateManyInput>;
   skipDuplicates?: InputMaybe<Scalars['Boolean']>;
 };
 
-
 export type MutationCreateManyChainTypeArgs = {
   data: Array<ChainTypeCreateManyInput>;
   skipDuplicates?: InputMaybe<Scalars['Boolean']>;
 };
-
 
 export type MutationCreateManyContributionArgs = {
   data: Array<ContributionCreateManyInput>;
   skipDuplicates?: InputMaybe<Scalars['Boolean']>;
 };
 
-
 export type MutationCreateManyContributionStatusArgs = {
   data: Array<ContributionStatusCreateManyInput>;
   skipDuplicates?: InputMaybe<Scalars['Boolean']>;
 };
-
 
 export type MutationCreateManyDiscordUserArgs = {
   data: Array<DiscordUserCreateManyInput>;
   skipDuplicates?: InputMaybe<Scalars['Boolean']>;
 };
 
-
 export type MutationCreateManyGuildArgs = {
   data: Array<GuildCreateManyInput>;
   skipDuplicates?: InputMaybe<Scalars['Boolean']>;
 };
-
 
 export type MutationCreateManyGuildActivityTypeArgs = {
   data: Array<GuildActivityTypeCreateManyInput>;
   skipDuplicates?: InputMaybe<Scalars['Boolean']>;
 };
 
-
 export type MutationCreateManyGuildContributionArgs = {
   data: Array<GuildContributionCreateManyInput>;
   skipDuplicates?: InputMaybe<Scalars['Boolean']>;
 };
-
 
 export type MutationCreateManyGuildUserArgs = {
   data: Array<GuildUserCreateManyInput>;
   skipDuplicates?: InputMaybe<Scalars['Boolean']>;
 };
 
-
 export type MutationCreateManyJobRunArgs = {
   data: Array<JobRunCreateManyInput>;
   skipDuplicates?: InputMaybe<Scalars['Boolean']>;
 };
-
 
 export type MutationCreateManyLinearCycleArgs = {
   data: Array<LinearCycleCreateManyInput>;
   skipDuplicates?: InputMaybe<Scalars['Boolean']>;
 };
 
-
 export type MutationCreateManyLinearIssueArgs = {
   data: Array<LinearIssueCreateManyInput>;
   skipDuplicates?: InputMaybe<Scalars['Boolean']>;
 };
-
 
 export type MutationCreateManyLinearProjectArgs = {
   data: Array<LinearProjectCreateManyInput>;
   skipDuplicates?: InputMaybe<Scalars['Boolean']>;
 };
 
-
 export type MutationCreateManyLinearTeamArgs = {
   data: Array<LinearTeamCreateManyInput>;
   skipDuplicates?: InputMaybe<Scalars['Boolean']>;
 };
-
 
 export type MutationCreateManyLinearUserArgs = {
   data: Array<LinearUserCreateManyInput>;
   skipDuplicates?: InputMaybe<Scalars['Boolean']>;
 };
 
-
 export type MutationCreateManyPartnerArgs = {
   data: Array<PartnerCreateManyInput>;
   skipDuplicates?: InputMaybe<Scalars['Boolean']>;
 };
-
 
 export type MutationCreateManyTwitterAccountArgs = {
   data: Array<TwitterAccountCreateManyInput>;
   skipDuplicates?: InputMaybe<Scalars['Boolean']>;
 };
 
-
 export type MutationCreateManyTwitterTweetArgs = {
   data: Array<TwitterTweetCreateManyInput>;
   skipDuplicates?: InputMaybe<Scalars['Boolean']>;
 };
-
 
 export type MutationCreateManyTwitterUserArgs = {
   data: Array<TwitterUserCreateManyInput>;
   skipDuplicates?: InputMaybe<Scalars['Boolean']>;
 };
 
-
 export type MutationCreateManyUserArgs = {
   data: Array<UserCreateManyInput>;
   skipDuplicates?: InputMaybe<Scalars['Boolean']>;
 };
-
 
 export type MutationCreateManyUserActivityArgs = {
   data: Array<UserActivityCreateManyInput>;
   skipDuplicates?: InputMaybe<Scalars['Boolean']>;
 };
 
-
 export type MutationCreatePartnerArgs = {
   data: PartnerCreateInput;
 };
-
 
 export type MutationCreateTwitterAccountArgs = {
   data: TwitterAccountCreateInput;
 };
 
-
 export type MutationCreateTwitterTweetArgs = {
   data: TwitterTweetCreateInput;
 };
-
 
 export type MutationCreateTwitterUserArgs = {
   data: TwitterUserCreateInput;
 };
 
-
 export type MutationCreateUserArgs = {
   data: UserCreateInput;
 };
-
 
 export type MutationCreateUserActivityArgs = {
   data: UserActivityCreateInput;
 };
 
-
 export type MutationDeleteActivityTypeArgs = {
   where: ActivityTypeWhereUniqueInput;
 };
-
 
 export type MutationDeleteAttestationArgs = {
   where: AttestationWhereUniqueInput;
 };
 
-
 export type MutationDeleteAttestationConfidenceArgs = {
   where: AttestationConfidenceWhereUniqueInput;
 };
-
 
 export type MutationDeleteCategoryActivityArgs = {
   where: CategoryActivityWhereUniqueInput;
 };
 
-
 export type MutationDeleteCategoryActivityTypeArgs = {
   where: CategoryActivityTypeWhereUniqueInput;
 };
-
 
 export type MutationDeleteChainTypeArgs = {
   where: ChainTypeWhereUniqueInput;
 };
 
-
 export type MutationDeleteContributionArgs = {
   where: ContributionWhereUniqueInput;
 };
-
 
 export type MutationDeleteContributionStatusArgs = {
   where: ContributionStatusWhereUniqueInput;
 };
 
-
 export type MutationDeleteDiscordUserArgs = {
   where: DiscordUserWhereUniqueInput;
 };
-
 
 export type MutationDeleteGuildArgs = {
   where: GuildWhereUniqueInput;
 };
 
-
 export type MutationDeleteGuildActivityTypeArgs = {
   where: GuildActivityTypeWhereUniqueInput;
 };
-
 
 export type MutationDeleteGuildContributionArgs = {
   where: GuildContributionWhereUniqueInput;
 };
 
-
 export type MutationDeleteGuildUserArgs = {
   where: GuildUserWhereUniqueInput;
 };
-
 
 export type MutationDeleteJobRunArgs = {
   where: JobRunWhereUniqueInput;
 };
 
-
 export type MutationDeleteLinearCycleArgs = {
   where: LinearCycleWhereUniqueInput;
 };
-
 
 export type MutationDeleteLinearIssueArgs = {
   where: LinearIssueWhereUniqueInput;
 };
 
-
 export type MutationDeleteLinearProjectArgs = {
   where: LinearProjectWhereUniqueInput;
 };
-
 
 export type MutationDeleteLinearTeamArgs = {
   where: LinearTeamWhereUniqueInput;
 };
 
-
 export type MutationDeleteLinearUserArgs = {
   where: LinearUserWhereUniqueInput;
 };
-
 
 export type MutationDeleteManyActivityTypeArgs = {
   where?: InputMaybe<ActivityTypeWhereInput>;
 };
 
-
 export type MutationDeleteManyAttestationArgs = {
   where?: InputMaybe<AttestationWhereInput>;
 };
-
 
 export type MutationDeleteManyAttestationConfidenceArgs = {
   where?: InputMaybe<AttestationConfidenceWhereInput>;
 };
 
-
 export type MutationDeleteManyCategoryActivityArgs = {
   where?: InputMaybe<CategoryActivityWhereInput>;
 };
-
 
 export type MutationDeleteManyCategoryActivityTypeArgs = {
   where?: InputMaybe<CategoryActivityTypeWhereInput>;
 };
 
-
 export type MutationDeleteManyChainTypeArgs = {
   where?: InputMaybe<ChainTypeWhereInput>;
 };
-
 
 export type MutationDeleteManyContributionArgs = {
   where?: InputMaybe<ContributionWhereInput>;
 };
 
-
 export type MutationDeleteManyContributionStatusArgs = {
   where?: InputMaybe<ContributionStatusWhereInput>;
 };
-
 
 export type MutationDeleteManyDiscordUserArgs = {
   where?: InputMaybe<DiscordUserWhereInput>;
 };
 
-
 export type MutationDeleteManyGuildArgs = {
   where?: InputMaybe<GuildWhereInput>;
 };
-
 
 export type MutationDeleteManyGuildActivityTypeArgs = {
   where?: InputMaybe<GuildActivityTypeWhereInput>;
 };
 
-
 export type MutationDeleteManyGuildContributionArgs = {
   where?: InputMaybe<GuildContributionWhereInput>;
 };
-
 
 export type MutationDeleteManyGuildUserArgs = {
   where?: InputMaybe<GuildUserWhereInput>;
 };
 
-
 export type MutationDeleteManyJobRunArgs = {
   where?: InputMaybe<JobRunWhereInput>;
 };
-
 
 export type MutationDeleteManyLinearCycleArgs = {
   where?: InputMaybe<LinearCycleWhereInput>;
 };
 
-
 export type MutationDeleteManyLinearIssueArgs = {
   where?: InputMaybe<LinearIssueWhereInput>;
 };
-
 
 export type MutationDeleteManyLinearProjectArgs = {
   where?: InputMaybe<LinearProjectWhereInput>;
 };
 
-
 export type MutationDeleteManyLinearTeamArgs = {
   where?: InputMaybe<LinearTeamWhereInput>;
 };
-
 
 export type MutationDeleteManyLinearUserArgs = {
   where?: InputMaybe<LinearUserWhereInput>;
 };
 
-
 export type MutationDeleteManyPartnerArgs = {
   where?: InputMaybe<PartnerWhereInput>;
 };
-
 
 export type MutationDeleteManyTwitterAccountArgs = {
   where?: InputMaybe<TwitterAccountWhereInput>;
 };
 
-
 export type MutationDeleteManyTwitterTweetArgs = {
   where?: InputMaybe<TwitterTweetWhereInput>;
 };
-
 
 export type MutationDeleteManyTwitterUserArgs = {
   where?: InputMaybe<TwitterUserWhereInput>;
 };
 
-
 export type MutationDeleteManyUserArgs = {
   where?: InputMaybe<UserWhereInput>;
 };
-
 
 export type MutationDeleteManyUserActivityArgs = {
   where?: InputMaybe<UserActivityWhereInput>;
 };
 
-
 export type MutationDeletePartnerArgs = {
   where: PartnerWhereUniqueInput;
 };
-
 
 export type MutationDeleteTwitterAccountArgs = {
   where: TwitterAccountWhereUniqueInput;
 };
 
-
 export type MutationDeleteTwitterTweetArgs = {
   where: TwitterTweetWhereUniqueInput;
 };
-
 
 export type MutationDeleteTwitterUserArgs = {
   where: TwitterUserWhereUniqueInput;
 };
 
-
 export type MutationDeleteUserArgs = {
   where: UserWhereUniqueInput;
 };
 
-
 export type MutationDeleteUserActivityArgs = {
   where: UserActivityWhereUniqueInput;
 };
-
 
 export type MutationUpdateActivityTypeArgs = {
   data: ActivityTypeUpdateInput;
   where: ActivityTypeWhereUniqueInput;
 };
 
-
 export type MutationUpdateAttestationArgs = {
   data: AttestationUpdateInput;
   where: AttestationWhereUniqueInput;
 };
-
 
 export type MutationUpdateAttestationConfidenceArgs = {
   data: AttestationConfidenceUpdateInput;
   where: AttestationConfidenceWhereUniqueInput;
 };
 
-
 export type MutationUpdateCategoryActivityArgs = {
   data: CategoryActivityUpdateInput;
   where: CategoryActivityWhereUniqueInput;
 };
-
 
 export type MutationUpdateCategoryActivityTypeArgs = {
   data: CategoryActivityTypeUpdateInput;
   where: CategoryActivityTypeWhereUniqueInput;
 };
 
-
 export type MutationUpdateChainTypeArgs = {
   data: ChainTypeUpdateInput;
   where: ChainTypeWhereUniqueInput;
 };
-
 
 export type MutationUpdateContributionArgs = {
   data: ContributionUpdateInput;
   where: ContributionWhereUniqueInput;
 };
 
-
 export type MutationUpdateContributionStatusArgs = {
   data: ContributionStatusUpdateInput;
   where: ContributionStatusWhereUniqueInput;
 };
-
 
 export type MutationUpdateDiscordUserArgs = {
   data: DiscordUserUpdateInput;
   where: DiscordUserWhereUniqueInput;
 };
 
-
 export type MutationUpdateGuildArgs = {
   data: GuildUpdateInput;
   where: GuildWhereUniqueInput;
 };
-
 
 export type MutationUpdateGuildActivityTypeArgs = {
   data: GuildActivityTypeUpdateInput;
   where: GuildActivityTypeWhereUniqueInput;
 };
 
-
 export type MutationUpdateGuildContributionArgs = {
   data: GuildContributionUpdateInput;
   where: GuildContributionWhereUniqueInput;
 };
-
 
 export type MutationUpdateGuildUserArgs = {
   data: GuildUserUpdateInput;
   where: GuildUserWhereUniqueInput;
 };
 
-
 export type MutationUpdateJobRunArgs = {
   data: JobRunUpdateInput;
   where: JobRunWhereUniqueInput;
 };
-
 
 export type MutationUpdateLinearCycleArgs = {
   data: LinearCycleUpdateInput;
   where: LinearCycleWhereUniqueInput;
 };
 
-
 export type MutationUpdateLinearIssueArgs = {
   data: LinearIssueUpdateInput;
   where: LinearIssueWhereUniqueInput;
 };
-
 
 export type MutationUpdateLinearProjectArgs = {
   data: LinearProjectUpdateInput;
   where: LinearProjectWhereUniqueInput;
 };
 
-
 export type MutationUpdateLinearTeamArgs = {
   data: LinearTeamUpdateInput;
   where: LinearTeamWhereUniqueInput;
 };
-
 
 export type MutationUpdateLinearUserArgs = {
   data: LinearUserUpdateInput;
   where: LinearUserWhereUniqueInput;
 };
 
-
 export type MutationUpdateManyActivityTypeArgs = {
   data: ActivityTypeUpdateManyMutationInput;
   where?: InputMaybe<ActivityTypeWhereInput>;
 };
-
 
 export type MutationUpdateManyAttestationArgs = {
   data: AttestationUpdateManyMutationInput;
   where?: InputMaybe<AttestationWhereInput>;
 };
 
-
 export type MutationUpdateManyAttestationConfidenceArgs = {
   data: AttestationConfidenceUpdateManyMutationInput;
   where?: InputMaybe<AttestationConfidenceWhereInput>;
 };
-
 
 export type MutationUpdateManyCategoryActivityArgs = {
   data: CategoryActivityUpdateManyMutationInput;
   where?: InputMaybe<CategoryActivityWhereInput>;
 };
 
-
 export type MutationUpdateManyCategoryActivityTypeArgs = {
   data: CategoryActivityTypeUpdateManyMutationInput;
   where?: InputMaybe<CategoryActivityTypeWhereInput>;
 };
-
 
 export type MutationUpdateManyChainTypeArgs = {
   data: ChainTypeUpdateManyMutationInput;
   where?: InputMaybe<ChainTypeWhereInput>;
 };
 
-
 export type MutationUpdateManyContributionArgs = {
   data: ContributionUpdateManyMutationInput;
   where?: InputMaybe<ContributionWhereInput>;
 };
-
 
 export type MutationUpdateManyContributionStatusArgs = {
   data: ContributionStatusUpdateManyMutationInput;
   where?: InputMaybe<ContributionStatusWhereInput>;
 };
 
-
 export type MutationUpdateManyDiscordUserArgs = {
   data: DiscordUserUpdateManyMutationInput;
   where?: InputMaybe<DiscordUserWhereInput>;
 };
-
 
 export type MutationUpdateManyGuildArgs = {
   data: GuildUpdateManyMutationInput;
   where?: InputMaybe<GuildWhereInput>;
 };
 
-
 export type MutationUpdateManyGuildActivityTypeArgs = {
   data: GuildActivityTypeUpdateManyMutationInput;
   where?: InputMaybe<GuildActivityTypeWhereInput>;
 };
-
 
 export type MutationUpdateManyGuildContributionArgs = {
   data: GuildContributionUpdateManyMutationInput;
   where?: InputMaybe<GuildContributionWhereInput>;
 };
 
-
 export type MutationUpdateManyGuildUserArgs = {
   data: GuildUserUpdateManyMutationInput;
   where?: InputMaybe<GuildUserWhereInput>;
 };
-
 
 export type MutationUpdateManyJobRunArgs = {
   data: JobRunUpdateManyMutationInput;
   where?: InputMaybe<JobRunWhereInput>;
 };
 
-
 export type MutationUpdateManyLinearCycleArgs = {
   data: LinearCycleUpdateManyMutationInput;
   where?: InputMaybe<LinearCycleWhereInput>;
 };
-
 
 export type MutationUpdateManyLinearIssueArgs = {
   data: LinearIssueUpdateManyMutationInput;
   where?: InputMaybe<LinearIssueWhereInput>;
 };
 
-
 export type MutationUpdateManyLinearProjectArgs = {
   data: LinearProjectUpdateManyMutationInput;
   where?: InputMaybe<LinearProjectWhereInput>;
 };
-
 
 export type MutationUpdateManyLinearTeamArgs = {
   data: LinearTeamUpdateManyMutationInput;
   where?: InputMaybe<LinearTeamWhereInput>;
 };
 
-
 export type MutationUpdateManyLinearUserArgs = {
   data: LinearUserUpdateManyMutationInput;
   where?: InputMaybe<LinearUserWhereInput>;
 };
-
 
 export type MutationUpdateManyPartnerArgs = {
   data: PartnerUpdateManyMutationInput;
   where?: InputMaybe<PartnerWhereInput>;
 };
 
-
 export type MutationUpdateManyTwitterAccountArgs = {
   data: TwitterAccountUpdateManyMutationInput;
   where?: InputMaybe<TwitterAccountWhereInput>;
 };
-
 
 export type MutationUpdateManyTwitterTweetArgs = {
   data: TwitterTweetUpdateManyMutationInput;
   where?: InputMaybe<TwitterTweetWhereInput>;
 };
 
-
 export type MutationUpdateManyTwitterUserArgs = {
   data: TwitterUserUpdateManyMutationInput;
   where?: InputMaybe<TwitterUserWhereInput>;
 };
-
 
 export type MutationUpdateManyUserArgs = {
   data: UserUpdateManyMutationInput;
   where?: InputMaybe<UserWhereInput>;
 };
 
-
 export type MutationUpdateManyUserActivityArgs = {
   data: UserActivityUpdateManyMutationInput;
   where?: InputMaybe<UserActivityWhereInput>;
 };
-
 
 export type MutationUpdatePartnerArgs = {
   data: PartnerUpdateInput;
   where: PartnerWhereUniqueInput;
 };
 
-
 export type MutationUpdateTwitterAccountArgs = {
   data: TwitterAccountUpdateInput;
   where: TwitterAccountWhereUniqueInput;
 };
-
 
 export type MutationUpdateTwitterTweetArgs = {
   data: TwitterTweetUpdateInput;
   where: TwitterTweetWhereUniqueInput;
 };
 
-
 export type MutationUpdateTwitterUserArgs = {
   data: TwitterUserUpdateInput;
   where: TwitterUserWhereUniqueInput;
 };
-
 
 export type MutationUpdateUserArgs = {
   data: UserUpdateInput;
   where: UserWhereUniqueInput;
 };
 
-
 export type MutationUpdateUserActivityArgs = {
   data: UserActivityUpdateInput;
   where: UserActivityWhereUniqueInput;
 };
-
 
 export type MutationUpsertActivityTypeArgs = {
   create: ActivityTypeCreateInput;
@@ -9198,13 +9217,11 @@ export type MutationUpsertActivityTypeArgs = {
   where: ActivityTypeWhereUniqueInput;
 };
 
-
 export type MutationUpsertAttestationArgs = {
   create: AttestationCreateInput;
   update: AttestationUpdateInput;
   where: AttestationWhereUniqueInput;
 };
-
 
 export type MutationUpsertAttestationConfidenceArgs = {
   create: AttestationConfidenceCreateInput;
@@ -9212,13 +9229,11 @@ export type MutationUpsertAttestationConfidenceArgs = {
   where: AttestationConfidenceWhereUniqueInput;
 };
 
-
 export type MutationUpsertCategoryActivityArgs = {
   create: CategoryActivityCreateInput;
   update: CategoryActivityUpdateInput;
   where: CategoryActivityWhereUniqueInput;
 };
-
 
 export type MutationUpsertCategoryActivityTypeArgs = {
   create: CategoryActivityTypeCreateInput;
@@ -9226,13 +9241,11 @@ export type MutationUpsertCategoryActivityTypeArgs = {
   where: CategoryActivityTypeWhereUniqueInput;
 };
 
-
 export type MutationUpsertChainTypeArgs = {
   create: ChainTypeCreateInput;
   update: ChainTypeUpdateInput;
   where: ChainTypeWhereUniqueInput;
 };
-
 
 export type MutationUpsertContributionArgs = {
   create: ContributionCreateInput;
@@ -9240,13 +9253,11 @@ export type MutationUpsertContributionArgs = {
   where: ContributionWhereUniqueInput;
 };
 
-
 export type MutationUpsertContributionStatusArgs = {
   create: ContributionStatusCreateInput;
   update: ContributionStatusUpdateInput;
   where: ContributionStatusWhereUniqueInput;
 };
-
 
 export type MutationUpsertDiscordUserArgs = {
   create: DiscordUserCreateInput;
@@ -9254,13 +9265,11 @@ export type MutationUpsertDiscordUserArgs = {
   where: DiscordUserWhereUniqueInput;
 };
 
-
 export type MutationUpsertGuildArgs = {
   create: GuildCreateInput;
   update: GuildUpdateInput;
   where: GuildWhereUniqueInput;
 };
-
 
 export type MutationUpsertGuildActivityTypeArgs = {
   create: GuildActivityTypeCreateInput;
@@ -9268,13 +9277,11 @@ export type MutationUpsertGuildActivityTypeArgs = {
   where: GuildActivityTypeWhereUniqueInput;
 };
 
-
 export type MutationUpsertGuildContributionArgs = {
   create: GuildContributionCreateInput;
   update: GuildContributionUpdateInput;
   where: GuildContributionWhereUniqueInput;
 };
-
 
 export type MutationUpsertGuildUserArgs = {
   create: GuildUserCreateInput;
@@ -9282,13 +9289,11 @@ export type MutationUpsertGuildUserArgs = {
   where: GuildUserWhereUniqueInput;
 };
 
-
 export type MutationUpsertJobRunArgs = {
   create: JobRunCreateInput;
   update: JobRunUpdateInput;
   where: JobRunWhereUniqueInput;
 };
-
 
 export type MutationUpsertLinearCycleArgs = {
   create: LinearCycleCreateInput;
@@ -9296,13 +9301,11 @@ export type MutationUpsertLinearCycleArgs = {
   where: LinearCycleWhereUniqueInput;
 };
 
-
 export type MutationUpsertLinearIssueArgs = {
   create: LinearIssueCreateInput;
   update: LinearIssueUpdateInput;
   where: LinearIssueWhereUniqueInput;
 };
-
 
 export type MutationUpsertLinearProjectArgs = {
   create: LinearProjectCreateInput;
@@ -9310,13 +9313,11 @@ export type MutationUpsertLinearProjectArgs = {
   where: LinearProjectWhereUniqueInput;
 };
 
-
 export type MutationUpsertLinearTeamArgs = {
   create: LinearTeamCreateInput;
   update: LinearTeamUpdateInput;
   where: LinearTeamWhereUniqueInput;
 };
-
 
 export type MutationUpsertLinearUserArgs = {
   create: LinearUserCreateInput;
@@ -9324,13 +9325,11 @@ export type MutationUpsertLinearUserArgs = {
   where: LinearUserWhereUniqueInput;
 };
 
-
 export type MutationUpsertPartnerArgs = {
   create: PartnerCreateInput;
   update: PartnerUpdateInput;
   where: PartnerWhereUniqueInput;
 };
-
 
 export type MutationUpsertTwitterAccountArgs = {
   create: TwitterAccountCreateInput;
@@ -9338,13 +9337,11 @@ export type MutationUpsertTwitterAccountArgs = {
   where: TwitterAccountWhereUniqueInput;
 };
 
-
 export type MutationUpsertTwitterTweetArgs = {
   create: TwitterTweetCreateInput;
   update: TwitterTweetUpdateInput;
   where: TwitterTweetWhereUniqueInput;
 };
-
 
 export type MutationUpsertTwitterUserArgs = {
   create: TwitterUserCreateInput;
@@ -9352,13 +9349,11 @@ export type MutationUpsertTwitterUserArgs = {
   where: TwitterUserWhereUniqueInput;
 };
 
-
 export type MutationUpsertUserArgs = {
   create: UserCreateInput;
   update: UserUpdateInput;
   where: UserWhereUniqueInput;
 };
-
 
 export type MutationUpsertUserActivityArgs = {
   create: UserActivityCreateInput;
@@ -9766,7 +9761,9 @@ export type PartnerCreateManyUserInputEnvelope = {
 
 export type PartnerCreateNestedManyWithoutContributionInput = {
   connect?: InputMaybe<Array<PartnerWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<PartnerCreateOrConnectWithoutContributionInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<PartnerCreateOrConnectWithoutContributionInput>
+  >;
   create?: InputMaybe<Array<PartnerCreateWithoutContributionInput>>;
   createMany?: InputMaybe<PartnerCreateManyContributionInputEnvelope>;
 };
@@ -9883,7 +9880,7 @@ export enum PartnerScalarFieldEnum {
   CreatedAt = 'createdAt',
   Id = 'id',
   UpdatedAt = 'updatedAt',
-  UserId = 'user_id'
+  UserId = 'user_id',
 }
 
 export type PartnerScalarWhereInput = {
@@ -9944,16 +9941,24 @@ export type PartnerUpdateManyWithWhereWithoutUserInput = {
 
 export type PartnerUpdateManyWithoutContributionInput = {
   connect?: InputMaybe<Array<PartnerWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<PartnerCreateOrConnectWithoutContributionInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<PartnerCreateOrConnectWithoutContributionInput>
+  >;
   create?: InputMaybe<Array<PartnerCreateWithoutContributionInput>>;
   createMany?: InputMaybe<PartnerCreateManyContributionInputEnvelope>;
   delete?: InputMaybe<Array<PartnerWhereUniqueInput>>;
   deleteMany?: InputMaybe<Array<PartnerScalarWhereInput>>;
   disconnect?: InputMaybe<Array<PartnerWhereUniqueInput>>;
   set?: InputMaybe<Array<PartnerWhereUniqueInput>>;
-  update?: InputMaybe<Array<PartnerUpdateWithWhereUniqueWithoutContributionInput>>;
-  updateMany?: InputMaybe<Array<PartnerUpdateManyWithWhereWithoutContributionInput>>;
-  upsert?: InputMaybe<Array<PartnerUpsertWithWhereUniqueWithoutContributionInput>>;
+  update?: InputMaybe<
+    Array<PartnerUpdateWithWhereUniqueWithoutContributionInput>
+  >;
+  updateMany?: InputMaybe<
+    Array<PartnerUpdateManyWithWhereWithoutContributionInput>
+  >;
+  upsert?: InputMaybe<
+    Array<PartnerUpsertWithWhereUniqueWithoutContributionInput>
+  >;
 };
 
 export type PartnerUpdateManyWithoutUserInput = {
@@ -10155,11 +10160,9 @@ export type Query = {
   users: Array<User>;
 };
 
-
 export type QueryActivityTypeArgs = {
   where: ActivityTypeWhereUniqueInput;
 };
-
 
 export type QueryActivityTypesArgs = {
   cursor?: InputMaybe<ActivityTypeWhereUniqueInput>;
@@ -10170,7 +10173,6 @@ export type QueryActivityTypesArgs = {
   where?: InputMaybe<ActivityTypeWhereInput>;
 };
 
-
 export type QueryAggregateActivityTypeArgs = {
   cursor?: InputMaybe<ActivityTypeWhereUniqueInput>;
   orderBy?: InputMaybe<Array<ActivityTypeOrderByWithRelationInput>>;
@@ -10178,7 +10180,6 @@ export type QueryAggregateActivityTypeArgs = {
   take?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<ActivityTypeWhereInput>;
 };
-
 
 export type QueryAggregateAttestationArgs = {
   cursor?: InputMaybe<AttestationWhereUniqueInput>;
@@ -10188,7 +10189,6 @@ export type QueryAggregateAttestationArgs = {
   where?: InputMaybe<AttestationWhereInput>;
 };
 
-
 export type QueryAggregateAttestationConfidenceArgs = {
   cursor?: InputMaybe<AttestationConfidenceWhereUniqueInput>;
   orderBy?: InputMaybe<Array<AttestationConfidenceOrderByWithRelationInput>>;
@@ -10196,7 +10196,6 @@ export type QueryAggregateAttestationConfidenceArgs = {
   take?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<AttestationConfidenceWhereInput>;
 };
-
 
 export type QueryAggregateCategoryActivityArgs = {
   cursor?: InputMaybe<CategoryActivityWhereUniqueInput>;
@@ -10206,7 +10205,6 @@ export type QueryAggregateCategoryActivityArgs = {
   where?: InputMaybe<CategoryActivityWhereInput>;
 };
 
-
 export type QueryAggregateCategoryActivityTypeArgs = {
   cursor?: InputMaybe<CategoryActivityTypeWhereUniqueInput>;
   orderBy?: InputMaybe<Array<CategoryActivityTypeOrderByWithRelationInput>>;
@@ -10214,7 +10212,6 @@ export type QueryAggregateCategoryActivityTypeArgs = {
   take?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<CategoryActivityTypeWhereInput>;
 };
-
 
 export type QueryAggregateChainTypeArgs = {
   cursor?: InputMaybe<ChainTypeWhereUniqueInput>;
@@ -10224,7 +10221,6 @@ export type QueryAggregateChainTypeArgs = {
   where?: InputMaybe<ChainTypeWhereInput>;
 };
 
-
 export type QueryAggregateContributionArgs = {
   cursor?: InputMaybe<ContributionWhereUniqueInput>;
   orderBy?: InputMaybe<Array<ContributionOrderByWithRelationInput>>;
@@ -10232,7 +10228,6 @@ export type QueryAggregateContributionArgs = {
   take?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<ContributionWhereInput>;
 };
-
 
 export type QueryAggregateContributionStatusArgs = {
   cursor?: InputMaybe<ContributionStatusWhereUniqueInput>;
@@ -10242,7 +10237,6 @@ export type QueryAggregateContributionStatusArgs = {
   where?: InputMaybe<ContributionStatusWhereInput>;
 };
 
-
 export type QueryAggregateDiscordUserArgs = {
   cursor?: InputMaybe<DiscordUserWhereUniqueInput>;
   orderBy?: InputMaybe<Array<DiscordUserOrderByWithRelationInput>>;
@@ -10250,7 +10244,6 @@ export type QueryAggregateDiscordUserArgs = {
   take?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<DiscordUserWhereInput>;
 };
-
 
 export type QueryAggregateGuildArgs = {
   cursor?: InputMaybe<GuildWhereUniqueInput>;
@@ -10260,7 +10253,6 @@ export type QueryAggregateGuildArgs = {
   where?: InputMaybe<GuildWhereInput>;
 };
 
-
 export type QueryAggregateGuildActivityTypeArgs = {
   cursor?: InputMaybe<GuildActivityTypeWhereUniqueInput>;
   orderBy?: InputMaybe<Array<GuildActivityTypeOrderByWithRelationInput>>;
@@ -10268,7 +10260,6 @@ export type QueryAggregateGuildActivityTypeArgs = {
   take?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<GuildActivityTypeWhereInput>;
 };
-
 
 export type QueryAggregateGuildContributionArgs = {
   cursor?: InputMaybe<GuildContributionWhereUniqueInput>;
@@ -10278,7 +10269,6 @@ export type QueryAggregateGuildContributionArgs = {
   where?: InputMaybe<GuildContributionWhereInput>;
 };
 
-
 export type QueryAggregateGuildUserArgs = {
   cursor?: InputMaybe<GuildUserWhereUniqueInput>;
   orderBy?: InputMaybe<Array<GuildUserOrderByWithRelationInput>>;
@@ -10286,7 +10276,6 @@ export type QueryAggregateGuildUserArgs = {
   take?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<GuildUserWhereInput>;
 };
-
 
 export type QueryAggregateJobRunArgs = {
   cursor?: InputMaybe<JobRunWhereUniqueInput>;
@@ -10296,7 +10285,6 @@ export type QueryAggregateJobRunArgs = {
   where?: InputMaybe<JobRunWhereInput>;
 };
 
-
 export type QueryAggregateLinearCycleArgs = {
   cursor?: InputMaybe<LinearCycleWhereUniqueInput>;
   orderBy?: InputMaybe<Array<LinearCycleOrderByWithRelationInput>>;
@@ -10304,7 +10292,6 @@ export type QueryAggregateLinearCycleArgs = {
   take?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<LinearCycleWhereInput>;
 };
-
 
 export type QueryAggregateLinearIssueArgs = {
   cursor?: InputMaybe<LinearIssueWhereUniqueInput>;
@@ -10314,7 +10301,6 @@ export type QueryAggregateLinearIssueArgs = {
   where?: InputMaybe<LinearIssueWhereInput>;
 };
 
-
 export type QueryAggregateLinearProjectArgs = {
   cursor?: InputMaybe<LinearProjectWhereUniqueInput>;
   orderBy?: InputMaybe<Array<LinearProjectOrderByWithRelationInput>>;
@@ -10322,7 +10308,6 @@ export type QueryAggregateLinearProjectArgs = {
   take?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<LinearProjectWhereInput>;
 };
-
 
 export type QueryAggregateLinearTeamArgs = {
   cursor?: InputMaybe<LinearTeamWhereUniqueInput>;
@@ -10332,7 +10317,6 @@ export type QueryAggregateLinearTeamArgs = {
   where?: InputMaybe<LinearTeamWhereInput>;
 };
 
-
 export type QueryAggregateLinearUserArgs = {
   cursor?: InputMaybe<LinearUserWhereUniqueInput>;
   orderBy?: InputMaybe<Array<LinearUserOrderByWithRelationInput>>;
@@ -10340,7 +10324,6 @@ export type QueryAggregateLinearUserArgs = {
   take?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<LinearUserWhereInput>;
 };
-
 
 export type QueryAggregatePartnerArgs = {
   cursor?: InputMaybe<PartnerWhereUniqueInput>;
@@ -10350,7 +10333,6 @@ export type QueryAggregatePartnerArgs = {
   where?: InputMaybe<PartnerWhereInput>;
 };
 
-
 export type QueryAggregateTwitterAccountArgs = {
   cursor?: InputMaybe<TwitterAccountWhereUniqueInput>;
   orderBy?: InputMaybe<Array<TwitterAccountOrderByWithRelationInput>>;
@@ -10358,7 +10340,6 @@ export type QueryAggregateTwitterAccountArgs = {
   take?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<TwitterAccountWhereInput>;
 };
-
 
 export type QueryAggregateTwitterTweetArgs = {
   cursor?: InputMaybe<TwitterTweetWhereUniqueInput>;
@@ -10368,7 +10349,6 @@ export type QueryAggregateTwitterTweetArgs = {
   where?: InputMaybe<TwitterTweetWhereInput>;
 };
 
-
 export type QueryAggregateTwitterUserArgs = {
   cursor?: InputMaybe<TwitterUserWhereUniqueInput>;
   orderBy?: InputMaybe<Array<TwitterUserOrderByWithRelationInput>>;
@@ -10376,7 +10356,6 @@ export type QueryAggregateTwitterUserArgs = {
   take?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<TwitterUserWhereInput>;
 };
-
 
 export type QueryAggregateUserArgs = {
   cursor?: InputMaybe<UserWhereUniqueInput>;
@@ -10386,7 +10365,6 @@ export type QueryAggregateUserArgs = {
   where?: InputMaybe<UserWhereInput>;
 };
 
-
 export type QueryAggregateUserActivityArgs = {
   cursor?: InputMaybe<UserActivityWhereUniqueInput>;
   orderBy?: InputMaybe<Array<UserActivityOrderByWithRelationInput>>;
@@ -10395,16 +10373,13 @@ export type QueryAggregateUserActivityArgs = {
   where?: InputMaybe<UserActivityWhereInput>;
 };
 
-
 export type QueryAttestationArgs = {
   where: AttestationWhereUniqueInput;
 };
 
-
 export type QueryAttestationConfidenceArgs = {
   where: AttestationConfidenceWhereUniqueInput;
 };
-
 
 export type QueryAttestationConfidencesArgs = {
   cursor?: InputMaybe<AttestationConfidenceWhereUniqueInput>;
@@ -10415,7 +10390,6 @@ export type QueryAttestationConfidencesArgs = {
   where?: InputMaybe<AttestationConfidenceWhereInput>;
 };
 
-
 export type QueryAttestationsArgs = {
   cursor?: InputMaybe<AttestationWhereUniqueInput>;
   distinct?: InputMaybe<Array<AttestationScalarFieldEnum>>;
@@ -10424,7 +10398,6 @@ export type QueryAttestationsArgs = {
   take?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<AttestationWhereInput>;
 };
-
 
 export type QueryCategoryActivitiesArgs = {
   cursor?: InputMaybe<CategoryActivityWhereUniqueInput>;
@@ -10435,16 +10408,13 @@ export type QueryCategoryActivitiesArgs = {
   where?: InputMaybe<CategoryActivityWhereInput>;
 };
 
-
 export type QueryCategoryActivityArgs = {
   where: CategoryActivityWhereUniqueInput;
 };
 
-
 export type QueryCategoryActivityTypeArgs = {
   where: CategoryActivityTypeWhereUniqueInput;
 };
-
 
 export type QueryCategoryActivityTypesArgs = {
   cursor?: InputMaybe<CategoryActivityTypeWhereUniqueInput>;
@@ -10455,11 +10425,9 @@ export type QueryCategoryActivityTypesArgs = {
   where?: InputMaybe<CategoryActivityTypeWhereInput>;
 };
 
-
 export type QueryChainTypeArgs = {
   where: ChainTypeWhereUniqueInput;
 };
-
 
 export type QueryChainTypesArgs = {
   cursor?: InputMaybe<ChainTypeWhereUniqueInput>;
@@ -10470,16 +10438,13 @@ export type QueryChainTypesArgs = {
   where?: InputMaybe<ChainTypeWhereInput>;
 };
 
-
 export type QueryContributionArgs = {
   where: ContributionWhereUniqueInput;
 };
 
-
 export type QueryContributionStatusArgs = {
   where: ContributionStatusWhereUniqueInput;
 };
-
 
 export type QueryContributionStatusesArgs = {
   cursor?: InputMaybe<ContributionStatusWhereUniqueInput>;
@@ -10490,7 +10455,6 @@ export type QueryContributionStatusesArgs = {
   where?: InputMaybe<ContributionStatusWhereInput>;
 };
 
-
 export type QueryContributionsArgs = {
   cursor?: InputMaybe<ContributionWhereUniqueInput>;
   distinct?: InputMaybe<Array<ContributionScalarFieldEnum>>;
@@ -10500,11 +10464,9 @@ export type QueryContributionsArgs = {
   where?: InputMaybe<ContributionWhereInput>;
 };
 
-
 export type QueryDiscordUserArgs = {
   where: DiscordUserWhereUniqueInput;
 };
-
 
 export type QueryDiscordUsersArgs = {
   cursor?: InputMaybe<DiscordUserWhereUniqueInput>;
@@ -10515,7 +10477,6 @@ export type QueryDiscordUsersArgs = {
   where?: InputMaybe<DiscordUserWhereInput>;
 };
 
-
 export type QueryFindFirstActivityTypeArgs = {
   cursor?: InputMaybe<ActivityTypeWhereUniqueInput>;
   distinct?: InputMaybe<Array<ActivityTypeScalarFieldEnum>>;
@@ -10524,7 +10485,6 @@ export type QueryFindFirstActivityTypeArgs = {
   take?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<ActivityTypeWhereInput>;
 };
-
 
 export type QueryFindFirstAttestationArgs = {
   cursor?: InputMaybe<AttestationWhereUniqueInput>;
@@ -10535,7 +10495,6 @@ export type QueryFindFirstAttestationArgs = {
   where?: InputMaybe<AttestationWhereInput>;
 };
 
-
 export type QueryFindFirstAttestationConfidenceArgs = {
   cursor?: InputMaybe<AttestationConfidenceWhereUniqueInput>;
   distinct?: InputMaybe<Array<AttestationConfidenceScalarFieldEnum>>;
@@ -10544,7 +10503,6 @@ export type QueryFindFirstAttestationConfidenceArgs = {
   take?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<AttestationConfidenceWhereInput>;
 };
-
 
 export type QueryFindFirstCategoryActivityArgs = {
   cursor?: InputMaybe<CategoryActivityWhereUniqueInput>;
@@ -10555,7 +10513,6 @@ export type QueryFindFirstCategoryActivityArgs = {
   where?: InputMaybe<CategoryActivityWhereInput>;
 };
 
-
 export type QueryFindFirstCategoryActivityTypeArgs = {
   cursor?: InputMaybe<CategoryActivityTypeWhereUniqueInput>;
   distinct?: InputMaybe<Array<CategoryActivityTypeScalarFieldEnum>>;
@@ -10564,7 +10521,6 @@ export type QueryFindFirstCategoryActivityTypeArgs = {
   take?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<CategoryActivityTypeWhereInput>;
 };
-
 
 export type QueryFindFirstChainTypeArgs = {
   cursor?: InputMaybe<ChainTypeWhereUniqueInput>;
@@ -10575,7 +10531,6 @@ export type QueryFindFirstChainTypeArgs = {
   where?: InputMaybe<ChainTypeWhereInput>;
 };
 
-
 export type QueryFindFirstContributionArgs = {
   cursor?: InputMaybe<ContributionWhereUniqueInput>;
   distinct?: InputMaybe<Array<ContributionScalarFieldEnum>>;
@@ -10584,7 +10539,6 @@ export type QueryFindFirstContributionArgs = {
   take?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<ContributionWhereInput>;
 };
-
 
 export type QueryFindFirstContributionStatusArgs = {
   cursor?: InputMaybe<ContributionStatusWhereUniqueInput>;
@@ -10595,7 +10549,6 @@ export type QueryFindFirstContributionStatusArgs = {
   where?: InputMaybe<ContributionStatusWhereInput>;
 };
 
-
 export type QueryFindFirstDiscordUserArgs = {
   cursor?: InputMaybe<DiscordUserWhereUniqueInput>;
   distinct?: InputMaybe<Array<DiscordUserScalarFieldEnum>>;
@@ -10604,7 +10557,6 @@ export type QueryFindFirstDiscordUserArgs = {
   take?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<DiscordUserWhereInput>;
 };
-
 
 export type QueryFindFirstGuildArgs = {
   cursor?: InputMaybe<GuildWhereUniqueInput>;
@@ -10615,7 +10567,6 @@ export type QueryFindFirstGuildArgs = {
   where?: InputMaybe<GuildWhereInput>;
 };
 
-
 export type QueryFindFirstGuildActivityTypeArgs = {
   cursor?: InputMaybe<GuildActivityTypeWhereUniqueInput>;
   distinct?: InputMaybe<Array<GuildActivityTypeScalarFieldEnum>>;
@@ -10624,7 +10575,6 @@ export type QueryFindFirstGuildActivityTypeArgs = {
   take?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<GuildActivityTypeWhereInput>;
 };
-
 
 export type QueryFindFirstGuildContributionArgs = {
   cursor?: InputMaybe<GuildContributionWhereUniqueInput>;
@@ -10635,7 +10585,6 @@ export type QueryFindFirstGuildContributionArgs = {
   where?: InputMaybe<GuildContributionWhereInput>;
 };
 
-
 export type QueryFindFirstGuildUserArgs = {
   cursor?: InputMaybe<GuildUserWhereUniqueInput>;
   distinct?: InputMaybe<Array<GuildUserScalarFieldEnum>>;
@@ -10644,7 +10593,6 @@ export type QueryFindFirstGuildUserArgs = {
   take?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<GuildUserWhereInput>;
 };
-
 
 export type QueryFindFirstJobRunArgs = {
   cursor?: InputMaybe<JobRunWhereUniqueInput>;
@@ -10655,7 +10603,6 @@ export type QueryFindFirstJobRunArgs = {
   where?: InputMaybe<JobRunWhereInput>;
 };
 
-
 export type QueryFindFirstLinearCycleArgs = {
   cursor?: InputMaybe<LinearCycleWhereUniqueInput>;
   distinct?: InputMaybe<Array<LinearCycleScalarFieldEnum>>;
@@ -10664,7 +10611,6 @@ export type QueryFindFirstLinearCycleArgs = {
   take?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<LinearCycleWhereInput>;
 };
-
 
 export type QueryFindFirstLinearIssueArgs = {
   cursor?: InputMaybe<LinearIssueWhereUniqueInput>;
@@ -10675,7 +10621,6 @@ export type QueryFindFirstLinearIssueArgs = {
   where?: InputMaybe<LinearIssueWhereInput>;
 };
 
-
 export type QueryFindFirstLinearProjectArgs = {
   cursor?: InputMaybe<LinearProjectWhereUniqueInput>;
   distinct?: InputMaybe<Array<LinearProjectScalarFieldEnum>>;
@@ -10684,7 +10629,6 @@ export type QueryFindFirstLinearProjectArgs = {
   take?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<LinearProjectWhereInput>;
 };
-
 
 export type QueryFindFirstLinearTeamArgs = {
   cursor?: InputMaybe<LinearTeamWhereUniqueInput>;
@@ -10695,7 +10639,6 @@ export type QueryFindFirstLinearTeamArgs = {
   where?: InputMaybe<LinearTeamWhereInput>;
 };
 
-
 export type QueryFindFirstLinearUserArgs = {
   cursor?: InputMaybe<LinearUserWhereUniqueInput>;
   distinct?: InputMaybe<Array<LinearUserScalarFieldEnum>>;
@@ -10704,7 +10647,6 @@ export type QueryFindFirstLinearUserArgs = {
   take?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<LinearUserWhereInput>;
 };
-
 
 export type QueryFindFirstPartnerArgs = {
   cursor?: InputMaybe<PartnerWhereUniqueInput>;
@@ -10715,7 +10657,6 @@ export type QueryFindFirstPartnerArgs = {
   where?: InputMaybe<PartnerWhereInput>;
 };
 
-
 export type QueryFindFirstTwitterAccountArgs = {
   cursor?: InputMaybe<TwitterAccountWhereUniqueInput>;
   distinct?: InputMaybe<Array<TwitterAccountScalarFieldEnum>>;
@@ -10724,7 +10665,6 @@ export type QueryFindFirstTwitterAccountArgs = {
   take?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<TwitterAccountWhereInput>;
 };
-
 
 export type QueryFindFirstTwitterTweetArgs = {
   cursor?: InputMaybe<TwitterTweetWhereUniqueInput>;
@@ -10735,7 +10675,6 @@ export type QueryFindFirstTwitterTweetArgs = {
   where?: InputMaybe<TwitterTweetWhereInput>;
 };
 
-
 export type QueryFindFirstTwitterUserArgs = {
   cursor?: InputMaybe<TwitterUserWhereUniqueInput>;
   distinct?: InputMaybe<Array<TwitterUserScalarFieldEnum>>;
@@ -10744,7 +10683,6 @@ export type QueryFindFirstTwitterUserArgs = {
   take?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<TwitterUserWhereInput>;
 };
-
 
 export type QueryFindFirstUserArgs = {
   cursor?: InputMaybe<UserWhereUniqueInput>;
@@ -10755,7 +10693,6 @@ export type QueryFindFirstUserArgs = {
   where?: InputMaybe<UserWhereInput>;
 };
 
-
 export type QueryFindFirstUserActivityArgs = {
   cursor?: InputMaybe<UserActivityWhereUniqueInput>;
   distinct?: InputMaybe<Array<UserActivityScalarFieldEnum>>;
@@ -10764,7 +10701,6 @@ export type QueryFindFirstUserActivityArgs = {
   take?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<UserActivityWhereInput>;
 };
-
 
 export type QueryGroupByActivityTypeArgs = {
   by: Array<ActivityTypeScalarFieldEnum>;
@@ -10775,7 +10711,6 @@ export type QueryGroupByActivityTypeArgs = {
   where?: InputMaybe<ActivityTypeWhereInput>;
 };
 
-
 export type QueryGroupByAttestationArgs = {
   by: Array<AttestationScalarFieldEnum>;
   having?: InputMaybe<AttestationScalarWhereWithAggregatesInput>;
@@ -10784,7 +10719,6 @@ export type QueryGroupByAttestationArgs = {
   take?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<AttestationWhereInput>;
 };
-
 
 export type QueryGroupByAttestationConfidenceArgs = {
   by: Array<AttestationConfidenceScalarFieldEnum>;
@@ -10795,7 +10729,6 @@ export type QueryGroupByAttestationConfidenceArgs = {
   where?: InputMaybe<AttestationConfidenceWhereInput>;
 };
 
-
 export type QueryGroupByCategoryActivityArgs = {
   by: Array<CategoryActivityScalarFieldEnum>;
   having?: InputMaybe<CategoryActivityScalarWhereWithAggregatesInput>;
@@ -10804,7 +10737,6 @@ export type QueryGroupByCategoryActivityArgs = {
   take?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<CategoryActivityWhereInput>;
 };
-
 
 export type QueryGroupByCategoryActivityTypeArgs = {
   by: Array<CategoryActivityTypeScalarFieldEnum>;
@@ -10815,7 +10747,6 @@ export type QueryGroupByCategoryActivityTypeArgs = {
   where?: InputMaybe<CategoryActivityTypeWhereInput>;
 };
 
-
 export type QueryGroupByChainTypeArgs = {
   by: Array<ChainTypeScalarFieldEnum>;
   having?: InputMaybe<ChainTypeScalarWhereWithAggregatesInput>;
@@ -10824,7 +10755,6 @@ export type QueryGroupByChainTypeArgs = {
   take?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<ChainTypeWhereInput>;
 };
-
 
 export type QueryGroupByContributionArgs = {
   by: Array<ContributionScalarFieldEnum>;
@@ -10835,7 +10765,6 @@ export type QueryGroupByContributionArgs = {
   where?: InputMaybe<ContributionWhereInput>;
 };
 
-
 export type QueryGroupByContributionStatusArgs = {
   by: Array<ContributionStatusScalarFieldEnum>;
   having?: InputMaybe<ContributionStatusScalarWhereWithAggregatesInput>;
@@ -10844,7 +10773,6 @@ export type QueryGroupByContributionStatusArgs = {
   take?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<ContributionStatusWhereInput>;
 };
-
 
 export type QueryGroupByDiscordUserArgs = {
   by: Array<DiscordUserScalarFieldEnum>;
@@ -10855,7 +10783,6 @@ export type QueryGroupByDiscordUserArgs = {
   where?: InputMaybe<DiscordUserWhereInput>;
 };
 
-
 export type QueryGroupByGuildArgs = {
   by: Array<GuildScalarFieldEnum>;
   having?: InputMaybe<GuildScalarWhereWithAggregatesInput>;
@@ -10864,7 +10791,6 @@ export type QueryGroupByGuildArgs = {
   take?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<GuildWhereInput>;
 };
-
 
 export type QueryGroupByGuildActivityTypeArgs = {
   by: Array<GuildActivityTypeScalarFieldEnum>;
@@ -10875,7 +10801,6 @@ export type QueryGroupByGuildActivityTypeArgs = {
   where?: InputMaybe<GuildActivityTypeWhereInput>;
 };
 
-
 export type QueryGroupByGuildContributionArgs = {
   by: Array<GuildContributionScalarFieldEnum>;
   having?: InputMaybe<GuildContributionScalarWhereWithAggregatesInput>;
@@ -10884,7 +10809,6 @@ export type QueryGroupByGuildContributionArgs = {
   take?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<GuildContributionWhereInput>;
 };
-
 
 export type QueryGroupByGuildUserArgs = {
   by: Array<GuildUserScalarFieldEnum>;
@@ -10895,7 +10819,6 @@ export type QueryGroupByGuildUserArgs = {
   where?: InputMaybe<GuildUserWhereInput>;
 };
 
-
 export type QueryGroupByJobRunArgs = {
   by: Array<JobRunScalarFieldEnum>;
   having?: InputMaybe<JobRunScalarWhereWithAggregatesInput>;
@@ -10904,7 +10827,6 @@ export type QueryGroupByJobRunArgs = {
   take?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<JobRunWhereInput>;
 };
-
 
 export type QueryGroupByLinearCycleArgs = {
   by: Array<LinearCycleScalarFieldEnum>;
@@ -10915,7 +10837,6 @@ export type QueryGroupByLinearCycleArgs = {
   where?: InputMaybe<LinearCycleWhereInput>;
 };
 
-
 export type QueryGroupByLinearIssueArgs = {
   by: Array<LinearIssueScalarFieldEnum>;
   having?: InputMaybe<LinearIssueScalarWhereWithAggregatesInput>;
@@ -10924,7 +10845,6 @@ export type QueryGroupByLinearIssueArgs = {
   take?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<LinearIssueWhereInput>;
 };
-
 
 export type QueryGroupByLinearProjectArgs = {
   by: Array<LinearProjectScalarFieldEnum>;
@@ -10935,7 +10855,6 @@ export type QueryGroupByLinearProjectArgs = {
   where?: InputMaybe<LinearProjectWhereInput>;
 };
 
-
 export type QueryGroupByLinearTeamArgs = {
   by: Array<LinearTeamScalarFieldEnum>;
   having?: InputMaybe<LinearTeamScalarWhereWithAggregatesInput>;
@@ -10944,7 +10863,6 @@ export type QueryGroupByLinearTeamArgs = {
   take?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<LinearTeamWhereInput>;
 };
-
 
 export type QueryGroupByLinearUserArgs = {
   by: Array<LinearUserScalarFieldEnum>;
@@ -10955,7 +10873,6 @@ export type QueryGroupByLinearUserArgs = {
   where?: InputMaybe<LinearUserWhereInput>;
 };
 
-
 export type QueryGroupByPartnerArgs = {
   by: Array<PartnerScalarFieldEnum>;
   having?: InputMaybe<PartnerScalarWhereWithAggregatesInput>;
@@ -10964,7 +10881,6 @@ export type QueryGroupByPartnerArgs = {
   take?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<PartnerWhereInput>;
 };
-
 
 export type QueryGroupByTwitterAccountArgs = {
   by: Array<TwitterAccountScalarFieldEnum>;
@@ -10975,7 +10891,6 @@ export type QueryGroupByTwitterAccountArgs = {
   where?: InputMaybe<TwitterAccountWhereInput>;
 };
 
-
 export type QueryGroupByTwitterTweetArgs = {
   by: Array<TwitterTweetScalarFieldEnum>;
   having?: InputMaybe<TwitterTweetScalarWhereWithAggregatesInput>;
@@ -10984,7 +10899,6 @@ export type QueryGroupByTwitterTweetArgs = {
   take?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<TwitterTweetWhereInput>;
 };
-
 
 export type QueryGroupByTwitterUserArgs = {
   by: Array<TwitterUserScalarFieldEnum>;
@@ -10995,7 +10909,6 @@ export type QueryGroupByTwitterUserArgs = {
   where?: InputMaybe<TwitterUserWhereInput>;
 };
 
-
 export type QueryGroupByUserArgs = {
   by: Array<UserScalarFieldEnum>;
   having?: InputMaybe<UserScalarWhereWithAggregatesInput>;
@@ -11004,7 +10917,6 @@ export type QueryGroupByUserArgs = {
   take?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<UserWhereInput>;
 };
-
 
 export type QueryGroupByUserActivityArgs = {
   by: Array<UserActivityScalarFieldEnum>;
@@ -11015,16 +10927,13 @@ export type QueryGroupByUserActivityArgs = {
   where?: InputMaybe<UserActivityWhereInput>;
 };
 
-
 export type QueryGuildArgs = {
   where: GuildWhereUniqueInput;
 };
 
-
 export type QueryGuildActivityTypeArgs = {
   where: GuildActivityTypeWhereUniqueInput;
 };
-
 
 export type QueryGuildActivityTypesArgs = {
   cursor?: InputMaybe<GuildActivityTypeWhereUniqueInput>;
@@ -11035,11 +10944,9 @@ export type QueryGuildActivityTypesArgs = {
   where?: InputMaybe<GuildActivityTypeWhereInput>;
 };
 
-
 export type QueryGuildContributionArgs = {
   where: GuildContributionWhereUniqueInput;
 };
-
 
 export type QueryGuildContributionsArgs = {
   cursor?: InputMaybe<GuildContributionWhereUniqueInput>;
@@ -11050,11 +10957,9 @@ export type QueryGuildContributionsArgs = {
   where?: InputMaybe<GuildContributionWhereInput>;
 };
 
-
 export type QueryGuildUserArgs = {
   where: GuildUserWhereUniqueInput;
 };
-
 
 export type QueryGuildUsersArgs = {
   cursor?: InputMaybe<GuildUserWhereUniqueInput>;
@@ -11065,7 +10970,6 @@ export type QueryGuildUsersArgs = {
   where?: InputMaybe<GuildUserWhereInput>;
 };
 
-
 export type QueryGuildsArgs = {
   cursor?: InputMaybe<GuildWhereUniqueInput>;
   distinct?: InputMaybe<Array<GuildScalarFieldEnum>>;
@@ -11075,11 +10979,9 @@ export type QueryGuildsArgs = {
   where?: InputMaybe<GuildWhereInput>;
 };
 
-
 export type QueryJobRunArgs = {
   where: JobRunWhereUniqueInput;
 };
-
 
 export type QueryJobRunsArgs = {
   cursor?: InputMaybe<JobRunWhereUniqueInput>;
@@ -11090,11 +10992,9 @@ export type QueryJobRunsArgs = {
   where?: InputMaybe<JobRunWhereInput>;
 };
 
-
 export type QueryLinearCycleArgs = {
   where: LinearCycleWhereUniqueInput;
 };
-
 
 export type QueryLinearCyclesArgs = {
   cursor?: InputMaybe<LinearCycleWhereUniqueInput>;
@@ -11105,11 +11005,9 @@ export type QueryLinearCyclesArgs = {
   where?: InputMaybe<LinearCycleWhereInput>;
 };
 
-
 export type QueryLinearIssueArgs = {
   where: LinearIssueWhereUniqueInput;
 };
-
 
 export type QueryLinearIssuesArgs = {
   cursor?: InputMaybe<LinearIssueWhereUniqueInput>;
@@ -11120,11 +11018,9 @@ export type QueryLinearIssuesArgs = {
   where?: InputMaybe<LinearIssueWhereInput>;
 };
 
-
 export type QueryLinearProjectArgs = {
   where: LinearProjectWhereUniqueInput;
 };
-
 
 export type QueryLinearProjectsArgs = {
   cursor?: InputMaybe<LinearProjectWhereUniqueInput>;
@@ -11135,11 +11031,9 @@ export type QueryLinearProjectsArgs = {
   where?: InputMaybe<LinearProjectWhereInput>;
 };
 
-
 export type QueryLinearTeamArgs = {
   where: LinearTeamWhereUniqueInput;
 };
-
 
 export type QueryLinearTeamsArgs = {
   cursor?: InputMaybe<LinearTeamWhereUniqueInput>;
@@ -11150,11 +11044,9 @@ export type QueryLinearTeamsArgs = {
   where?: InputMaybe<LinearTeamWhereInput>;
 };
 
-
 export type QueryLinearUserArgs = {
   where: LinearUserWhereUniqueInput;
 };
-
 
 export type QueryLinearUsersArgs = {
   cursor?: InputMaybe<LinearUserWhereUniqueInput>;
@@ -11165,11 +11057,9 @@ export type QueryLinearUsersArgs = {
   where?: InputMaybe<LinearUserWhereInput>;
 };
 
-
 export type QueryPartnerArgs = {
   where: PartnerWhereUniqueInput;
 };
-
 
 export type QueryPartnersArgs = {
   cursor?: InputMaybe<PartnerWhereUniqueInput>;
@@ -11180,11 +11070,9 @@ export type QueryPartnersArgs = {
   where?: InputMaybe<PartnerWhereInput>;
 };
 
-
 export type QueryTwitterAccountArgs = {
   where: TwitterAccountWhereUniqueInput;
 };
-
 
 export type QueryTwitterAccountsArgs = {
   cursor?: InputMaybe<TwitterAccountWhereUniqueInput>;
@@ -11195,11 +11083,9 @@ export type QueryTwitterAccountsArgs = {
   where?: InputMaybe<TwitterAccountWhereInput>;
 };
 
-
 export type QueryTwitterTweetArgs = {
   where: TwitterTweetWhereUniqueInput;
 };
-
 
 export type QueryTwitterTweetsArgs = {
   cursor?: InputMaybe<TwitterTweetWhereUniqueInput>;
@@ -11210,11 +11096,9 @@ export type QueryTwitterTweetsArgs = {
   where?: InputMaybe<TwitterTweetWhereInput>;
 };
 
-
 export type QueryTwitterUserArgs = {
   where: TwitterUserWhereUniqueInput;
 };
-
 
 export type QueryTwitterUsersArgs = {
   cursor?: InputMaybe<TwitterUserWhereUniqueInput>;
@@ -11225,11 +11109,9 @@ export type QueryTwitterUsersArgs = {
   where?: InputMaybe<TwitterUserWhereInput>;
 };
 
-
 export type QueryUserArgs = {
   where: UserWhereUniqueInput;
 };
-
 
 export type QueryUserActivitiesArgs = {
   cursor?: InputMaybe<UserActivityWhereUniqueInput>;
@@ -11240,11 +11122,9 @@ export type QueryUserActivitiesArgs = {
   where?: InputMaybe<UserActivityWhereInput>;
 };
 
-
 export type QueryUserActivityArgs = {
   where: UserActivityWhereUniqueInput;
 };
-
 
 export type QueryUsersArgs = {
   cursor?: InputMaybe<UserWhereUniqueInput>;
@@ -11257,12 +11137,12 @@ export type QueryUsersArgs = {
 
 export enum QueryMode {
   Default = 'default',
-  Insensitive = 'insensitive'
+  Insensitive = 'insensitive',
 }
 
 export enum SortOrder {
   Asc = 'asc',
-  Desc = 'desc'
+  Desc = 'desc',
 }
 
 export type StringFieldUpdateOperationsInput = {
@@ -11480,7 +11360,7 @@ export enum TwitterAccountScalarFieldEnum {
   CreatedAt = 'createdAt',
   GuildId = 'guild_id',
   Id = 'id',
-  UpdatedAt = 'updatedAt'
+  UpdatedAt = 'updatedAt',
 }
 
 export type TwitterAccountScalarWhereWithAggregatesInput = {
@@ -11638,7 +11518,9 @@ export type TwitterTweetCreateManyTwitter_UserInputEnvelope = {
 
 export type TwitterTweetCreateNestedManyWithoutTwitter_UserInput = {
   connect?: InputMaybe<Array<TwitterTweetWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<TwitterTweetCreateOrConnectWithoutTwitter_UserInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<TwitterTweetCreateOrConnectWithoutTwitter_UserInput>
+  >;
   create?: InputMaybe<Array<TwitterTweetCreateWithoutTwitter_UserInput>>;
   createMany?: InputMaybe<TwitterTweetCreateManyTwitter_UserInputEnvelope>;
 };
@@ -11779,7 +11661,7 @@ export enum TwitterTweetScalarFieldEnum {
   Text = 'text',
   TwitterTweetId = 'twitter_tweet_id',
   TwitterUserId = 'twitter_user_id',
-  UpdatedAt = 'updatedAt'
+  UpdatedAt = 'updatedAt',
 }
 
 export type TwitterTweetScalarWhereInput = {
@@ -11845,16 +11727,24 @@ export type TwitterTweetUpdateManyWithWhereWithoutTwitter_UserInput = {
 
 export type TwitterTweetUpdateManyWithoutTwitter_UserInput = {
   connect?: InputMaybe<Array<TwitterTweetWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<TwitterTweetCreateOrConnectWithoutTwitter_UserInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<TwitterTweetCreateOrConnectWithoutTwitter_UserInput>
+  >;
   create?: InputMaybe<Array<TwitterTweetCreateWithoutTwitter_UserInput>>;
   createMany?: InputMaybe<TwitterTweetCreateManyTwitter_UserInputEnvelope>;
   delete?: InputMaybe<Array<TwitterTweetWhereUniqueInput>>;
   deleteMany?: InputMaybe<Array<TwitterTweetScalarWhereInput>>;
   disconnect?: InputMaybe<Array<TwitterTweetWhereUniqueInput>>;
   set?: InputMaybe<Array<TwitterTweetWhereUniqueInput>>;
-  update?: InputMaybe<Array<TwitterTweetUpdateWithWhereUniqueWithoutTwitter_UserInput>>;
-  updateMany?: InputMaybe<Array<TwitterTweetUpdateManyWithWhereWithoutTwitter_UserInput>>;
-  upsert?: InputMaybe<Array<TwitterTweetUpsertWithWhereUniqueWithoutTwitter_UserInput>>;
+  update?: InputMaybe<
+    Array<TwitterTweetUpdateWithWhereUniqueWithoutTwitter_UserInput>
+  >;
+  updateMany?: InputMaybe<
+    Array<TwitterTweetUpdateManyWithWhereWithoutTwitter_UserInput>
+  >;
+  upsert?: InputMaybe<
+    Array<TwitterTweetUpsertWithWhereUniqueWithoutTwitter_UserInput>
+  >;
 };
 
 export type TwitterTweetUpdateOneWithoutContributionInput = {
@@ -11933,7 +11823,6 @@ export type TwitterUser = {
   user_id?: Maybe<Scalars['Int']>;
   username: Scalars['String'];
 };
-
 
 export type TwitterUserTweetsArgs = {
   cursor?: InputMaybe<TwitterTweetWhereUniqueInput>;
@@ -12147,7 +12036,7 @@ export enum TwitterUserScalarFieldEnum {
   TwitterUserId = 'twitter_user_id',
   UpdatedAt = 'updatedAt',
   UserId = 'user_id',
-  Username = 'username'
+  Username = 'username',
 }
 
 export type TwitterUserScalarWhereWithAggregatesInput = {
@@ -12287,7 +12176,6 @@ export type User = {
   updatedAt: Scalars['DateTime'];
 };
 
-
 export type UserActivitiesArgs = {
   cursor?: InputMaybe<UserActivityWhereUniqueInput>;
   distinct?: InputMaybe<Array<UserActivityScalarFieldEnum>>;
@@ -12296,7 +12184,6 @@ export type UserActivitiesArgs = {
   take?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<UserActivityWhereInput>;
 };
-
 
 export type UserAttestationsArgs = {
   cursor?: InputMaybe<AttestationWhereUniqueInput>;
@@ -12307,7 +12194,6 @@ export type UserAttestationsArgs = {
   where?: InputMaybe<AttestationWhereInput>;
 };
 
-
 export type UserContributionPartnersArgs = {
   cursor?: InputMaybe<PartnerWhereUniqueInput>;
   distinct?: InputMaybe<Array<PartnerScalarFieldEnum>>;
@@ -12316,7 +12202,6 @@ export type UserContributionPartnersArgs = {
   take?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<PartnerWhereInput>;
 };
-
 
 export type UserContributionsArgs = {
   cursor?: InputMaybe<ContributionWhereUniqueInput>;
@@ -12327,7 +12212,6 @@ export type UserContributionsArgs = {
   where?: InputMaybe<ContributionWhereInput>;
 };
 
-
 export type UserDiscord_UsersArgs = {
   cursor?: InputMaybe<DiscordUserWhereUniqueInput>;
   distinct?: InputMaybe<Array<DiscordUserScalarFieldEnum>>;
@@ -12337,7 +12221,6 @@ export type UserDiscord_UsersArgs = {
   where?: InputMaybe<DiscordUserWhereInput>;
 };
 
-
 export type UserGuild_UsersArgs = {
   cursor?: InputMaybe<GuildUserWhereUniqueInput>;
   distinct?: InputMaybe<Array<GuildUserScalarFieldEnum>>;
@@ -12346,7 +12229,6 @@ export type UserGuild_UsersArgs = {
   take?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<GuildUserWhereInput>;
 };
-
 
 export type UserLinear_UsersArgs = {
   cursor?: InputMaybe<LinearUserWhereUniqueInput>;
@@ -12437,14 +12319,18 @@ export type UserActivityCreateManyUserInputEnvelope = {
 
 export type UserActivityCreateNestedManyWithoutActivity_TypeInput = {
   connect?: InputMaybe<Array<UserActivityWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<UserActivityCreateOrConnectWithoutActivity_TypeInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<UserActivityCreateOrConnectWithoutActivity_TypeInput>
+  >;
   create?: InputMaybe<Array<UserActivityCreateWithoutActivity_TypeInput>>;
   createMany?: InputMaybe<UserActivityCreateManyActivity_TypeInputEnvelope>;
 };
 
 export type UserActivityCreateNestedManyWithoutUserInput = {
   connect?: InputMaybe<Array<UserActivityWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<UserActivityCreateOrConnectWithoutUserInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<UserActivityCreateOrConnectWithoutUserInput>
+  >;
   create?: InputMaybe<Array<UserActivityCreateWithoutUserInput>>;
   createMany?: InputMaybe<UserActivityCreateManyUserInputEnvelope>;
 };
@@ -12554,7 +12440,7 @@ export enum UserActivityScalarFieldEnum {
   CreatedAt = 'createdAt',
   Id = 'id',
   UpdatedAt = 'updatedAt',
-  UserId = 'user_id'
+  UserId = 'user_id',
 }
 
 export type UserActivityScalarWhereInput = {
@@ -12615,21 +12501,31 @@ export type UserActivityUpdateManyWithWhereWithoutUserInput = {
 
 export type UserActivityUpdateManyWithoutActivity_TypeInput = {
   connect?: InputMaybe<Array<UserActivityWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<UserActivityCreateOrConnectWithoutActivity_TypeInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<UserActivityCreateOrConnectWithoutActivity_TypeInput>
+  >;
   create?: InputMaybe<Array<UserActivityCreateWithoutActivity_TypeInput>>;
   createMany?: InputMaybe<UserActivityCreateManyActivity_TypeInputEnvelope>;
   delete?: InputMaybe<Array<UserActivityWhereUniqueInput>>;
   deleteMany?: InputMaybe<Array<UserActivityScalarWhereInput>>;
   disconnect?: InputMaybe<Array<UserActivityWhereUniqueInput>>;
   set?: InputMaybe<Array<UserActivityWhereUniqueInput>>;
-  update?: InputMaybe<Array<UserActivityUpdateWithWhereUniqueWithoutActivity_TypeInput>>;
-  updateMany?: InputMaybe<Array<UserActivityUpdateManyWithWhereWithoutActivity_TypeInput>>;
-  upsert?: InputMaybe<Array<UserActivityUpsertWithWhereUniqueWithoutActivity_TypeInput>>;
+  update?: InputMaybe<
+    Array<UserActivityUpdateWithWhereUniqueWithoutActivity_TypeInput>
+  >;
+  updateMany?: InputMaybe<
+    Array<UserActivityUpdateManyWithWhereWithoutActivity_TypeInput>
+  >;
+  upsert?: InputMaybe<
+    Array<UserActivityUpsertWithWhereUniqueWithoutActivity_TypeInput>
+  >;
 };
 
 export type UserActivityUpdateManyWithoutUserInput = {
   connect?: InputMaybe<Array<UserActivityWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<UserActivityCreateOrConnectWithoutUserInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<UserActivityCreateOrConnectWithoutUserInput>
+  >;
   create?: InputMaybe<Array<UserActivityCreateWithoutUserInput>>;
   createMany?: InputMaybe<UserActivityCreateManyUserInputEnvelope>;
   delete?: InputMaybe<Array<UserActivityWhereUniqueInput>>;
@@ -12637,7 +12533,9 @@ export type UserActivityUpdateManyWithoutUserInput = {
   disconnect?: InputMaybe<Array<UserActivityWhereUniqueInput>>;
   set?: InputMaybe<Array<UserActivityWhereUniqueInput>>;
   update?: InputMaybe<Array<UserActivityUpdateWithWhereUniqueWithoutUserInput>>;
-  updateMany?: InputMaybe<Array<UserActivityUpdateManyWithWhereWithoutUserInput>>;
+  updateMany?: InputMaybe<
+    Array<UserActivityUpdateManyWithWhereWithoutUserInput>
+  >;
   upsert?: InputMaybe<Array<UserActivityUpsertWithWhereUniqueWithoutUserInput>>;
 };
 
@@ -12787,7 +12685,9 @@ export type UserCreateManyInput = {
 
 export type UserCreateNestedManyWithoutChain_TypeInput = {
   connect?: InputMaybe<Array<UserWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<UserCreateOrConnectWithoutChain_TypeInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<UserCreateOrConnectWithoutChain_TypeInput>
+  >;
   create?: InputMaybe<Array<UserCreateWithoutChain_TypeInput>>;
   createMany?: InputMaybe<UserCreateManyChain_TypeInputEnvelope>;
 };
@@ -13157,7 +13057,7 @@ export enum UserScalarFieldEnum {
   FullName = 'full_name',
   Id = 'id',
   Name = 'name',
-  UpdatedAt = 'updatedAt'
+  UpdatedAt = 'updatedAt',
 }
 
 export type UserScalarWhereInput = {
@@ -13232,7 +13132,9 @@ export type UserUpdateManyWithWhereWithoutChain_TypeInput = {
 
 export type UserUpdateManyWithoutChain_TypeInput = {
   connect?: InputMaybe<Array<UserWhereUniqueInput>>;
-  connectOrCreate?: InputMaybe<Array<UserCreateOrConnectWithoutChain_TypeInput>>;
+  connectOrCreate?: InputMaybe<
+    Array<UserCreateOrConnectWithoutChain_TypeInput>
+  >;
   create?: InputMaybe<Array<UserCreateWithoutChain_TypeInput>>;
   createMany?: InputMaybe<UserCreateManyChain_TypeInputEnvelope>;
   delete?: InputMaybe<Array<UserWhereUniqueInput>>;
@@ -13543,34 +13445,69 @@ export type UserWhereUniqueInput = {
   id?: InputMaybe<Scalars['Int']>;
 };
 
-export type JobFieldsFragmentFragment = { id: number, createdAt: any, updatedAt: any, completedDate: any, name: string, startDate: any };
+export type JobFieldsFragmentFragment = {
+  id: number;
+  createdAt: any;
+  updatedAt: any;
+  completedDate: any;
+  name: string;
+  startDate: any;
+};
 
 export type ListJobRunsQueryVariables = Exact<{
   where?: JobRunWhereInput;
   skip?: Scalars['Int'];
   first?: Scalars['Int'];
-  orderBy?: InputMaybe<Array<JobRunOrderByWithRelationInput> | JobRunOrderByWithRelationInput>;
+  orderBy?: InputMaybe<
+    Array<JobRunOrderByWithRelationInput> | JobRunOrderByWithRelationInput
+  >;
 }>;
 
-
-export type ListJobRunsQuery = { result: Array<{ id: number, createdAt: any, updatedAt: any, completedDate: any, name: string, startDate: any }> };
+export type ListJobRunsQuery = {
+  result: Array<{
+    id: number;
+    createdAt: any;
+    updatedAt: any;
+    completedDate: any;
+    name: string;
+    startDate: any;
+  }>;
+};
 
 export type GetJobRunQueryVariables = Exact<{
   where: JobRunWhereUniqueInput;
 }>;
 
-
-export type GetJobRunQuery = { result?: { id: number, createdAt: any, updatedAt: any, completedDate: any, name: string, startDate: any } | null };
+export type GetJobRunQuery = {
+  result?: {
+    id: number;
+    createdAt: any;
+    updatedAt: any;
+    completedDate: any;
+    name: string;
+    startDate: any;
+  } | null;
+};
 
 export type BulkCreateIssuesMutationVariables = Exact<{
   data: Array<LinearIssueCreateManyInput> | LinearIssueCreateManyInput;
   skipDuplicates: Scalars['Boolean'];
 }>;
 
+export type BulkCreateIssuesMutation = {
+  createManyLinearIssue: { count: number };
+};
 
-export type BulkCreateIssuesMutation = { createManyLinearIssue: { count: number } };
-
-export type LinearUserFragmentFragment = { active: boolean, displayName?: string | null, email?: string | null, linear_id: string, name?: string | null, url?: string | null, id: number, createdAt?: any | null };
+export type LinearUserFragmentFragment = {
+  active: boolean;
+  displayName?: string | null;
+  email?: string | null;
+  linear_id: string;
+  name?: string | null;
+  url?: string | null;
+  id: number;
+  createdAt?: any | null;
+};
 
 export type UpsertLinearUserMutationVariables = Exact<{
   create: LinearUserCreateInput;
@@ -13578,16 +13515,36 @@ export type UpsertLinearUserMutationVariables = Exact<{
   where: LinearUserWhereUniqueInput;
 }>;
 
-
-export type UpsertLinearUserMutation = { upsertLinearUser: { active: boolean, displayName?: string | null, email?: string | null, linear_id: string, name?: string | null, url?: string | null, id: number, createdAt?: any | null } };
+export type UpsertLinearUserMutation = {
+  upsertLinearUser: {
+    active: boolean;
+    displayName?: string | null;
+    email?: string | null;
+    linear_id: string;
+    name?: string | null;
+    url?: string | null;
+    id: number;
+    createdAt?: any | null;
+  };
+};
 
 export type UpdateLinearUserMutationVariables = Exact<{
   data: LinearUserUpdateInput;
   where: LinearUserWhereUniqueInput;
 }>;
 
-
-export type UpdateLinearUserMutation = { updateLinearUser?: { active: boolean, displayName?: string | null, email?: string | null, linear_id: string, name?: string | null, url?: string | null, id: number, createdAt?: any | null } | null };
+export type UpdateLinearUserMutation = {
+  updateLinearUser?: {
+    active: boolean;
+    displayName?: string | null;
+    email?: string | null;
+    linear_id: string;
+    name?: string | null;
+    url?: string | null;
+    id: number;
+    createdAt?: any | null;
+  } | null;
+};
 
 export type UpsertLinearCycleMutationVariables = Exact<{
   create: LinearCycleCreateInput;
@@ -13595,8 +13552,15 @@ export type UpsertLinearCycleMutationVariables = Exact<{
   where: LinearCycleWhereUniqueInput;
 }>;
 
-
-export type UpsertLinearCycleMutation = { upsertLinearCycle: { id: number, endsAt: any, linear_id: string, number: number, startsAt: any } };
+export type UpsertLinearCycleMutation = {
+  upsertLinearCycle: {
+    id: number;
+    endsAt: any;
+    linear_id: string;
+    number: number;
+    startsAt: any;
+  };
+};
 
 export type UpsertLinearProjectMutationVariables = Exact<{
   create: LinearProjectCreateInput;
@@ -13604,8 +13568,9 @@ export type UpsertLinearProjectMutationVariables = Exact<{
   where: LinearProjectWhereUniqueInput;
 }>;
 
-
-export type UpsertLinearProjectMutation = { upsertLinearProject: { id: number, linear_id: string, name: string } };
+export type UpsertLinearProjectMutation = {
+  upsertLinearProject: { id: number; linear_id: string; name: string };
+};
 
 export type UpsertLinearTeamMutationVariables = Exact<{
   create: LinearTeamCreateInput;
@@ -13613,53 +13578,132 @@ export type UpsertLinearTeamMutationVariables = Exact<{
   where: LinearTeamWhereUniqueInput;
 }>;
 
-
-export type UpsertLinearTeamMutation = { upsertLinearTeam: { id: number, key: string, name: string, linear_id: string } };
+export type UpsertLinearTeamMutation = {
+  upsertLinearTeam: {
+    id: number;
+    key: string;
+    name: string;
+    linear_id: string;
+  };
+};
 
 export type CreateJobRunMutationVariables = Exact<{
   data: JobRunCreateInput;
 }>;
 
-
-export type CreateJobRunMutation = { createJobRun: { completedDate: any, startDate: any, name: string } };
+export type CreateJobRunMutation = {
+  createJobRun: { completedDate: any; startDate: any; name: string };
+};
 
 export type CreateGuildMutationVariables = Exact<{
   data: GuildCreateInput;
 }>;
 
-
-export type CreateGuildMutation = { createGuild: { congrats_channel?: number | null, discord_id?: any | null, logo?: string | null, name?: string | null } };
+export type CreateGuildMutation = {
+  createGuild: {
+    congrats_channel?: number | null;
+    discord_id?: any | null;
+    logo?: string | null;
+    name?: string | null;
+  };
+};
 
 export type DeleteGuildUserMutationVariables = Exact<{
   where: GuildUserWhereUniqueInput;
 }>;
 
+export type DeleteGuildUserMutation = {
+  deleteGuildUser?: { id: number } | null;
+};
 
-export type DeleteGuildUserMutation = { deleteGuildUser?: { id: number } | null };
-
-export type TwitterTweetFragmentFragment = { id: number, updatedAt: any, createdAt: any, text: string, twitter_tweet_id: number, twitter_user?: { id: number, name: string, createdAt: any, updatedAt: any, username: string } | null, contribution?: { date_of_engagement: any, date_of_submission: any, details?: string | null, id: number, name: string, proof?: string | null, updatedAt: any, activity_type: { active: boolean, createdAt: any, id: number, name: string, updatedAt: any }, status: { createdAt: any, id: number, name: string, updatedAt: any }, user: { address: string, createdAt: any, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: any }, attestations: Array<{ id: number }> } | null };
+export type TwitterTweetFragmentFragment = {
+  id: number;
+  updatedAt: any;
+  createdAt: any;
+  text: string;
+  twitter_tweet_id: number;
+  twitter_user?: {
+    id: number;
+    name: string;
+    createdAt: any;
+    updatedAt: any;
+    username: string;
+  } | null;
+  contribution?: {
+    date_of_engagement: any;
+    date_of_submission: any;
+    details?: string | null;
+    id: number;
+    name: string;
+    proof?: string | null;
+    updatedAt: any;
+    activity_type: {
+      active: boolean;
+      createdAt: any;
+      id: number;
+      name: string;
+      updatedAt: any;
+    };
+    status: { createdAt: any; id: number; name: string; updatedAt: any };
+    user: {
+      address: string;
+      createdAt: any;
+      display_name?: string | null;
+      full_name?: string | null;
+      id: number;
+      name?: string | null;
+      updatedAt: any;
+    };
+    attestations: Array<{ id: number }>;
+  } | null;
+};
 
 export type BulkCreateTwitterTweetMutationVariables = Exact<{
   data: Array<TwitterTweetCreateManyInput> | TwitterTweetCreateManyInput;
   skipDuplicates: Scalars['Boolean'];
 }>;
 
+export type BulkCreateTwitterTweetMutation = {
+  createManyTwitterTweet: { count: number };
+};
 
-export type BulkCreateTwitterTweetMutation = { createManyTwitterTweet: { count: number } };
-
-export type TwitterAccountFragmentFragment = { account_name: string, createdAt: any, id: number, updatedAt: any, guild?: { id: number, name?: string | null } | null };
+export type TwitterAccountFragmentFragment = {
+  account_name: string;
+  createdAt: any;
+  id: number;
+  updatedAt: any;
+  guild?: { id: number; name?: string | null } | null;
+};
 
 export type ListTwitterAccountsQueryVariables = Exact<{
   where?: TwitterAccountWhereInput;
   skip?: Scalars['Int'];
   first?: Scalars['Int'];
-  orderBy?: InputMaybe<Array<TwitterAccountOrderByWithRelationInput> | TwitterAccountOrderByWithRelationInput>;
+  orderBy?: InputMaybe<
+    | Array<TwitterAccountOrderByWithRelationInput>
+    | TwitterAccountOrderByWithRelationInput
+  >;
 }>;
 
+export type ListTwitterAccountsQuery = {
+  result: Array<{
+    account_name: string;
+    createdAt: any;
+    id: number;
+    updatedAt: any;
+    guild?: { id: number; name?: string | null } | null;
+  }>;
+};
 
-export type ListTwitterAccountsQuery = { result: Array<{ account_name: string, createdAt: any, id: number, updatedAt: any, guild?: { id: number, name?: string | null } | null }> };
-
-export type TwitterUserFragmentFragment = { createdAt: any, updatedAt: any, description: string, id: number, twitter_user_id: string, username: string, user?: { id: number } | null };
+export type TwitterUserFragmentFragment = {
+  createdAt: any;
+  updatedAt: any;
+  description: string;
+  id: number;
+  twitter_user_id: string;
+  username: string;
+  user?: { id: number } | null;
+};
 
 export type UpsertTwitterUserMutationVariables = Exact<{
   create: TwitterUserCreateInput;
@@ -13667,174 +13711,565 @@ export type UpsertTwitterUserMutationVariables = Exact<{
   where: TwitterUserWhereUniqueInput;
 }>;
 
+export type UpsertTwitterUserMutation = {
+  upsertTwitterUser: {
+    createdAt: any;
+    updatedAt: any;
+    description: string;
+    id: number;
+    twitter_user_id: string;
+    username: string;
+    user?: { id: number } | null;
+  };
+};
 
-export type UpsertTwitterUserMutation = { upsertTwitterUser: { createdAt: any, updatedAt: any, description: string, id: number, twitter_user_id: string, username: string, user?: { id: number } | null } };
-
-export type UserFragmentFragment = { address: string, createdAt: any, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: any, chain_type: { id: number, name: string, createdAt: any, updatedAt: any } };
+export type UserFragmentFragment = {
+  address: string;
+  createdAt: any;
+  display_name?: string | null;
+  full_name?: string | null;
+  id: number;
+  name?: string | null;
+  updatedAt: any;
+  chain_type: { id: number; name: string; createdAt: any; updatedAt: any };
+};
 
 export type GetUserQueryVariables = Exact<{
   where: UserWhereUniqueInput;
 }>;
 
-
-export type GetUserQuery = { result?: { address: string, createdAt: any, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: any, chain_type: { id: number, name: string, createdAt: any, updatedAt: any } } | null };
+export type GetUserQuery = {
+  result?: {
+    address: string;
+    createdAt: any;
+    display_name?: string | null;
+    full_name?: string | null;
+    id: number;
+    name?: string | null;
+    updatedAt: any;
+    chain_type: { id: number; name: string; createdAt: any; updatedAt: any };
+  } | null;
+};
 
 export type ListUsersQueryVariables = Exact<{
   where?: UserWhereInput;
   skip?: Scalars['Int'];
   first?: Scalars['Int'];
-  orderBy?: InputMaybe<Array<UserOrderByWithRelationInput> | UserOrderByWithRelationInput>;
+  orderBy?: InputMaybe<
+    Array<UserOrderByWithRelationInput> | UserOrderByWithRelationInput
+  >;
 }>;
 
-
-export type ListUsersQuery = { result: Array<{ address: string, createdAt: any, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: any, chain_type: { id: number, name: string, createdAt: any, updatedAt: any } }> };
+export type ListUsersQuery = {
+  result: Array<{
+    address: string;
+    createdAt: any;
+    display_name?: string | null;
+    full_name?: string | null;
+    id: number;
+    name?: string | null;
+    updatedAt: any;
+    chain_type: { id: number; name: string; createdAt: any; updatedAt: any };
+  }>;
+};
 
 export type UpdateUserMutationVariables = Exact<{
   data: UserUpdateInput;
   where: UserWhereUniqueInput;
 }>;
 
-
-export type UpdateUserMutation = { updateUser?: { address: string, createdAt: any, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: any, chain_type: { id: number, name: string, createdAt: any, updatedAt: any } } | null };
+export type UpdateUserMutation = {
+  updateUser?: {
+    address: string;
+    createdAt: any;
+    display_name?: string | null;
+    full_name?: string | null;
+    id: number;
+    name?: string | null;
+    updatedAt: any;
+    chain_type: { id: number; name: string; createdAt: any; updatedAt: any };
+  } | null;
+};
 
 export type CreateUserMutationVariables = Exact<{
   data: UserCreateInput;
 }>;
 
+export type CreateUserMutation = {
+  createUser: {
+    address: string;
+    createdAt: any;
+    display_name?: string | null;
+    full_name?: string | null;
+    id: number;
+    name?: string | null;
+    updatedAt: any;
+    chain_type: { id: number; name: string; createdAt: any; updatedAt: any };
+  };
+};
 
-export type CreateUserMutation = { createUser: { address: string, createdAt: any, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: any, chain_type: { id: number, name: string, createdAt: any, updatedAt: any } } };
-
-export type ContributionFragmentFragment = { date_of_engagement: any, date_of_submission: any, details?: string | null, id: number, name: string, proof?: string | null, updatedAt: any, activity_type: { active: boolean, createdAt: any, id: number, name: string, updatedAt: any }, status: { createdAt: any, id: number, name: string, updatedAt: any }, user: { address: string, createdAt: any, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: any }, attestations: Array<{ id: number }> };
+export type ContributionFragmentFragment = {
+  date_of_engagement: any;
+  date_of_submission: any;
+  details?: string | null;
+  id: number;
+  name: string;
+  proof?: string | null;
+  updatedAt: any;
+  activity_type: {
+    active: boolean;
+    createdAt: any;
+    id: number;
+    name: string;
+    updatedAt: any;
+  };
+  status: { createdAt: any; id: number; name: string; updatedAt: any };
+  user: {
+    address: string;
+    createdAt: any;
+    display_name?: string | null;
+    full_name?: string | null;
+    id: number;
+    name?: string | null;
+    updatedAt: any;
+  };
+  attestations: Array<{ id: number }>;
+};
 
 export type GetContributionQueryVariables = Exact<{
   where: ContributionWhereUniqueInput;
 }>;
 
-
-export type GetContributionQuery = { result?: { date_of_engagement: any, date_of_submission: any, details?: string | null, id: number, name: string, proof?: string | null, updatedAt: any, activity_type: { active: boolean, createdAt: any, id: number, name: string, updatedAt: any }, status: { createdAt: any, id: number, name: string, updatedAt: any }, user: { address: string, createdAt: any, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: any }, attestations: Array<{ id: number }> } | null };
+export type GetContributionQuery = {
+  result?: {
+    date_of_engagement: any;
+    date_of_submission: any;
+    details?: string | null;
+    id: number;
+    name: string;
+    proof?: string | null;
+    updatedAt: any;
+    activity_type: {
+      active: boolean;
+      createdAt: any;
+      id: number;
+      name: string;
+      updatedAt: any;
+    };
+    status: { createdAt: any; id: number; name: string; updatedAt: any };
+    user: {
+      address: string;
+      createdAt: any;
+      display_name?: string | null;
+      full_name?: string | null;
+      id: number;
+      name?: string | null;
+      updatedAt: any;
+    };
+    attestations: Array<{ id: number }>;
+  } | null;
+};
 
 export type ListContributionsQueryVariables = Exact<{
   where?: ContributionWhereInput;
   skip?: Scalars['Int'];
   first?: Scalars['Int'];
-  orderBy?: InputMaybe<Array<ContributionOrderByWithRelationInput> | ContributionOrderByWithRelationInput>;
+  orderBy?: InputMaybe<
+    | Array<ContributionOrderByWithRelationInput>
+    | ContributionOrderByWithRelationInput
+  >;
 }>;
 
-
-export type ListContributionsQuery = { result: Array<{ date_of_engagement: any, date_of_submission: any, details?: string | null, id: number, name: string, proof?: string | null, updatedAt: any, activity_type: { active: boolean, createdAt: any, id: number, name: string, updatedAt: any }, status: { createdAt: any, id: number, name: string, updatedAt: any }, user: { address: string, createdAt: any, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: any }, attestations: Array<{ id: number }> }> };
+export type ListContributionsQuery = {
+  result: Array<{
+    date_of_engagement: any;
+    date_of_submission: any;
+    details?: string | null;
+    id: number;
+    name: string;
+    proof?: string | null;
+    updatedAt: any;
+    activity_type: {
+      active: boolean;
+      createdAt: any;
+      id: number;
+      name: string;
+      updatedAt: any;
+    };
+    status: { createdAt: any; id: number; name: string; updatedAt: any };
+    user: {
+      address: string;
+      createdAt: any;
+      display_name?: string | null;
+      full_name?: string | null;
+      id: number;
+      name?: string | null;
+      updatedAt: any;
+    };
+    attestations: Array<{ id: number }>;
+  }>;
+};
 
 export type CreateContributionMutationVariables = Exact<{
   data: ContributionCreateInput;
 }>;
 
-
-export type CreateContributionMutation = { createContribution: { date_of_engagement: any, date_of_submission: any, details?: string | null, id: number, name: string, proof?: string | null, updatedAt: any, activity_type: { active: boolean, createdAt: any, id: number, name: string, updatedAt: any }, status: { createdAt: any, id: number, name: string, updatedAt: any }, user: { address: string, createdAt: any, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: any }, attestations: Array<{ id: number }> } };
+export type CreateContributionMutation = {
+  createContribution: {
+    date_of_engagement: any;
+    date_of_submission: any;
+    details?: string | null;
+    id: number;
+    name: string;
+    proof?: string | null;
+    updatedAt: any;
+    activity_type: {
+      active: boolean;
+      createdAt: any;
+      id: number;
+      name: string;
+      updatedAt: any;
+    };
+    status: { createdAt: any; id: number; name: string; updatedAt: any };
+    user: {
+      address: string;
+      createdAt: any;
+      display_name?: string | null;
+      full_name?: string | null;
+      id: number;
+      name?: string | null;
+      updatedAt: any;
+    };
+    attestations: Array<{ id: number }>;
+  };
+};
 
 export type UpdateContributionMutationVariables = Exact<{
   data: ContributionUpdateInput;
   where: ContributionWhereUniqueInput;
 }>;
 
+export type UpdateContributionMutation = {
+  updateContribution?: {
+    date_of_engagement: any;
+    date_of_submission: any;
+    details?: string | null;
+    id: number;
+    name: string;
+    proof?: string | null;
+    updatedAt: any;
+    activity_type: {
+      active: boolean;
+      createdAt: any;
+      id: number;
+      name: string;
+      updatedAt: any;
+    };
+    status: { createdAt: any; id: number; name: string; updatedAt: any };
+    user: {
+      address: string;
+      createdAt: any;
+      display_name?: string | null;
+      full_name?: string | null;
+      id: number;
+      name?: string | null;
+      updatedAt: any;
+    };
+    attestations: Array<{ id: number }>;
+  } | null;
+};
 
-export type UpdateContributionMutation = { updateContribution?: { date_of_engagement: any, date_of_submission: any, details?: string | null, id: number, name: string, proof?: string | null, updatedAt: any, activity_type: { active: boolean, createdAt: any, id: number, name: string, updatedAt: any }, status: { createdAt: any, id: number, name: string, updatedAt: any }, user: { address: string, createdAt: any, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: any }, attestations: Array<{ id: number }> } | null };
-
-export type ActivityTypeFragmentFragment = { active: boolean, createdAt: any, id: number, name: string, updatedAt: any };
+export type ActivityTypeFragmentFragment = {
+  active: boolean;
+  createdAt: any;
+  id: number;
+  name: string;
+  updatedAt: any;
+};
 
 export type ListActivityTypesQueryVariables = Exact<{
   where?: ActivityTypeWhereInput;
   skip?: Scalars['Int'];
   first?: Scalars['Int'];
-  orderBy?: InputMaybe<Array<ActivityTypeOrderByWithRelationInput> | ActivityTypeOrderByWithRelationInput>;
+  orderBy?: InputMaybe<
+    | Array<ActivityTypeOrderByWithRelationInput>
+    | ActivityTypeOrderByWithRelationInput
+  >;
 }>;
 
+export type ListActivityTypesQuery = {
+  result: Array<{
+    active: boolean;
+    createdAt: any;
+    id: number;
+    name: string;
+    updatedAt: any;
+  }>;
+};
 
-export type ListActivityTypesQuery = { result: Array<{ active: boolean, createdAt: any, id: number, name: string, updatedAt: any }> };
-
-export type AttestationFragmentFragment = { date_of_attestation: any, id: number, updatedAt: any, confidence: { createdAt: any, id: number, name: string, updatedAt: any }, contribution: { activity_type_id: number, date_of_engagement: any, date_of_submission: any, details?: string | null, id: number, name: string, proof?: string | null, status_id: number, updatedAt: any, user_id: number }, user: { name?: string | null, address: string, id: number } };
+export type AttestationFragmentFragment = {
+  date_of_attestation: any;
+  id: number;
+  updatedAt: any;
+  confidence: { createdAt: any; id: number; name: string; updatedAt: any };
+  contribution: {
+    activity_type_id: number;
+    date_of_engagement: any;
+    date_of_submission: any;
+    details?: string | null;
+    id: number;
+    name: string;
+    proof?: string | null;
+    status_id: number;
+    updatedAt: any;
+    user_id: number;
+  };
+  user: { name?: string | null; address: string; id: number };
+};
 
 export type ListAttestationsQueryVariables = Exact<{
   where?: AttestationWhereInput;
   skip?: Scalars['Int'];
   first?: Scalars['Int'];
-  orderBy?: InputMaybe<Array<AttestationOrderByWithRelationInput> | AttestationOrderByWithRelationInput>;
+  orderBy?: InputMaybe<
+    | Array<AttestationOrderByWithRelationInput>
+    | AttestationOrderByWithRelationInput
+  >;
 }>;
 
-
-export type ListAttestationsQuery = { result: Array<{ date_of_attestation: any, id: number, updatedAt: any, confidence: { createdAt: any, id: number, name: string, updatedAt: any }, contribution: { activity_type_id: number, date_of_engagement: any, date_of_submission: any, details?: string | null, id: number, name: string, proof?: string | null, status_id: number, updatedAt: any, user_id: number }, user: { name?: string | null, address: string, id: number } }> };
+export type ListAttestationsQuery = {
+  result: Array<{
+    date_of_attestation: any;
+    id: number;
+    updatedAt: any;
+    confidence: { createdAt: any; id: number; name: string; updatedAt: any };
+    contribution: {
+      activity_type_id: number;
+      date_of_engagement: any;
+      date_of_submission: any;
+      details?: string | null;
+      id: number;
+      name: string;
+      proof?: string | null;
+      status_id: number;
+      updatedAt: any;
+      user_id: number;
+    };
+    user: { name?: string | null; address: string; id: number };
+  }>;
+};
 
 export type CreateAttestationMutationVariables = Exact<{
   data: AttestationCreateInput;
 }>;
 
-
-export type CreateAttestationMutation = { createAttestation: { date_of_attestation: any, id: number, updatedAt: any, confidence: { createdAt: any, id: number, name: string, updatedAt: any }, contribution: { activity_type_id: number, date_of_engagement: any, date_of_submission: any, details?: string | null, id: number, name: string, proof?: string | null, status_id: number, updatedAt: any, user_id: number }, user: { name?: string | null, address: string, id: number } } };
+export type CreateAttestationMutation = {
+  createAttestation: {
+    date_of_attestation: any;
+    id: number;
+    updatedAt: any;
+    confidence: { createdAt: any; id: number; name: string; updatedAt: any };
+    contribution: {
+      activity_type_id: number;
+      date_of_engagement: any;
+      date_of_submission: any;
+      details?: string | null;
+      id: number;
+      name: string;
+      proof?: string | null;
+      status_id: number;
+      updatedAt: any;
+      user_id: number;
+    };
+    user: { name?: string | null; address: string; id: number };
+  };
+};
 
 export type UpdateAttestationMutationVariables = Exact<{
   data: AttestationUpdateInput;
   where: AttestationWhereUniqueInput;
 }>;
 
+export type UpdateAttestationMutation = {
+  updateAttestation?: {
+    date_of_attestation: any;
+    id: number;
+    updatedAt: any;
+    confidence: { createdAt: any; id: number; name: string; updatedAt: any };
+    contribution: {
+      activity_type_id: number;
+      date_of_engagement: any;
+      date_of_submission: any;
+      details?: string | null;
+      id: number;
+      name: string;
+      proof?: string | null;
+      status_id: number;
+      updatedAt: any;
+      user_id: number;
+    };
+    user: { name?: string | null; address: string; id: number };
+  } | null;
+};
 
-export type UpdateAttestationMutation = { updateAttestation?: { date_of_attestation: any, id: number, updatedAt: any, confidence: { createdAt: any, id: number, name: string, updatedAt: any }, contribution: { activity_type_id: number, date_of_engagement: any, date_of_submission: any, details?: string | null, id: number, name: string, proof?: string | null, status_id: number, updatedAt: any, user_id: number }, user: { name?: string | null, address: string, id: number } } | null };
-
-export type PartnerFragmentFragment = { createdAt: any, updatedAt: any, contribution: { activity_type_id: number, date_of_engagement: any, date_of_submission: any, details?: string | null, id: number, name: string, proof?: string | null, status_id: number, updatedAt: any, user_id: number }, user: { name?: string | null, address: string, id: number } };
+export type PartnerFragmentFragment = {
+  createdAt: any;
+  updatedAt: any;
+  contribution: {
+    activity_type_id: number;
+    date_of_engagement: any;
+    date_of_submission: any;
+    details?: string | null;
+    id: number;
+    name: string;
+    proof?: string | null;
+    status_id: number;
+    updatedAt: any;
+    user_id: number;
+  };
+  user: { name?: string | null; address: string; id: number };
+};
 
 export type ListPartnersQueryVariables = Exact<{
   where?: PartnerWhereInput;
   skip?: Scalars['Int'];
   first?: Scalars['Int'];
-  orderBy?: InputMaybe<Array<PartnerOrderByWithRelationInput> | PartnerOrderByWithRelationInput>;
+  orderBy?: InputMaybe<
+    Array<PartnerOrderByWithRelationInput> | PartnerOrderByWithRelationInput
+  >;
 }>;
 
-
-export type ListPartnersQuery = { result: Array<{ createdAt: any, updatedAt: any, contribution: { activity_type_id: number, date_of_engagement: any, date_of_submission: any, details?: string | null, id: number, name: string, proof?: string | null, status_id: number, updatedAt: any, user_id: number }, user: { name?: string | null, address: string, id: number } }> };
+export type ListPartnersQuery = {
+  result: Array<{
+    createdAt: any;
+    updatedAt: any;
+    contribution: {
+      activity_type_id: number;
+      date_of_engagement: any;
+      date_of_submission: any;
+      details?: string | null;
+      id: number;
+      name: string;
+      proof?: string | null;
+      status_id: number;
+      updatedAt: any;
+      user_id: number;
+    };
+    user: { name?: string | null; address: string; id: number };
+  }>;
+};
 
 export const JobFieldsFragmentFragmentDoc = gql`
-    fragment JobFieldsFragment on JobRun {
-  id
-  createdAt
-  updatedAt
-  completedDate
-  name
-  startDate
-}
-    `;
+  fragment JobFieldsFragment on JobRun {
+    id
+    createdAt
+    updatedAt
+    completedDate
+    name
+    startDate
+  }
+`;
 export const LinearUserFragmentFragmentDoc = gql`
-    fragment LinearUserFragment on LinearUser {
-  active
-  displayName
-  email
-  linear_id
-  name
-  url
-  id
-  createdAt
-}
-    `;
-export const ContributionFragmentFragmentDoc = gql`
-    fragment ContributionFragment on Contribution {
-  activity_type {
+  fragment LinearUserFragment on LinearUser {
     active
+    displayName
+    email
+    linear_id
+    name
+    url
+    id
     createdAt
+  }
+`;
+export const ContributionFragmentFragmentDoc = gql`
+  fragment ContributionFragment on Contribution {
+    activity_type {
+      active
+      createdAt
+      id
+      name
+      updatedAt
+    }
+    date_of_engagement
+    date_of_submission
+    details
     id
     name
+    proof
+    status {
+      createdAt
+      id
+      name
+      updatedAt
+    }
     updatedAt
+    user {
+      address
+      createdAt
+      display_name
+      full_name
+      id
+      name
+      updatedAt
+    }
+    attestations {
+      id
+    }
   }
-  date_of_engagement
-  date_of_submission
-  details
-  id
-  name
-  proof
-  status {
-    createdAt
+`;
+export const TwitterTweetFragmentFragmentDoc = gql`
+  fragment TwitterTweetFragment on TwitterTweet {
     id
-    name
+    updatedAt
+    createdAt
+    text
+    twitter_tweet_id
+    twitter_user {
+      id
+      name
+      createdAt
+      updatedAt
+      username
+    }
+    contribution {
+      ...ContributionFragment
+    }
+  }
+`;
+export const TwitterAccountFragmentFragmentDoc = gql`
+  fragment TwitterAccountFragment on TwitterAccount {
+    account_name
+    createdAt
+    guild {
+      id
+      name
+    }
+    id
     updatedAt
   }
-  updatedAt
-  user {
+`;
+export const TwitterUserFragmentFragmentDoc = gql`
+  fragment TwitterUserFragment on TwitterUser {
+    createdAt
+    updatedAt
+    description
+    id
+    twitter_user_id
+    user {
+      id
+    }
+    username
+  }
+`;
+export const UserFragmentFragmentDoc = gql`
+  fragment UserFragment on User {
     address
+    chain_type {
+      id
+      name
+      createdAt
+      updatedAt
+    }
     createdAt
     display_name
     full_name
@@ -13842,446 +14277,806 @@ export const ContributionFragmentFragmentDoc = gql`
     name
     updatedAt
   }
-  attestations {
-    id
-  }
-}
-    `;
-export const TwitterTweetFragmentFragmentDoc = gql`
-    fragment TwitterTweetFragment on TwitterTweet {
-  id
-  updatedAt
-  createdAt
-  text
-  twitter_tweet_id
-  twitter_user {
-    id
-    name
-    createdAt
-    updatedAt
-    username
-  }
-  contribution {
-    ...ContributionFragment
-  }
-}
-    `;
-export const TwitterAccountFragmentFragmentDoc = gql`
-    fragment TwitterAccountFragment on TwitterAccount {
-  account_name
-  createdAt
-  guild {
-    id
-    name
-  }
-  id
-  updatedAt
-}
-    `;
-export const TwitterUserFragmentFragmentDoc = gql`
-    fragment TwitterUserFragment on TwitterUser {
-  createdAt
-  updatedAt
-  description
-  id
-  twitter_user_id
-  user {
-    id
-  }
-  username
-}
-    `;
-export const UserFragmentFragmentDoc = gql`
-    fragment UserFragment on User {
-  address
-  chain_type {
-    id
-    name
-    createdAt
-    updatedAt
-  }
-  createdAt
-  display_name
-  full_name
-  id
-  name
-  updatedAt
-}
-    `;
+`;
 export const ActivityTypeFragmentFragmentDoc = gql`
-    fragment ActivityTypeFragment on ActivityType {
-  active
-  createdAt
-  id
-  name
-  updatedAt
-}
-    `;
-export const AttestationFragmentFragmentDoc = gql`
-    fragment AttestationFragment on Attestation {
-  confidence {
+  fragment ActivityTypeFragment on ActivityType {
+    active
     createdAt
     id
     name
     updatedAt
   }
-  contribution {
-    activity_type_id
-    date_of_engagement
-    date_of_submission
-    details
-    id
-    name
-    proof
-    status_id
-    updatedAt
-    user_id
-  }
-  date_of_attestation
-  id
-  updatedAt
-  user {
-    name
-    address
-    id
-  }
-}
-    `;
-export const PartnerFragmentFragmentDoc = gql`
-    fragment PartnerFragment on Partner {
-  contribution {
-    activity_type_id
-    date_of_engagement
-    date_of_submission
-    details
-    id
-    name
-    proof
-    status_id
-    updatedAt
-    user_id
-  }
-  createdAt
-  updatedAt
-  user {
-    name
-    address
-    id
-  }
-}
-    `;
-export const ListJobRunsDocument = gql`
-    query listJobRuns($where: JobRunWhereInput! = {}, $skip: Int! = 0, $first: Int! = 10, $orderBy: [JobRunOrderByWithRelationInput!]) {
-  result: jobRuns(where: $where, skip: $skip, take: $first, orderBy: $orderBy) {
-    ...JobFieldsFragment
-  }
-}
-    ${JobFieldsFragmentFragmentDoc}`;
-export const GetJobRunDocument = gql`
-    query getJobRun($where: JobRunWhereUniqueInput!) {
-  result: jobRun(where: $where) {
-    ...JobFieldsFragment
-  }
-}
-    ${JobFieldsFragmentFragmentDoc}`;
-export const BulkCreateIssuesDocument = gql`
-    mutation bulkCreateIssues($data: [LinearIssueCreateManyInput!]!, $skipDuplicates: Boolean!) {
-  createManyLinearIssue(data: $data, skipDuplicates: $skipDuplicates) {
-    count
-  }
-}
-    `;
-export const UpsertLinearUserDocument = gql`
-    mutation upsertLinearUser($create: LinearUserCreateInput!, $update: LinearUserUpdateInput!, $where: LinearUserWhereUniqueInput!) {
-  upsertLinearUser(create: $create, update: $update, where: $where) {
-    ...LinearUserFragment
-  }
-}
-    ${LinearUserFragmentFragmentDoc}`;
-export const UpdateLinearUserDocument = gql`
-    mutation updateLinearUser($data: LinearUserUpdateInput!, $where: LinearUserWhereUniqueInput!) {
-  updateLinearUser(data: $data, where: $where) {
-    ...LinearUserFragment
-  }
-}
-    ${LinearUserFragmentFragmentDoc}`;
-export const UpsertLinearCycleDocument = gql`
-    mutation upsertLinearCycle($create: LinearCycleCreateInput!, $update: LinearCycleUpdateInput!, $where: LinearCycleWhereUniqueInput!) {
-  upsertLinearCycle(create: $create, update: $update, where: $where) {
-    id
-    endsAt
-    linear_id
-    number
-    startsAt
-  }
-}
-    `;
-export const UpsertLinearProjectDocument = gql`
-    mutation upsertLinearProject($create: LinearProjectCreateInput!, $update: LinearProjectUpdateInput!, $where: LinearProjectWhereUniqueInput!) {
-  upsertLinearProject(create: $create, update: $update, where: $where) {
-    id
-    linear_id
-    name
-  }
-}
-    `;
-export const UpsertLinearTeamDocument = gql`
-    mutation upsertLinearTeam($create: LinearTeamCreateInput!, $update: LinearTeamUpdateInput!, $where: LinearTeamWhereUniqueInput!) {
-  upsertLinearTeam(create: $create, update: $update, where: $where) {
-    id
-    key
-    name
-    linear_id
-  }
-}
-    `;
-export const CreateJobRunDocument = gql`
-    mutation createJobRun($data: JobRunCreateInput!) {
-  createJobRun(data: $data) {
-    completedDate
-    startDate
-    name
-  }
-}
-    `;
-export const CreateGuildDocument = gql`
-    mutation createGuild($data: GuildCreateInput!) {
-  createGuild(data: $data) {
-    congrats_channel
-    discord_id
-    logo
-    name
-  }
-}
-    `;
-export const DeleteGuildUserDocument = gql`
-    mutation deleteGuildUser($where: GuildUserWhereUniqueInput!) {
-  deleteGuildUser(where: $where) {
-    id
-  }
-}
-    `;
-export const BulkCreateTwitterTweetDocument = gql`
-    mutation bulkCreateTwitterTweet($data: [TwitterTweetCreateManyInput!]!, $skipDuplicates: Boolean!) {
-  createManyTwitterTweet(data: $data, skipDuplicates: $skipDuplicates) {
-    count
-  }
-}
-    `;
-export const ListTwitterAccountsDocument = gql`
-    query listTwitterAccounts($where: TwitterAccountWhereInput! = {}, $skip: Int! = 0, $first: Int! = 10, $orderBy: [TwitterAccountOrderByWithRelationInput!]) {
-  result: twitterAccounts(
-    where: $where
-    skip: $skip
-    take: $first
-    orderBy: $orderBy
-  ) {
-    ...TwitterAccountFragment
-  }
-}
-    ${TwitterAccountFragmentFragmentDoc}`;
-export const UpsertTwitterUserDocument = gql`
-    mutation upsertTwitterUser($create: TwitterUserCreateInput!, $update: TwitterUserUpdateInput!, $where: TwitterUserWhereUniqueInput!) {
-  upsertTwitterUser(create: $create, update: $update, where: $where) {
-    ...TwitterUserFragment
-  }
-}
-    ${TwitterUserFragmentFragmentDoc}`;
-export const GetUserDocument = gql`
-    query getUser($where: UserWhereUniqueInput!) {
-  result: user(where: $where) {
-    ...UserFragment
-  }
-}
-    ${UserFragmentFragmentDoc}`;
-export const ListUsersDocument = gql`
-    query listUsers($where: UserWhereInput! = {}, $skip: Int! = 0, $first: Int! = 10, $orderBy: [UserOrderByWithRelationInput!]) {
-  result: users(where: $where, skip: $skip, take: $first, orderBy: $orderBy) {
-    ...UserFragment
-  }
-}
-    ${UserFragmentFragmentDoc}`;
-export const UpdateUserDocument = gql`
-    mutation updateUser($data: UserUpdateInput!, $where: UserWhereUniqueInput!) {
-  updateUser(data: $data, where: $where) {
-    ...UserFragment
-  }
-}
-    ${UserFragmentFragmentDoc}`;
-export const CreateUserDocument = gql`
-    mutation createUser($data: UserCreateInput!) {
-  createUser(data: $data) {
-    ...UserFragment
-  }
-}
-    ${UserFragmentFragmentDoc}`;
-export const GetContributionDocument = gql`
-    query getContribution($where: ContributionWhereUniqueInput!) {
-  result: contribution(where: $where) {
-    ...ContributionFragment
-  }
-}
-    ${ContributionFragmentFragmentDoc}`;
-export const ListContributionsDocument = gql`
-    query listContributions($where: ContributionWhereInput! = {}, $skip: Int! = 0, $first: Int! = 10, $orderBy: [ContributionOrderByWithRelationInput!]) {
-  result: contributions(
-    where: $where
-    skip: $skip
-    take: $first
-    orderBy: $orderBy
-  ) {
-    ...ContributionFragment
-  }
-}
-    ${ContributionFragmentFragmentDoc}`;
-export const CreateContributionDocument = gql`
-    mutation createContribution($data: ContributionCreateInput!) {
-  createContribution(data: $data) {
-    ...ContributionFragment
-  }
-}
-    ${ContributionFragmentFragmentDoc}`;
-export const UpdateContributionDocument = gql`
-    mutation updateContribution($data: ContributionUpdateInput!, $where: ContributionWhereUniqueInput!) {
-  updateContribution(data: $data, where: $where) {
-    ...ContributionFragment
-  }
-}
-    ${ContributionFragmentFragmentDoc}`;
-export const ListActivityTypesDocument = gql`
-    query listActivityTypes($where: ActivityTypeWhereInput! = {}, $skip: Int! = 0, $first: Int! = 10, $orderBy: [ActivityTypeOrderByWithRelationInput!]) {
-  result: activityTypes(
-    where: $where
-    skip: $skip
-    take: $first
-    orderBy: $orderBy
-  ) {
-    ...ActivityTypeFragment
-  }
-}
-    ${ActivityTypeFragmentFragmentDoc}`;
-export const ListAttestationsDocument = gql`
-    query listAttestations($where: AttestationWhereInput! = {}, $skip: Int! = 0, $first: Int! = 10, $orderBy: [AttestationOrderByWithRelationInput!]) {
-  result: attestations(
-    where: $where
-    skip: $skip
-    take: $first
-    orderBy: $orderBy
-  ) {
-    ...AttestationFragment
-  }
-}
-    ${AttestationFragmentFragmentDoc}`;
-export const CreateAttestationDocument = gql`
-    mutation createAttestation($data: AttestationCreateInput!) {
-  createAttestation(data: $data) {
-    ...AttestationFragment
-  }
-}
-    ${AttestationFragmentFragmentDoc}`;
-export const UpdateAttestationDocument = gql`
-    mutation updateAttestation($data: AttestationUpdateInput!, $where: AttestationWhereUniqueInput!) {
-  updateAttestation(data: $data, where: $where) {
-    ...AttestationFragment
-  }
-}
-    ${AttestationFragmentFragmentDoc}`;
-export const ListPartnersDocument = gql`
-    query listPartners($where: PartnerWhereInput! = {}, $skip: Int! = 0, $first: Int! = 10, $orderBy: [PartnerOrderByWithRelationInput!]) {
-  result: partners(where: $where, skip: $skip, take: $first, orderBy: $orderBy) {
-    ...PartnerFragment
-  }
-}
-    ${PartnerFragmentFragmentDoc}`;
-
-export type SdkFunctionWrapper = <T>(action: (requestHeaders?:Record<string, string>) => Promise<T>, operationName: string, operationType?: string) => Promise<T>;
-
-
-const defaultWrapper: SdkFunctionWrapper = (action, _operationName, _operationType) => action();
-
-export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
-  return {
-    listJobRuns(variables?: ListJobRunsQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<ListJobRunsQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<ListJobRunsQuery>(ListJobRunsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'listJobRuns', 'query');
-    },
-    getJobRun(variables: GetJobRunQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<GetJobRunQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<GetJobRunQuery>(GetJobRunDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getJobRun', 'query');
-    },
-    bulkCreateIssues(variables: BulkCreateIssuesMutationVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<BulkCreateIssuesMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<BulkCreateIssuesMutation>(BulkCreateIssuesDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'bulkCreateIssues', 'mutation');
-    },
-    upsertLinearUser(variables: UpsertLinearUserMutationVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<UpsertLinearUserMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<UpsertLinearUserMutation>(UpsertLinearUserDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'upsertLinearUser', 'mutation');
-    },
-    updateLinearUser(variables: UpdateLinearUserMutationVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<UpdateLinearUserMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<UpdateLinearUserMutation>(UpdateLinearUserDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'updateLinearUser', 'mutation');
-    },
-    upsertLinearCycle(variables: UpsertLinearCycleMutationVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<UpsertLinearCycleMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<UpsertLinearCycleMutation>(UpsertLinearCycleDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'upsertLinearCycle', 'mutation');
-    },
-    upsertLinearProject(variables: UpsertLinearProjectMutationVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<UpsertLinearProjectMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<UpsertLinearProjectMutation>(UpsertLinearProjectDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'upsertLinearProject', 'mutation');
-    },
-    upsertLinearTeam(variables: UpsertLinearTeamMutationVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<UpsertLinearTeamMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<UpsertLinearTeamMutation>(UpsertLinearTeamDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'upsertLinearTeam', 'mutation');
-    },
-    createJobRun(variables: CreateJobRunMutationVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<CreateJobRunMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<CreateJobRunMutation>(CreateJobRunDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'createJobRun', 'mutation');
-    },
-    createGuild(variables: CreateGuildMutationVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<CreateGuildMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<CreateGuildMutation>(CreateGuildDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'createGuild', 'mutation');
-    },
-    deleteGuildUser(variables: DeleteGuildUserMutationVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<DeleteGuildUserMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<DeleteGuildUserMutation>(DeleteGuildUserDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'deleteGuildUser', 'mutation');
-    },
-    bulkCreateTwitterTweet(variables: BulkCreateTwitterTweetMutationVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<BulkCreateTwitterTweetMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<BulkCreateTwitterTweetMutation>(BulkCreateTwitterTweetDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'bulkCreateTwitterTweet', 'mutation');
-    },
-    listTwitterAccounts(variables?: ListTwitterAccountsQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<ListTwitterAccountsQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<ListTwitterAccountsQuery>(ListTwitterAccountsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'listTwitterAccounts', 'query');
-    },
-    upsertTwitterUser(variables: UpsertTwitterUserMutationVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<UpsertTwitterUserMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<UpsertTwitterUserMutation>(UpsertTwitterUserDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'upsertTwitterUser', 'mutation');
-    },
-    getUser(variables: GetUserQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<GetUserQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<GetUserQuery>(GetUserDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getUser', 'query');
-    },
-    listUsers(variables?: ListUsersQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<ListUsersQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<ListUsersQuery>(ListUsersDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'listUsers', 'query');
-    },
-    updateUser(variables: UpdateUserMutationVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<UpdateUserMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<UpdateUserMutation>(UpdateUserDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'updateUser', 'mutation');
-    },
-    createUser(variables: CreateUserMutationVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<CreateUserMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<CreateUserMutation>(CreateUserDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'createUser', 'mutation');
-    },
-    getContribution(variables: GetContributionQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<GetContributionQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<GetContributionQuery>(GetContributionDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getContribution', 'query');
-    },
-    listContributions(variables?: ListContributionsQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<ListContributionsQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<ListContributionsQuery>(ListContributionsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'listContributions', 'query');
-    },
-    createContribution(variables: CreateContributionMutationVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<CreateContributionMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<CreateContributionMutation>(CreateContributionDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'createContribution', 'mutation');
-    },
-    updateContribution(variables: UpdateContributionMutationVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<UpdateContributionMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<UpdateContributionMutation>(UpdateContributionDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'updateContribution', 'mutation');
-    },
-    listActivityTypes(variables?: ListActivityTypesQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<ListActivityTypesQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<ListActivityTypesQuery>(ListActivityTypesDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'listActivityTypes', 'query');
-    },
-    listAttestations(variables?: ListAttestationsQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<ListAttestationsQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<ListAttestationsQuery>(ListAttestationsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'listAttestations', 'query');
-    },
-    createAttestation(variables: CreateAttestationMutationVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<CreateAttestationMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<CreateAttestationMutation>(CreateAttestationDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'createAttestation', 'mutation');
-    },
-    updateAttestation(variables: UpdateAttestationMutationVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<UpdateAttestationMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<UpdateAttestationMutation>(UpdateAttestationDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'updateAttestation', 'mutation');
-    },
-    listPartners(variables?: ListPartnersQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<ListPartnersQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<ListPartnersQuery>(ListPartnersDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'listPartners', 'query');
+`;
+export const AttestationFragmentFragmentDoc = gql`
+  fragment AttestationFragment on Attestation {
+    confidence {
+      createdAt
+      id
+      name
+      updatedAt
     }
+    contribution {
+      activity_type_id
+      date_of_engagement
+      date_of_submission
+      details
+      id
+      name
+      proof
+      status_id
+      updatedAt
+      user_id
+    }
+    date_of_attestation
+    id
+    updatedAt
+    user {
+      name
+      address
+      id
+    }
+  }
+`;
+export const PartnerFragmentFragmentDoc = gql`
+  fragment PartnerFragment on Partner {
+    contribution {
+      activity_type_id
+      date_of_engagement
+      date_of_submission
+      details
+      id
+      name
+      proof
+      status_id
+      updatedAt
+      user_id
+    }
+    createdAt
+    updatedAt
+    user {
+      name
+      address
+      id
+    }
+  }
+`;
+export const ListJobRunsDocument = gql`
+  query listJobRuns(
+    $where: JobRunWhereInput! = {}
+    $skip: Int! = 0
+    $first: Int! = 10
+    $orderBy: [JobRunOrderByWithRelationInput!]
+  ) {
+    result: jobRuns(
+      where: $where
+      skip: $skip
+      take: $first
+      orderBy: $orderBy
+    ) {
+      ...JobFieldsFragment
+    }
+  }
+  ${JobFieldsFragmentFragmentDoc}
+`;
+export const GetJobRunDocument = gql`
+  query getJobRun($where: JobRunWhereUniqueInput!) {
+    result: jobRun(where: $where) {
+      ...JobFieldsFragment
+    }
+  }
+  ${JobFieldsFragmentFragmentDoc}
+`;
+export const BulkCreateIssuesDocument = gql`
+  mutation bulkCreateIssues(
+    $data: [LinearIssueCreateManyInput!]!
+    $skipDuplicates: Boolean!
+  ) {
+    createManyLinearIssue(data: $data, skipDuplicates: $skipDuplicates) {
+      count
+    }
+  }
+`;
+export const UpsertLinearUserDocument = gql`
+  mutation upsertLinearUser(
+    $create: LinearUserCreateInput!
+    $update: LinearUserUpdateInput!
+    $where: LinearUserWhereUniqueInput!
+  ) {
+    upsertLinearUser(create: $create, update: $update, where: $where) {
+      ...LinearUserFragment
+    }
+  }
+  ${LinearUserFragmentFragmentDoc}
+`;
+export const UpdateLinearUserDocument = gql`
+  mutation updateLinearUser(
+    $data: LinearUserUpdateInput!
+    $where: LinearUserWhereUniqueInput!
+  ) {
+    updateLinearUser(data: $data, where: $where) {
+      ...LinearUserFragment
+    }
+  }
+  ${LinearUserFragmentFragmentDoc}
+`;
+export const UpsertLinearCycleDocument = gql`
+  mutation upsertLinearCycle(
+    $create: LinearCycleCreateInput!
+    $update: LinearCycleUpdateInput!
+    $where: LinearCycleWhereUniqueInput!
+  ) {
+    upsertLinearCycle(create: $create, update: $update, where: $where) {
+      id
+      endsAt
+      linear_id
+      number
+      startsAt
+    }
+  }
+`;
+export const UpsertLinearProjectDocument = gql`
+  mutation upsertLinearProject(
+    $create: LinearProjectCreateInput!
+    $update: LinearProjectUpdateInput!
+    $where: LinearProjectWhereUniqueInput!
+  ) {
+    upsertLinearProject(create: $create, update: $update, where: $where) {
+      id
+      linear_id
+      name
+    }
+  }
+`;
+export const UpsertLinearTeamDocument = gql`
+  mutation upsertLinearTeam(
+    $create: LinearTeamCreateInput!
+    $update: LinearTeamUpdateInput!
+    $where: LinearTeamWhereUniqueInput!
+  ) {
+    upsertLinearTeam(create: $create, update: $update, where: $where) {
+      id
+      key
+      name
+      linear_id
+    }
+  }
+`;
+export const CreateJobRunDocument = gql`
+  mutation createJobRun($data: JobRunCreateInput!) {
+    createJobRun(data: $data) {
+      completedDate
+      startDate
+      name
+    }
+  }
+`;
+export const CreateGuildDocument = gql`
+  mutation createGuild($data: GuildCreateInput!) {
+    createGuild(data: $data) {
+      congrats_channel
+      discord_id
+      logo
+      name
+    }
+  }
+`;
+export const DeleteGuildUserDocument = gql`
+  mutation deleteGuildUser($where: GuildUserWhereUniqueInput!) {
+    deleteGuildUser(where: $where) {
+      id
+    }
+  }
+`;
+export const BulkCreateTwitterTweetDocument = gql`
+  mutation bulkCreateTwitterTweet(
+    $data: [TwitterTweetCreateManyInput!]!
+    $skipDuplicates: Boolean!
+  ) {
+    createManyTwitterTweet(data: $data, skipDuplicates: $skipDuplicates) {
+      count
+    }
+  }
+`;
+export const ListTwitterAccountsDocument = gql`
+  query listTwitterAccounts(
+    $where: TwitterAccountWhereInput! = {}
+    $skip: Int! = 0
+    $first: Int! = 10
+    $orderBy: [TwitterAccountOrderByWithRelationInput!]
+  ) {
+    result: twitterAccounts(
+      where: $where
+      skip: $skip
+      take: $first
+      orderBy: $orderBy
+    ) {
+      ...TwitterAccountFragment
+    }
+  }
+  ${TwitterAccountFragmentFragmentDoc}
+`;
+export const UpsertTwitterUserDocument = gql`
+  mutation upsertTwitterUser(
+    $create: TwitterUserCreateInput!
+    $update: TwitterUserUpdateInput!
+    $where: TwitterUserWhereUniqueInput!
+  ) {
+    upsertTwitterUser(create: $create, update: $update, where: $where) {
+      ...TwitterUserFragment
+    }
+  }
+  ${TwitterUserFragmentFragmentDoc}
+`;
+export const GetUserDocument = gql`
+  query getUser($where: UserWhereUniqueInput!) {
+    result: user(where: $where) {
+      ...UserFragment
+    }
+  }
+  ${UserFragmentFragmentDoc}
+`;
+export const ListUsersDocument = gql`
+  query listUsers(
+    $where: UserWhereInput! = {}
+    $skip: Int! = 0
+    $first: Int! = 10
+    $orderBy: [UserOrderByWithRelationInput!]
+  ) {
+    result: users(where: $where, skip: $skip, take: $first, orderBy: $orderBy) {
+      ...UserFragment
+    }
+  }
+  ${UserFragmentFragmentDoc}
+`;
+export const UpdateUserDocument = gql`
+  mutation updateUser($data: UserUpdateInput!, $where: UserWhereUniqueInput!) {
+    updateUser(data: $data, where: $where) {
+      ...UserFragment
+    }
+  }
+  ${UserFragmentFragmentDoc}
+`;
+export const CreateUserDocument = gql`
+  mutation createUser($data: UserCreateInput!) {
+    createUser(data: $data) {
+      ...UserFragment
+    }
+  }
+  ${UserFragmentFragmentDoc}
+`;
+export const GetContributionDocument = gql`
+  query getContribution($where: ContributionWhereUniqueInput!) {
+    result: contribution(where: $where) {
+      ...ContributionFragment
+    }
+  }
+  ${ContributionFragmentFragmentDoc}
+`;
+export const ListContributionsDocument = gql`
+  query listContributions(
+    $where: ContributionWhereInput! = {}
+    $skip: Int! = 0
+    $first: Int! = 10
+    $orderBy: [ContributionOrderByWithRelationInput!]
+  ) {
+    result: contributions(
+      where: $where
+      skip: $skip
+      take: $first
+      orderBy: $orderBy
+    ) {
+      ...ContributionFragment
+    }
+  }
+  ${ContributionFragmentFragmentDoc}
+`;
+export const CreateContributionDocument = gql`
+  mutation createContribution($data: ContributionCreateInput!) {
+    createContribution(data: $data) {
+      ...ContributionFragment
+    }
+  }
+  ${ContributionFragmentFragmentDoc}
+`;
+export const UpdateContributionDocument = gql`
+  mutation updateContribution(
+    $data: ContributionUpdateInput!
+    $where: ContributionWhereUniqueInput!
+  ) {
+    updateContribution(data: $data, where: $where) {
+      ...ContributionFragment
+    }
+  }
+  ${ContributionFragmentFragmentDoc}
+`;
+export const ListActivityTypesDocument = gql`
+  query listActivityTypes(
+    $where: ActivityTypeWhereInput! = {}
+    $skip: Int! = 0
+    $first: Int! = 10
+    $orderBy: [ActivityTypeOrderByWithRelationInput!]
+  ) {
+    result: activityTypes(
+      where: $where
+      skip: $skip
+      take: $first
+      orderBy: $orderBy
+    ) {
+      ...ActivityTypeFragment
+    }
+  }
+  ${ActivityTypeFragmentFragmentDoc}
+`;
+export const ListAttestationsDocument = gql`
+  query listAttestations(
+    $where: AttestationWhereInput! = {}
+    $skip: Int! = 0
+    $first: Int! = 10
+    $orderBy: [AttestationOrderByWithRelationInput!]
+  ) {
+    result: attestations(
+      where: $where
+      skip: $skip
+      take: $first
+      orderBy: $orderBy
+    ) {
+      ...AttestationFragment
+    }
+  }
+  ${AttestationFragmentFragmentDoc}
+`;
+export const CreateAttestationDocument = gql`
+  mutation createAttestation($data: AttestationCreateInput!) {
+    createAttestation(data: $data) {
+      ...AttestationFragment
+    }
+  }
+  ${AttestationFragmentFragmentDoc}
+`;
+export const UpdateAttestationDocument = gql`
+  mutation updateAttestation(
+    $data: AttestationUpdateInput!
+    $where: AttestationWhereUniqueInput!
+  ) {
+    updateAttestation(data: $data, where: $where) {
+      ...AttestationFragment
+    }
+  }
+  ${AttestationFragmentFragmentDoc}
+`;
+export const ListPartnersDocument = gql`
+  query listPartners(
+    $where: PartnerWhereInput! = {}
+    $skip: Int! = 0
+    $first: Int! = 10
+    $orderBy: [PartnerOrderByWithRelationInput!]
+  ) {
+    result: partners(
+      where: $where
+      skip: $skip
+      take: $first
+      orderBy: $orderBy
+    ) {
+      ...PartnerFragment
+    }
+  }
+  ${PartnerFragmentFragmentDoc}
+`;
+
+export type SdkFunctionWrapper = <T>(
+  action: (requestHeaders?: Record<string, string>) => Promise<T>,
+  operationName: string,
+  operationType?: string
+) => Promise<T>;
+
+const defaultWrapper: SdkFunctionWrapper = (
+  action,
+  _operationName,
+  _operationType
+) => action();
+
+export function getSdk(
+  client: GraphQLClient,
+  withWrapper: SdkFunctionWrapper = defaultWrapper
+) {
+  return {
+    listJobRuns(
+      variables?: ListJobRunsQueryVariables,
+      requestHeaders?: Dom.RequestInit['headers']
+    ): Promise<ListJobRunsQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<ListJobRunsQuery>(ListJobRunsDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'listJobRuns',
+        'query'
+      );
+    },
+    getJobRun(
+      variables: GetJobRunQueryVariables,
+      requestHeaders?: Dom.RequestInit['headers']
+    ): Promise<GetJobRunQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<GetJobRunQuery>(GetJobRunDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'getJobRun',
+        'query'
+      );
+    },
+    bulkCreateIssues(
+      variables: BulkCreateIssuesMutationVariables,
+      requestHeaders?: Dom.RequestInit['headers']
+    ): Promise<BulkCreateIssuesMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<BulkCreateIssuesMutation>(
+            BulkCreateIssuesDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders }
+          ),
+        'bulkCreateIssues',
+        'mutation'
+      );
+    },
+    upsertLinearUser(
+      variables: UpsertLinearUserMutationVariables,
+      requestHeaders?: Dom.RequestInit['headers']
+    ): Promise<UpsertLinearUserMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<UpsertLinearUserMutation>(
+            UpsertLinearUserDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders }
+          ),
+        'upsertLinearUser',
+        'mutation'
+      );
+    },
+    updateLinearUser(
+      variables: UpdateLinearUserMutationVariables,
+      requestHeaders?: Dom.RequestInit['headers']
+    ): Promise<UpdateLinearUserMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<UpdateLinearUserMutation>(
+            UpdateLinearUserDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders }
+          ),
+        'updateLinearUser',
+        'mutation'
+      );
+    },
+    upsertLinearCycle(
+      variables: UpsertLinearCycleMutationVariables,
+      requestHeaders?: Dom.RequestInit['headers']
+    ): Promise<UpsertLinearCycleMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<UpsertLinearCycleMutation>(
+            UpsertLinearCycleDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders }
+          ),
+        'upsertLinearCycle',
+        'mutation'
+      );
+    },
+    upsertLinearProject(
+      variables: UpsertLinearProjectMutationVariables,
+      requestHeaders?: Dom.RequestInit['headers']
+    ): Promise<UpsertLinearProjectMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<UpsertLinearProjectMutation>(
+            UpsertLinearProjectDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders }
+          ),
+        'upsertLinearProject',
+        'mutation'
+      );
+    },
+    upsertLinearTeam(
+      variables: UpsertLinearTeamMutationVariables,
+      requestHeaders?: Dom.RequestInit['headers']
+    ): Promise<UpsertLinearTeamMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<UpsertLinearTeamMutation>(
+            UpsertLinearTeamDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders }
+          ),
+        'upsertLinearTeam',
+        'mutation'
+      );
+    },
+    createJobRun(
+      variables: CreateJobRunMutationVariables,
+      requestHeaders?: Dom.RequestInit['headers']
+    ): Promise<CreateJobRunMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<CreateJobRunMutation>(
+            CreateJobRunDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders }
+          ),
+        'createJobRun',
+        'mutation'
+      );
+    },
+    createGuild(
+      variables: CreateGuildMutationVariables,
+      requestHeaders?: Dom.RequestInit['headers']
+    ): Promise<CreateGuildMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<CreateGuildMutation>(CreateGuildDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'createGuild',
+        'mutation'
+      );
+    },
+    deleteGuildUser(
+      variables: DeleteGuildUserMutationVariables,
+      requestHeaders?: Dom.RequestInit['headers']
+    ): Promise<DeleteGuildUserMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<DeleteGuildUserMutation>(
+            DeleteGuildUserDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders }
+          ),
+        'deleteGuildUser',
+        'mutation'
+      );
+    },
+    bulkCreateTwitterTweet(
+      variables: BulkCreateTwitterTweetMutationVariables,
+      requestHeaders?: Dom.RequestInit['headers']
+    ): Promise<BulkCreateTwitterTweetMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<BulkCreateTwitterTweetMutation>(
+            BulkCreateTwitterTweetDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders }
+          ),
+        'bulkCreateTwitterTweet',
+        'mutation'
+      );
+    },
+    listTwitterAccounts(
+      variables?: ListTwitterAccountsQueryVariables,
+      requestHeaders?: Dom.RequestInit['headers']
+    ): Promise<ListTwitterAccountsQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<ListTwitterAccountsQuery>(
+            ListTwitterAccountsDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders }
+          ),
+        'listTwitterAccounts',
+        'query'
+      );
+    },
+    upsertTwitterUser(
+      variables: UpsertTwitterUserMutationVariables,
+      requestHeaders?: Dom.RequestInit['headers']
+    ): Promise<UpsertTwitterUserMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<UpsertTwitterUserMutation>(
+            UpsertTwitterUserDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders }
+          ),
+        'upsertTwitterUser',
+        'mutation'
+      );
+    },
+    getUser(
+      variables: GetUserQueryVariables,
+      requestHeaders?: Dom.RequestInit['headers']
+    ): Promise<GetUserQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<GetUserQuery>(GetUserDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'getUser',
+        'query'
+      );
+    },
+    listUsers(
+      variables?: ListUsersQueryVariables,
+      requestHeaders?: Dom.RequestInit['headers']
+    ): Promise<ListUsersQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<ListUsersQuery>(ListUsersDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'listUsers',
+        'query'
+      );
+    },
+    updateUser(
+      variables: UpdateUserMutationVariables,
+      requestHeaders?: Dom.RequestInit['headers']
+    ): Promise<UpdateUserMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<UpdateUserMutation>(UpdateUserDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'updateUser',
+        'mutation'
+      );
+    },
+    createUser(
+      variables: CreateUserMutationVariables,
+      requestHeaders?: Dom.RequestInit['headers']
+    ): Promise<CreateUserMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<CreateUserMutation>(CreateUserDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'createUser',
+        'mutation'
+      );
+    },
+    getContribution(
+      variables: GetContributionQueryVariables,
+      requestHeaders?: Dom.RequestInit['headers']
+    ): Promise<GetContributionQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<GetContributionQuery>(
+            GetContributionDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders }
+          ),
+        'getContribution',
+        'query'
+      );
+    },
+    listContributions(
+      variables?: ListContributionsQueryVariables,
+      requestHeaders?: Dom.RequestInit['headers']
+    ): Promise<ListContributionsQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<ListContributionsQuery>(
+            ListContributionsDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders }
+          ),
+        'listContributions',
+        'query'
+      );
+    },
+    createContribution(
+      variables: CreateContributionMutationVariables,
+      requestHeaders?: Dom.RequestInit['headers']
+    ): Promise<CreateContributionMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<CreateContributionMutation>(
+            CreateContributionDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders }
+          ),
+        'createContribution',
+        'mutation'
+      );
+    },
+    updateContribution(
+      variables: UpdateContributionMutationVariables,
+      requestHeaders?: Dom.RequestInit['headers']
+    ): Promise<UpdateContributionMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<UpdateContributionMutation>(
+            UpdateContributionDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders }
+          ),
+        'updateContribution',
+        'mutation'
+      );
+    },
+    listActivityTypes(
+      variables?: ListActivityTypesQueryVariables,
+      requestHeaders?: Dom.RequestInit['headers']
+    ): Promise<ListActivityTypesQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<ListActivityTypesQuery>(
+            ListActivityTypesDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders }
+          ),
+        'listActivityTypes',
+        'query'
+      );
+    },
+    listAttestations(
+      variables?: ListAttestationsQueryVariables,
+      requestHeaders?: Dom.RequestInit['headers']
+    ): Promise<ListAttestationsQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<ListAttestationsQuery>(
+            ListAttestationsDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders }
+          ),
+        'listAttestations',
+        'query'
+      );
+    },
+    createAttestation(
+      variables: CreateAttestationMutationVariables,
+      requestHeaders?: Dom.RequestInit['headers']
+    ): Promise<CreateAttestationMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<CreateAttestationMutation>(
+            CreateAttestationDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders }
+          ),
+        'createAttestation',
+        'mutation'
+      );
+    },
+    updateAttestation(
+      variables: UpdateAttestationMutationVariables,
+      requestHeaders?: Dom.RequestInit['headers']
+    ): Promise<UpdateAttestationMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<UpdateAttestationMutation>(
+            UpdateAttestationDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders }
+          ),
+        'updateAttestation',
+        'mutation'
+      );
+    },
+    listPartners(
+      variables?: ListPartnersQueryVariables,
+      requestHeaders?: Dom.RequestInit['headers']
+    ): Promise<ListPartnersQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<ListPartnersQuery>(ListPartnersDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'listPartners',
+        'query'
+      );
+    },
   };
 }
 export type Sdk = ReturnType<typeof getSdk>;

--- a/libs/protocol-client/src/lib/protocol-types.ts
+++ b/libs/protocol-client/src/lib/protocol-types.ts
@@ -13906,7 +13906,7 @@ export type ListContributionsQuery = {
       name?: string | null;
       updatedAt: any;
     };
-    attestations: Array<{ id: number }>;
+    attestations: Array<{ id: number; user_id: number }>;
   }>;
 };
 
@@ -14214,6 +14214,7 @@ export const ContributionFragmentFragmentDoc = gql`
     }
     attestations {
       id
+      user_id
     }
   }
 `;

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "graphql-request": "^4.2.0",
     "graphql-scalars": "^1.17.0",
     "graphql-tag": "^2.12.6",
+    "lodash": "^4.17.21",
     "notistack": "^1.0.10",
     "process-es6": "^0.11.6",
     "react": "^17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19095,9 +19095,14 @@ lodash@4.17.20:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
-lodash@4.x, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.7.0, lodash@~4.17.0:
+lodash@4.x, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.4, lodash@^4.7.0, lodash@~4.17.0:
   version "4.17.21"
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 log-symbols@4.1.0, log-symbols@^4.0.0, log-symbols@^4.1.0:


### PR DESCRIPTION
## Overview

Initially this was going to include the minting flow but I wanted to split that into another PR. This PR includes the following:

- Fixes the `regeneratorRuntime` issue (we'll probably want to revisit this with a longer-term fix such as a polyfill on the `babelrc` but this works
- Filters the Attestations feed by Contributions that the user hasn't attested to
- Fixes issue where the Contributions feed wasn't properly scoping to the user (was showing all Contributions instead of user only)
- Adds in the groundwork for the minting flow 
- Adds in the bulk attestations (select all -> attest) with the confidence change 

## Packages Added

- lodash