### PR TITLE
fix/update-username (PRO-254)

### DIFF
--- a/apps/protocol-frontend/src/components/HomeShell.tsx
+++ b/apps/protocol-frontend/src/components/HomeShell.tsx
@@ -16,7 +16,7 @@ const HomeShell = () => {
     null
   );
 
-  const { userDataByAddress } = useUser();
+  const { userDataByAddress, userData } = useUser();
 
   useEffect(() => {
     if (userDataByAddress) {
@@ -86,7 +86,7 @@ const HomeShell = () => {
                     bgGradient="linear(to-l, #7928CA, #FF0080)"
                     bgClip="text"
                   >
-                    {userDataByAddress?.name}
+                    {userData?.name || userDataByAddress?.name}
                   </Text>
                   . Click below to view your contributions.
                 </Text>

--- a/apps/protocol-frontend/src/contexts/UserContext.tsx
+++ b/apps/protocol-frontend/src/contexts/UserContext.tsx
@@ -96,7 +96,6 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
       return;
     }
     try {
-      console.log(govrn);
       const userDataByAddressResponse = await govrn.custom.listUserByAddress(
         address
       );

--- a/apps/protocol-frontend/src/contexts/UserContext.tsx
+++ b/apps/protocol-frontend/src/contexts/UserContext.tsx
@@ -443,7 +443,6 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
         contributionId: contribution.id,
         currentGuildId: contribution.guilds[0]?.guild?.id || undefined,
       });
-      console.log('update response', updateResp);
       getUserActivityTypes();
       getUserContributions();
       toast({
@@ -474,6 +473,7 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
         name: values.name,
         id: userData.id,
       });
+      getUser();
       toast({
         title: 'User Profile Updated',
         description: 'Your Profile has been updated',


### PR DESCRIPTION
## Linear Issue

- https://linear.app/govrn/issue/PRO-254/bug-update-username-isnt-working

## Overview

This now rehydrates the data with a background refresh similar to our other updates. The profile name was being updated but not updating for the user without a refresh. This now works and also added this to the Home/welcome view if a user navigates back there.

https://user-images.githubusercontent.com/9438776/179537158-af81dd00-5411-4e8b-ad1b-1c4a1efe34f0.mp4


