### PR TITLE
disabled button and input- twitter&Email. Added custom button styles

### DIFF
--- a/apps/protocol-frontend/src/components/ProfileForm.tsx
+++ b/apps/protocol-frontend/src/components/ProfileForm.tsx
@@ -137,7 +137,7 @@ const ProfileForm = () => {
               color="brand.primary.600"
               backgroundColor="brand.primary.50"
               transition="all 100ms ease-in-out"
-              //_hover={{ bgColor: 'brand.primary.100' }}
+              _hover={{ bgColor: 'brand.primary.100' }}
             >
               Save Username
             </Button>

--- a/apps/protocol-frontend/src/components/ProfileForm.tsx
+++ b/apps/protocol-frontend/src/components/ProfileForm.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect } from 'react';
-import { Flex, Heading, Button, Divider } from '@chakra-ui/react';
+import { Flex, Heading, Button, Divider} from '@chakra-ui/react';
 import { Input } from '@govrn/protocol-ui';
 import { useForm } from 'react-hook-form';
 
@@ -137,7 +137,7 @@ const ProfileForm = () => {
               color="brand.primary.600"
               backgroundColor="brand.primary.50"
               transition="all 100ms ease-in-out"
-              _hover={{ bgColor: 'brand.primary.100' }}
+              //_hover={{ bgColor: 'brand.primary.100' }}
             >
               Save Username
             </Button>
@@ -198,16 +198,13 @@ const ProfileForm = () => {
                 tip="Enter the email address you used with Linear for the integration."
                 placeholder="user@govrn.io"
                 localForm={localFormLinear} //TODO: resolve this type issue -- need to investigate this
-                disabled
+                isDisabled
               />
               <Button
                 type="submit"
                 width="100%"
-                color="brand.primary.600"
-                backgroundColor="brand.primary.50"
-                transition="all 100ms ease-in-out"
-                _hover={{ bgColor: 'brand.primary.100' }}
-                disabled
+                variant="disabled"
+                isDisabled
               >
                 Link Email
               </Button>
@@ -228,16 +225,13 @@ const ProfileForm = () => {
                 tip="Enter your Twitter handle for the upcoming Twitter integration."
                 placeholder="govrn"
                 localForm={localForm} //TODO: resolve this type issue -- need to investigate this
-                disabled
+                isDisabled
               />
               <Button
                 type="submit"
                 width="100%"
-                color="brand.primary.600"
-                backgroundColor="brand.primary.50"
-                transition="all 100ms ease-in-out"
-                disabled
-                _hover={{ bgColor: 'brand.primary.100' }}
+                variant="disabled"
+                isDisabled
               >
                 Link Twitter
               </Button>

--- a/libs/protocol-ui/src/theme/components/button.tsx
+++ b/libs/protocol-ui/src/theme/components/button.tsx
@@ -1,0 +1,16 @@
+export default {
+    variants: {
+      disabled: {
+        _disabled: {
+          bgColor: 'gray.300',
+          color: 'gray.800',
+        },
+        _hover: {
+          _disabled: {
+            bgColor: 'gray.300',
+          },
+        },
+      },
+    },
+  };
+  

--- a/libs/protocol-ui/src/theme/index.ts
+++ b/libs/protocol-ui/src/theme/index.ts
@@ -1,4 +1,5 @@
 import colors from './colors';
+import Button from './components/button'
 import Input from './components/input';
 import Checkbox from './components/checkbox';
 import Table from './components/table';
@@ -20,7 +21,7 @@ export const GovrnTheme = extendTheme({
     heading: 'InterVariable, -apple-system, system-ui, sans-serif',
     body: 'InterVariable, -apple-system, system-ui, sans-serif',
   },
-  components: { Input, Checkbox, Table, Tabs, Textarea },
+  components: { Button, Input, Checkbox, Table, Tabs, Textarea },
   config: {
     initialColorMode: 'light',
     useSystemColorMode: false,


### PR DESCRIPTION
Linear Issue: 
     PRO-255 
Issue Link:
     https://linear.app/govrn/issue/PRO-255/on-profile-if-the-integration-isnt-ready-might-be-worth-it-to-grey-out

Description:
     Fixed the following:
          1. Input box: 
                (i)Disabled it (used chakra's 'isDisabled' props)
          2. Button box: 
                (i)  Disabled the button (used chakra's 'isDisabled' props)
                (ii) Created custom styles in "libs/protocol-ui/src /theme/components/button" to override chakra's
                              default hovering effect on the button.

@jonathanprozzi @alexkeating 