### PR TITLE
fix/filter-out-user-contributions (PRO-250)

### DIFF
--- a/apps/protocol-frontend/src/components/AttestationsTable.tsx
+++ b/apps/protocol-frontend/src/components/AttestationsTable.tsx
@@ -41,7 +41,11 @@ const AttestationsTable = ({
     setModals({ addAttestationFormModal: true });
   };
 
-  const unattestedContributions = _.filter(contributionsData, function (a) {
+  const nonUserContributions = _.filter(contributionsData, function (a) {
+    return a.user.id !== userData.id;
+  });
+
+  const unattestedContributions = _.filter(nonUserContributions, function (a) {
     return a.attestations.every((b: any) => b.user_id !== userData.id);
   });
 
@@ -99,7 +103,7 @@ const AttestationsTable = ({
         Header: 'Contributor',
         accessor: 'contributor',
       },
-      { Header: 'DAO', accessor: 'guild' },
+      // { Header: 'DAO', accessor: 'guild' },
     ],
     []
   );

--- a/apps/protocol-frontend/src/components/AttestationsTable.tsx
+++ b/apps/protocol-frontend/src/components/AttestationsTable.tsx
@@ -12,7 +12,6 @@ import {
   Text,
 } from '@chakra-ui/react';
 import { IoArrowDown, IoArrowUp } from 'react-icons/io5';
-import { FiCheckSquare } from 'react-icons/fi';
 import {
   useTable,
   useSortBy,
@@ -56,17 +55,12 @@ const AttestationsTable = ({
         submissionDate: format(new Date(contribution.date_of_submission), 'P'),
         engagementDate: format(new Date(contribution.date_of_engagement), 'P'),
         attestations: contribution.attestations || null,
-        // attestations:
-        //   contribution.attestations !== null
-        //     ? Object.keys(contribution.attestations).length
-        //     : 0,
         guilds: contribution.attestations || null,
         status: contribution.status.name,
         action: '',
         name: contribution.name,
         attestationDate: null,
         onChainId: contribution.on_chain_id,
-        // format(new Date(contribution.attestationDate), 'P') || null,
         contributor: contribution.user.name,
       })),
     [contributionsData]

--- a/apps/protocol-frontend/src/components/AttestationsTableShell.tsx
+++ b/apps/protocol-frontend/src/components/AttestationsTableShell.tsx
@@ -21,7 +21,7 @@ import { ModalWrapper } from '@govrn/protocol-ui';
 import BulkAttestationModal from './BulkAttestationModal';
 
 const AttestationsTableShell = () => {
-  const { daoContributions } = useUser();
+  const { daoContributions, userData } = useUser();
   const localOverlay = useOverlay();
   const { setModals } = useOverlay();
   const [selectedContributions, setSelectedContributions] = useState<any>();

--- a/apps/protocol-frontend/src/components/MyAttestationsTable.tsx
+++ b/apps/protocol-frontend/src/components/MyAttestationsTable.tsx
@@ -88,7 +88,7 @@ any) => {
         Header: 'Contributor',
         accessor: 'contributor',
       },
-      { Header: 'DAO', accessor: 'guild' },
+      // { Header: 'DAO', accessor: 'guild' },
     ],
     []
   );


### PR DESCRIPTION
## Linear Issue

- https://linear.app/govrn/issue/PRO-250/should-i-see-my-own-contributions-in-my-attestation-feed

## Overview

This filters out the user's Contributions from their Attestation Feed to reduce noise. We can consider other UX around this such as adding in a toggle or additional tab to cover the usecases when a user may want to see this.

Before:

![attestations-feed-before-filter](https://user-images.githubusercontent.com/9438776/179617233-7c158d5c-4b1f-4476-b3de-b66098ea8720.gif)

After:
![attestations-feed-after-filter](https://user-images.githubusercontent.com/9438776/179617259-82a95d6c-c556-4655-8ade-320e90a0638b.gif)

