### PR TITLE
Update contract sync job to load off-chain details

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 
 
-<p align="center"><img src="https://beta.govrn.app/assets/govrn-logo.344f0de2.png" width="350"></p>
+<p align="center"><img src="./apps/protocol-frontend/src/assets/govrn-logo.png" width="350"></p>
 
 # Govrn Monorepo
  Our monorepo uses [Nx](https://nx.dev/getting-started/intro) as a build system and for scaffolding.

--- a/apps/contract-sync-job/README.md
+++ b/apps/contract-sync-job/README.md
@@ -18,8 +18,9 @@ This App is generated using [`@nrwl/node:application`](https://nx.dev/packages/n
 - `PROTOCOL_URL`: link to gql [endpoint](../protocol-api/README.md#express): `http://localhost:4000/graphql`
 - `DATABASE_URL`: URL references that Database cluster, `govrn`.[^1]
 - `SUBGRAPH_URL`: Link to [subgraph](https://thegraph.com/docs/en/developer/quick-start/) that is used to fetch Contract's events.
-- `KEVIN_MALONE_TOKEN`: Authorization token for GraphQL requests.[^2]
+- `CONTRACT_SYNC_TOKEN`: Authorization token for GraphQL requests.[^2]
 
 
 [^1]: How to prepare `postgres` and get `DATABASE_URL` go to [`protocol-api`](../protocol-api/README.md#postgres).
-[^2]: For Developement, it should match with `KEVIN_MALONE_TOKEN` at [protocol-api](../protocol-api)
+
+[^2]: For Development, it should match with `KEVIN_MALONE_TOKEN` at [protocol-api](../protocol-api)

--- a/apps/contract-sync-job/README.md
+++ b/apps/contract-sync-job/README.md
@@ -17,6 +17,9 @@ This App is generated using [`@nrwl/node:application`](https://nx.dev/packages/n
 - `CHAIN_URL`: chain that Govrn Contract is deployed.
 - `PROTOCOL_URL`: link to gql [endpoint](../protocol-api/README.md#express): `http://localhost:4000/graphql`
 - `DATABASE_URL`: URL references that Database cluster, `govrn`.[^1]
-- `SUBGRAPH_URL`: Link to [subgraph](https://thegraph.com/docs/en/developer/quick-start/) that is used to fetch Contract's events 
+- `SUBGRAPH_URL`: Link to [subgraph](https://thegraph.com/docs/en/developer/quick-start/) that is used to fetch Contract's events.
+- `KEVIN_MALONE_TOKEN`: Authorization token for GraphQL requests.[^2]
+
 
 [^1]: How to prepare `postgres` and get `DATABASE_URL` go to [`protocol-api`](../protocol-api/README.md#postgres).
+[^2]: For Developement, it should match with `KEVIN_MALONE_TOKEN` at [protocol-api](../protocol-api)

--- a/apps/contract-sync-job/src/main.ts
+++ b/apps/contract-sync-job/src/main.ts
@@ -1,3 +1,4 @@
+import fetch from 'node-fetch';
 import { GovrnContract, NetworkConfig } from '@govrn/govrn-contract-client';
 import { GovrnGraphClient } from '@govrn/govrn-subgraph-client';
 import {
@@ -22,6 +23,18 @@ const networkConfig: NetworkConfig = {
 const provider = new ethers.providers.JsonRpcProvider(CHAIN_URL);
 const govrnContract = new GovrnContract(networkConfig, provider);
 
+export const fetchIPFS = async (ipfsHash: string) => {
+  const resp = await fetch(
+    `https://ipfs.infura.io:5001/api/v0/cat?arg=${ipfsHash
+      .split('/')
+      .slice(2)}`,
+    {
+      method: 'post',
+    }
+  );
+  return await resp?.blob();
+};
+
 const getOrInsertUser = async (
   govrn: GovrnProtocol,
   data: { address: string }
@@ -35,9 +48,10 @@ const getOrInsertUser = async (
   });
 
   // Returns the id, if user exists.
-  if (user.length !== 0) {
+  if (user.length === 1) {
     return user[0]?.id;
   }
+  console.dir(data);
 
   // Insert new user into db, if user doesn't exist.
   const newUser = await govrn.user.create({
@@ -97,7 +111,9 @@ const main = async () => {
   console.log(':: Starting to Process Contribution(s)');
 
   const graphQLClient = new GraphQLClient(SUBGRAPH_ENDPOINT);
-  const govrn = new GovrnProtocol(protcolUrl);
+  const govrn = new GovrnProtocol(protcolUrl, null, {
+    Authorization: 'Flutes',
+  });
   const client = new GovrnGraphClient(graphQLClient);
 
   const lastRun = await govrn.jobRun.list({
@@ -118,28 +134,29 @@ const main = async () => {
   );
   const contributions = await Promise.all(
     contributionsEvents.map(
-      // async (event): Promise<ContributionCreateManyInput> => { needs updated type
-      async (event) => {
+      async (event): Promise<ContributionCreateManyInput> => {
         const contr = await govrnContract.contributions({
           tokenId: event.contributionId,
         });
-
-        // console.log(`:: Processing Contribution: ${event.id} => ${contr.name}`);
 
         const userId = await getOrInsertUser(govrn, {
           address: event.address,
         });
 
+        const detailsUri = ethers.utils.toUtf8String(contr.detailsUri);
+        const ipfsBlob = await fetchIPFS(detailsUri);
+        const ipfsText = await ipfsBlob.text();
+        const contributionDetails = JSON.parse(ipfsText);
+
         return {
-          // name: contr.name,
-          detailsUri: contr.detailsUri,
+          name: contributionDetails.name,
           status_id: 2,
           activity_type_id: contributionActivityTypeId,
           user_id: userId,
           date_of_engagement: new Date(contr.dateOfEngagement.toNumber()),
           date_of_submission: new Date(contr.dateOfSubmission.toNumber()),
-          // details: contr.details,
-          // proof: contr.proof,
+          details: contributionDetails.details,
+          proof: contributionDetails.proof,
           on_chain_id: Number(event.id),
         };
       }
@@ -148,7 +165,7 @@ const main = async () => {
 
   const contributionsCount = await govrn.contribution.bulkCreate({
     data: contributions,
-    skipDuplicates: false,
+    skipDuplicates: true,
   });
 
   console.log(`:: Inserting ${contributionsCount} Contribution(s)`);
@@ -187,7 +204,7 @@ const main = async () => {
 
   const attestationsCount = await govrn.attestation.bulkCreate({
     data: attestations,
-    skipDuplicates: false,
+    skipDuplicates: true,
   });
 
   console.log(

--- a/apps/contract-sync-job/src/main.ts
+++ b/apps/contract-sync-job/src/main.ts
@@ -11,6 +11,7 @@ import { GraphQLClient } from 'graphql-request';
 
 const protcolUrl = process.env.PROTOCOL_URL;
 const SUBGRAPH_ENDPOINT = process.env.SUBGRAPH_URL;
+const KEVIN_MALONE_TOKEN = process.env.KEVIN_MALONE_TOKEN;
 const jobName = 'contract-sync-job';
 
 const CONTRACT_ADDRESS = process.env.CONTRACT_ADDRESS;
@@ -112,8 +113,9 @@ const main = async () => {
 
   const graphQLClient = new GraphQLClient(SUBGRAPH_ENDPOINT);
   const govrn = new GovrnProtocol(protcolUrl, null, {
-    Authorization: 'Flutes',
+    Authorization: KEVIN_MALONE_TOKEN,
   });
+  console.dir(KEVIN_MALONE_TOKEN);
   const client = new GovrnGraphClient(graphQLClient);
 
   const lastRun = await govrn.jobRun.list({

--- a/apps/contract-sync-job/src/main.ts
+++ b/apps/contract-sync-job/src/main.ts
@@ -11,7 +11,7 @@ import { GraphQLClient } from 'graphql-request';
 
 const protcolUrl = process.env.PROTOCOL_URL;
 const SUBGRAPH_ENDPOINT = process.env.SUBGRAPH_URL;
-const KEVIN_MALONE_TOKEN = process.env.KEVIN_MALONE_TOKEN;
+const CONTRACT_SYNC_TOKEN = process.env.CONTRACT_SYNC_TOKEN;
 const jobName = 'contract-sync-job';
 
 const CONTRACT_ADDRESS = process.env.CONTRACT_ADDRESS;
@@ -52,7 +52,6 @@ const getOrInsertUser = async (
   if (user.length === 1) {
     return user[0]?.id;
   }
-  console.dir(data);
 
   // Insert new user into db, if user doesn't exist.
   const newUser = await govrn.user.create({
@@ -113,9 +112,8 @@ const main = async () => {
 
   const graphQLClient = new GraphQLClient(SUBGRAPH_ENDPOINT);
   const govrn = new GovrnProtocol(protcolUrl, null, {
-    Authorization: KEVIN_MALONE_TOKEN,
+    Authorization: CONTRACT_SYNC_TOKEN,
   });
-  console.dir(KEVIN_MALONE_TOKEN);
   const client = new GovrnGraphClient(graphQLClient);
 
   const lastRun = await govrn.jobRun.list({

--- a/apps/protocol-api/README.md
+++ b/apps/protocol-api/README.md
@@ -69,6 +69,6 @@ This App is generated using [`@nrwl/node:application`](https://nx.dev/packages/n
 
 [^1]: uses [`@nx-tools/nx-prisma`](https://github.com/nx-tools/nx-tools/tree/main/packages/nx-prisma) builder that provides a wrapper around the Prisma CLI.
 
-[^2]: As example it used at [contract-sync-job](../../apps/contract-sync-job/) app.
+[^2]: As example it used at [contract-sync-job](../../apps/contract-sync-job/) app, check `CONTRACT_SYNC_TOKEN` env.
 
 [tables-diagram]: https://uc23339e6c54300c902cea3be2f9.previews.dropboxusercontent.com/p/thumb/ABkXnXgTK9SVrC4jkheewuGlytV3Am4VVFNfHXzNpqSF5C9vMfA0qKa9Ifn913XUW3xa9DI-3oFRF1wSbkYc-jrCko1PdijKW_YNCvVU8qBIPOJk1uu2IJ8fU-SZ5PeR-TFp0WQd-dDaHXPMDi39Ta7qNXccG9tCXG4ELKh2EQqI8oOzxyxUoLsGANnqiYAlc1x97j0NVnKuvKPXsviWqB-0T1w29bD2iNkCbKU0-maHnPcCNUnBtM5Z1QqeTahG9EVkW-ppBLn1EjnG-rUGlmjOSU7W1neA974wgtEZSBwCTCPIz4_9CUdvdpnSuU04Q5npkhQdFCuJimF7ynIdwmEwChwpe0FjlBuZDBJxFcYHE7m4cBW8shIw-Ce8NoUabAWWETke-efYi2t16vLYkpZMJzSy25YrkTso5LSg4i9Fkg/p.png

--- a/apps/protocol-api/README.md
+++ b/apps/protocol-api/README.md
@@ -64,9 +64,11 @@ This App is generated using [`@nrwl/node:application`](https://nx.dev/packages/n
 
 - `PROTOCOL_COOKIE_SECRET`: [secret](https://github.com/expressjs/cookie-session#secret) A string which will be used as single key. You can use any string, ex: `PROTOCOL_COOKIE_SECRET="truculent Falafel"`
 - `CORS_ORIGIN`: A comma separated list of allowed origins. Locally it would be `localhost:3000`.
-- `KEVIN_MALONE_TOKEN`
+- `KEVIN_MALONE_TOKEN`: Authorization token for GraphQL requests.[^2]
 
 
 [^1]: uses [`@nx-tools/nx-prisma`](https://github.com/nx-tools/nx-tools/tree/main/packages/nx-prisma) builder that provides a wrapper around the Prisma CLI.
+
+[^2]: As example it used at [contract-sync-job](../../apps/contract-sync-job/) app.
 
 [tables-diagram]: https://uc23339e6c54300c902cea3be2f9.previews.dropboxusercontent.com/p/thumb/ABkXnXgTK9SVrC4jkheewuGlytV3Am4VVFNfHXzNpqSF5C9vMfA0qKa9Ifn913XUW3xa9DI-3oFRF1wSbkYc-jrCko1PdijKW_YNCvVU8qBIPOJk1uu2IJ8fU-SZ5PeR-TFp0WQd-dDaHXPMDi39Ta7qNXccG9tCXG4ELKh2EQqI8oOzxyxUoLsGANnqiYAlc1x97j0NVnKuvKPXsviWqB-0T1w29bD2iNkCbKU0-maHnPcCNUnBtM5Z1QqeTahG9EVkW-ppBLn1EjnG-rUGlmjOSU7W1neA974wgtEZSBwCTCPIz4_9CUdvdpnSuU04Q5npkhQdFCuJimF7ynIdwmEwChwpe0FjlBuZDBJxFcYHE7m4cBW8shIw-Ce8NoUabAWWETke-efYi2t16vLYkpZMJzSy25YrkTso5LSg4i9Fkg/p.png

--- a/apps/protocol-api/src/main.ts
+++ b/apps/protocol-api/src/main.ts
@@ -8,7 +8,7 @@ import { generateNonce, SiweErrorType, SiweMessage } from 'siwe';
 
 import { resolvers } from './prisma/generated/type-graphql';
 import { customResolvers } from './prisma/resolvers';
-import { and, deny, or, rule, shield, allow } from 'graphql-shield';
+import { and, deny, or, rule, shield } from 'graphql-shield';
 import { graphqlHTTP } from 'express-graphql';
 import cors = require('cors');
 
@@ -54,25 +54,29 @@ const permissions = shield(
       guild: hasToken,
       listUserByAddress: isAuthenticated,
       users: hasToken,
+      jobRuns: hasToken,
     },
     Mutation: {
       '*': deny,
-      createUserCustom: and(OwnsData, isAuthenticated),
+      createActivityType: hasToken,
+      createContribution: hasToken,
+      createGuild: hasToken,
+      createGuildUser: or(isAuthenticated, hasToken),
+      createJobRun: hasToken,
+      createManyContribution: hasToken,
+      createOnChainUserContribution: isAuthenticated,
+      createUser: or(isAuthenticated, hasToken),
+      createUserActivity: hasToken,
       createUserAttestation: and(OwnsData, isAuthenticated),
       createUserContribution: and(OwnsData, isAuthenticated),
+      createUserCustom: or(hasToken, and(OwnsData, isAuthenticated)),
+      createUserOnChainAttestation: isAuthenticated,
+      updateGuild: hasToken,
+      updateUser: hasToken,
       updateUserContribution: and(OwnsData, isAuthenticated),
       updateUserCustom: and(OwnsData, isAuthenticated),
-      createUser: or(isAuthenticated, hasToken),
-      createGuildUser: or(isAuthenticated, hasToken),
-      createOnChainUserContribution: isAuthenticated,
-      updateUserOnChainContribution: isAuthenticated,
-      createUserOnChainAttestation: isAuthenticated,
       updateUserOnChainAttestation: isAuthenticated,
-      updateUser: hasToken,
-      updateGuild: hasToken,
-      createGuild: hasToken,
-      createContribution: hasToken,
-      createUserActivity: hasToken,
+      updateUserOnChainContribution: isAuthenticated,
     },
     ActivityType: {
       id: or(isAuthenticated, hasToken),
@@ -178,6 +182,17 @@ const permissions = shield(
       id: or(isAuthenticated, hasToken),
       name: or(isAuthenticated, hasToken),
       username: or(isAuthenticated, hasToken),
+    },
+    AffectedRowsOutput: {
+      count: hasToken,
+    },
+    JobRun: {
+      id: hasToken,
+      createdAt: hasToken,
+      updatedAt: hasToken,
+      completedDate: hasToken,
+      startDate: hasToken,
+      name: hasToken,
     },
     User: {
       id: or(isAuthenticated, hasToken),

--- a/libs/protocol-client/src/lib/client/contribution.ts
+++ b/libs/protocol-client/src/lib/client/contribution.ts
@@ -1,7 +1,7 @@
 import { ethers } from 'ethers';
 import { BaseClient } from './base';
-import { Attestation } from './attestation';
 import {
+  BulkCreateContributionMutationVariables,
   CreateContributionMutationVariables,
   ListContributionsQueryVariables,
   UpdateContributionMutationVariables,
@@ -29,9 +29,7 @@ export class Contribution extends BaseClient {
     return contributions.createContribution;
   }
 
-  // public async bulkCreate(args: BulkCreateContributionMutationVariables) {
-  public async bulkCreate(args: any) {
-    // very temporary change to build
+  public async bulkCreate(args: BulkCreateContributionMutationVariables) {
     const mutation = await this.sdk.bulkCreateContribution(args);
     return mutation.createManyContribution.count;
   }

--- a/libs/protocol-client/src/lib/client/user.ts
+++ b/libs/protocol-client/src/lib/client/user.ts
@@ -1,10 +1,11 @@
-import { UserUpdateInput, UserWhereUniqueInput } from '../protocol-types';
-import { BaseClient } from './base';
 import {
-  UserCreateCustomInput,
   ListUsersQueryVariables,
   MutationDeleteGuildUserArgs,
+  UserCreateCustomInput,
+  UserUpdateInput,
+  UserWhereUniqueInput,
 } from '../protocol-types';
+import { BaseClient } from './base';
 import { GraphQLClient } from 'graphql-request';
 
 export class User extends BaseClient {
@@ -31,7 +32,7 @@ export class User extends BaseClient {
   }
 
   public async create(args: UserCreateCustomInput) {
-    console.log(this.sdk);
+    // console.log(this.sdk);
     const contributions = await this.sdk.createUserCustom({ data: args });
     return contributions.createUserCustom;
   }

--- a/libs/protocol-client/src/lib/client/user.ts
+++ b/libs/protocol-client/src/lib/client/user.ts
@@ -32,7 +32,6 @@ export class User extends BaseClient {
   }
 
   public async create(args: UserCreateCustomInput) {
-    // console.log(this.sdk);
     const contributions = await this.sdk.createUserCustom({ data: args });
     return contributions.createUserCustom;
   }


### PR DESCRIPTION
Update Contract Sync Job to use the off-chain ipfs uri to load data like: `name`, `details`& `proof` in order to be inserted in the `Contributions` table.

-----
Related Linear Ticket: [PRO-257](https://linear.app/govrn/issue/PRO-257/drop-tables-before-running-contract-sync-job)