### PR TITLE
fix/report-dao-optional (PRO-282)

### DIFF
--- a/apps/protocol-api/src/prisma/resolvers/Contribution.ts
+++ b/apps/protocol-api/src/prisma/resolvers/Contribution.ts
@@ -33,8 +33,8 @@ export class UserContributionCreateInput {
   @TypeGraphQL.Field((_type) => String)
   status: string;
 
-  @TypeGraphQL.Field((_type) => Number)
-  guildId: number;
+  @TypeGraphQL.Field((_type) => Number, { nullable: true })
+  guildId?: number;
 }
 
 @TypeGraphQL.ArgsType()
@@ -181,6 +181,7 @@ export class ContributionCustomResolver {
     @TypeGraphQL.Ctx() { prisma }: Context,
     @TypeGraphQL.Args() args: CreateUserContributionArgs
   ) {
+    console.log('args', args.data)
     return await prisma.contribution.create({
       data: {
         user: {
@@ -222,7 +223,7 @@ export class ContributionCustomResolver {
             },
           },
         },
-        ...(args.data.guildId && {
+        ...(args.data.guildId !== undefined && {
           guilds: {
             create: [
               {

--- a/apps/protocol-api/src/prisma/resolvers/Contribution.ts
+++ b/apps/protocol-api/src/prisma/resolvers/Contribution.ts
@@ -181,7 +181,7 @@ export class ContributionCustomResolver {
     @TypeGraphQL.Ctx() { prisma }: Context,
     @TypeGraphQL.Args() args: CreateUserContributionArgs
   ) {
-    console.log('args', args.data)
+
     return await prisma.contribution.create({
       data: {
         user: {

--- a/apps/protocol-frontend/src/components/EditContributionForm.tsx
+++ b/apps/protocol-frontend/src/components/EditContributionForm.tsx
@@ -62,8 +62,6 @@ const EditContributionForm = ({
     new Date(contribution?.date_of_engagement)
   );
 
-  console.log('contribution', contribution);
-
   useEffect(() => {
     setValue('name', contribution?.name);
     setValue('details', contribution?.details);

--- a/libs/protocol-client/src/lib/protocol-types.ts
+++ b/libs/protocol-client/src/lib/protocol-types.ts
@@ -12670,7 +12670,7 @@ export type UserContributionCreateInput = {
   chainName: Scalars['String'];
   dateOfEngagement: Scalars['DateTime'];
   details: Scalars['String'];
-  guildId: Scalars['Float'];
+  guildId?: InputMaybe<Scalars['Float']>;
   name: Scalars['String'];
   proof: Scalars['String'];
   status: Scalars['String'];


### PR DESCRIPTION
## Linear Issue

- https://linear.app/govrn/issue/PRO-282/bug-report-dao-on-report-form-throws-error-if-not-set-should-be

## Overview

This now allows for the DAO to be optional during the initial ReportForm contribution reporting.