### PR TITLE
feature/delete-attributed-dao

### DIFF
--- a/apps/protocol-api/src/prisma/resolvers/Contribution.ts
+++ b/apps/protocol-api/src/prisma/resolvers/Contribution.ts
@@ -119,7 +119,7 @@ export class UserContributionUpdateInput {
   @TypeGraphQL.Field((_type) => TypeGraphQL.Int)
   contributionId: number;
 
-  @TypeGraphQL.Field((_type) => Number)
+  @TypeGraphQL.Field((_type) => Number, { nullable: true })
   guildId: number;
 
   @TypeGraphQL.Field((_type) => Number, { nullable: true })
@@ -296,11 +296,12 @@ export class ContributionCustomResolver {
     if (res.count !== 1) {
       throw `Wrong number of rows updated ${res.count} updateUserContribution`;
     }
+
     if (args.data.currentGuildId !== undefined) {
 
       await prisma.contribution.update({
         data: {
-          ...(args.data.guildId && {
+          ...(args.data.currentGuildId && {
             guilds: {
               delete: [{
                 guild_id_contribution_id: {
@@ -317,6 +318,7 @@ export class ContributionCustomResolver {
         },
       });
     }
+
     return await prisma.contribution.update({
       data: {
         activity_type: {
@@ -349,7 +351,7 @@ export class ContributionCustomResolver {
             name: args.data.status,
           },
         },
-        ...(args.data.guildId && {
+        ...(args.data.guildId !== null && {
           guilds: {
             create: [
               {

--- a/apps/protocol-frontend/src/components/EditContributionForm.tsx
+++ b/apps/protocol-frontend/src/components/EditContributionForm.tsx
@@ -114,7 +114,6 @@ const EditContributionForm = ({
   const combinedDaoListOptions = [...new Set([...daoReset, ...daoListOptions])];
 
   const updateContributionHandler = async (values: any) => {
-    console.log('values', values);
     updateContribution(contribution, values);
     reset();
   };

--- a/apps/protocol-frontend/src/components/EditContributionForm.tsx
+++ b/apps/protocol-frontend/src/components/EditContributionForm.tsx
@@ -99,20 +99,11 @@ const EditContributionForm = ({
     label: dao.name,
   }));
 
-  const daoReset = [
-    {
-      value: '',
-      label: '',
-    },
-  ];
-
   const combinedDaoListOptions = [
-    ...new Set([...[{ value: null, label: '' }], ...daoListOptions]),
+    ...new Set([...[{ value: null, label: 'No DAO' }], ...daoListOptions]),
   ];
-  console.log('combined', combinedDaoListOptions);
 
   const updateContributionHandler = async (values: any) => {
-    console.log('values', values);
     updateContribution(contribution, values);
     reset();
   };

--- a/apps/protocol-frontend/src/components/EditContributionForm.tsx
+++ b/apps/protocol-frontend/src/components/EditContributionForm.tsx
@@ -80,12 +80,6 @@ const EditContributionForm = ({
     'Design',
     'Other',
   ];
-
-  const daoListOptions = allDaos.map((dao) => ({
-    value: dao.id,
-    label: dao.name,
-  }));
-
   const combinedActivityTypesList = [
     ...new Set([
       ...activityTypesList,
@@ -99,6 +93,23 @@ const EditContributionForm = ({
       label: activity,
     })
   );
+
+  const daoListOptions = allDaos.map((dao) => ({
+    value: dao.id,
+    label: dao.name,
+  }));
+
+  const daoReset = [
+    {
+      value: '',
+      label: '',
+    },
+  ];
+
+  const combinedDaoListOptions = [
+    ...new Set([...[{ value: null, label: '' }], ...daoListOptions]),
+  ];
+  console.log('combined', combinedDaoListOptions);
 
   const updateContributionHandler = async (values: any) => {
     console.log('values', values);
@@ -160,7 +171,7 @@ const EditContributionForm = ({
             console.log('daoId', dao.value);
             setValue('daoId', dao.value);
           }}
-          options={daoListOptions}
+          options={combinedDaoListOptions}
           localForm={localForm}
         />
         <DatePicker

--- a/apps/protocol-frontend/src/components/EditContributionForm.tsx
+++ b/apps/protocol-frontend/src/components/EditContributionForm.tsx
@@ -70,7 +70,12 @@ const EditContributionForm = ({
     setValue('proof', contribution?.proof);
     setValue('engagementDate', new Date(contribution?.date_of_engagement));
     setValue('activityType', contribution?.activity_type.name);
-    setValue('daoId', contribution?.guilds[0]?.guild.id);
+    setValue(
+      'daoId',
+      contribution?.guilds[0]?.guild.id
+        ? contribution?.guilds[0]?.guild.id
+        : daoReset[0].value
+    );
   }, [contribution]);
 
   const activityTypesList = [
@@ -99,11 +104,17 @@ const EditContributionForm = ({
     label: dao.name,
   }));
 
-  const combinedDaoListOptions = [
-    ...new Set([...[{ value: null, label: 'No DAO' }], ...daoListOptions]),
+  const daoReset = [
+    {
+      value: null,
+      label: 'No DAO',
+    },
   ];
 
+  const combinedDaoListOptions = [...new Set([...daoReset, ...daoListOptions])];
+
   const updateContributionHandler = async (values: any) => {
+    console.log('values', values);
     updateContribution(contribution, values);
     reset();
   };
@@ -155,11 +166,14 @@ const EditContributionForm = ({
           label="DAO"
           placeholder="Select a DAO to assocaite this Contribution with."
           defaultValue={{
-            value: contribution?.guilds[0]?.guild.id,
-            label: contribution?.guilds[0]?.guild.name,
+            value: contribution?.guilds[0]?.guild.id
+              ? contribution?.guilds[0]?.guild.id
+              : daoReset[0].value,
+            label: contribution?.guilds[0]?.guild.name
+              ? contribution?.guilds[0]?.guild.name
+              : daoReset[0].label,
           }}
           onChange={(dao) => {
-            console.log('daoId', dao.value);
             setValue('daoId', dao.value);
           }}
           options={combinedDaoListOptions}

--- a/apps/protocol-frontend/src/contexts/UserContext.tsx
+++ b/apps/protocol-frontend/src/contexts/UserContext.tsx
@@ -281,7 +281,6 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
         activityType: values.activityType,
         engagementDate: values.engagementDate,
       });
-      console.log('resp', resp);
       navigate('/contributions');
     } catch (error) {
       console.log(error);
@@ -442,8 +441,9 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
         status: 'staging',
         guildId: values.daoId,
         contributionId: contribution.id,
-        currentGuildId: contribution.guilds[0]?.guild?.id || undefined
+        currentGuildId: contribution.guilds[0]?.guild?.id || undefined,
       });
+      console.log('update response', updateResp);
       getUserActivityTypes();
       getUserContributions();
       toast({

--- a/libs/protocol-client/src/lib/protocol-types.ts
+++ b/libs/protocol-client/src/lib/protocol-types.ts
@@ -12685,7 +12685,7 @@ export type UserContributionUpdateInput = {
   currentGuildId?: InputMaybe<Scalars['Float']>;
   dateOfEngagement: Scalars['DateTime'];
   details: Scalars['String'];
-  guildId: Scalars['Float'];
+  guildId?: InputMaybe<Scalars['Float']>;
   name: Scalars['String'];
   proof: Scalars['String'];
   status: Scalars['String'];


### PR DESCRIPTION
## Linear Issue

https://linear.app/govrn/issue/PRO-265/add-ability-for-a-user-to-removedelete-a-dao-attribution-from-a

## Overview

Users can now delete (unattribute) a selected DAO from the Edit Contribution Modal. 

![dao-delete](https://user-images.githubusercontent.com/9438776/178634512-2a08e996-85ec-4c3b-9cad-91a893581e5d.gif)

If a user chooses "No DAO" as the option (default is the top of the DAOs list) then this clears the associated DAO. The actual value in the database is gone -- the "No DAO" is for UX purposes. It's not actually set as "No DAO" in the db.

I did this with a `null` value coming through in the `guildId` -- a user selecting the "No DAO" option sends a `null` value for `guildId` and then this deletes the value.

Checked with my local Postgres and this deletes from the db. 