### PR TITLE
Better warning message indicating we can't edit a minted contribution(PRO-249)

### DIFF
--- a/apps/protocol-frontend/src/components/ContributionsTable.tsx
+++ b/apps/protocol-frontend/src/components/ContributionsTable.tsx
@@ -10,6 +10,7 @@ import {
   Thead,
   Tr,
   chakra,
+  Tooltip
 } from '@chakra-ui/react';
 import { useUser } from '../contexts/UserContext';
 import { format } from 'date-fns';
@@ -128,7 +129,34 @@ const ContributionsTable = ({
         id: 'actions',
         Header: 'Actions',
         Cell: ({ row }) => (
-          <HStack spacing="1">
+          row.original.status ===  'minted' ?
+            (<Tooltip label='Minted contribution(s) cannot be edited' aria-label='A tooltip'>
+            <HStack spacing="1">
+              <IconButton
+                icon={<FiEdit2 fontSize="1rem" />}
+                variant="ghost"
+                color="gray.800"
+                aria-label="Edit Contribution"
+                disabled={
+                  row.original.user.id !== userData?.user ||
+                  row.original.status === 'minted'
+                }
+                onClick={() => handleEditContributionFormModal(row.original.id)}
+              />
+              <IconButton
+                icon={<FiTrash2 fontSize="1rem" />}
+                variant="ghost"
+                color="gray.800"
+                disabled={
+                  row.original.user.id !== userData?.user ||
+                  row.original.status === 'minted'
+                }
+                aria-label="Delete Contribution"
+              />
+            </HStack>
+            </Tooltip>) 
+            :
+            <HStack spacing="1">
             <IconButton
               icon={<FiEdit2 fontSize="1rem" />}
               variant="ghost"
@@ -150,6 +178,7 @@ const ContributionsTable = ({
               }
               aria-label="Delete Contribution"
             />
+      
           </HStack>
         ),
       },


### PR DESCRIPTION
Linear Issue:
PRO-249

Issue Link:
https://linear.app/govrn/issue/PRO-249/better-warning-message-that-we-cant-edit-a-minted-contribution

Description:
What happens if you click on/hover the 'Actions' (edit/delete) icons in the Contributions table if the Contribution's status
is 'staged'? What if the Contribution status is 'minted'?
Utilized: Chakra's ToolTip.

Logic:  
       IF status == 'minted', then display 'cannot edit minted contribution' :  Else, let edit/delete icons do their jobs.

@jonathanprozzi  @alexkeating 