### PR TITLE
fix/supported-networks-ux (PRO-244, PRO-245)

### DIFF
--- a/apps/protocol-frontend/src/components/ConnectWallet.tsx
+++ b/apps/protocol-frontend/src/components/ConnectWallet.tsx
@@ -15,9 +15,15 @@ import { FiKey, FiChevronDown, FiCopy, FiXCircle } from 'react-icons/fi';
 import { useUser } from '../contexts/UserContext';
 
 const ConnectWallet = () => {
-  const { connectWallet, isConnecting, isConnected, disconnect, address } =
-    useWallet();
-  const { authenticateAddress } = useUser();
+  const {
+    connectWallet,
+    isConnecting,
+    isConnected,
+    switchNetwork,
+    disconnect,
+    address,
+  } = useWallet();
+  const { authenticateAddress, currentChain } = useUser();
   const copyAddress = useClipboard(address as string);
   const connectAndVerify = async () => {
     await connectWallet();

--- a/apps/protocol-frontend/src/components/HomeShell.tsx
+++ b/apps/protocol-frontend/src/components/HomeShell.tsx
@@ -172,7 +172,7 @@ const HomeShell = () => {
         ) : (
           <>
             <Text color="gray.800" paddingBottom={8}>
-              To get started, connect your wallet.
+              To get started, connect your wallet to Gnosis Chain.
             </Text>
             <ConnectWallet />
           </>

--- a/apps/protocol-frontend/src/contexts/UserContext.tsx
+++ b/apps/protocol-frontend/src/contexts/UserContext.tsx
@@ -31,6 +31,9 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
   const govrn = new GovrnProtocol(protocolUrl, { credentials: 'include' });
   const { setModals } = useOverlay();
 
+  const [currentChain, setCurrentChain] = useState<string | null | undefined>(
+    undefined
+  );
   const [userAddress, setUserAddress] = useState<any>(null);
   const [userDataByAddress, setUserDataByAddress] = useState<any>(null);
   const [userData, setUserData] = useState<any>(null);
@@ -45,6 +48,25 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
   useEffect(() => {
     setUserAddress(address);
   }, [isConnected, address, userAddress]);
+
+  useEffect(() => {
+    // if (isConnected) {
+    console.log('chainId change');
+    console.log('chainid', chainId);
+    // setCurrentChain(chainId);
+    if (chainId && chainId !== '0x64') {
+      console.log('toast');
+      toast({
+        title: 'Unsupported Chain',
+        description: `Please switch to a supported network.`,
+        status: 'error',
+        duration: 6000,
+        isClosable: true,
+        position: 'top-right',
+      });
+      // }
+    }
+  }, [isConnected, chainId]);
 
   const authenticateAddress = useCallback(async () => {
     if (!chainId || !provider) {
@@ -620,6 +642,8 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
 
 export const useUser = () => {
   const {
+    currentChain,
+    setCurrentChain,
     userAddress,
     setUserAddress,
     userDataByAddress,
@@ -645,12 +669,13 @@ export const useUser = () => {
     updateContribution,
     updateProfile,
     updateLinearEmail,
-
     isAuthenticated,
     isAuthenticating,
     authenticateAddress,
   } = useContext(UserContext);
   return {
+    currentChain,
+    setCurrentChain,
     userAddress,
     setUserAddress,
     userDataByAddress,

--- a/apps/protocol-frontend/src/contexts/UserContext.tsx
+++ b/apps/protocol-frontend/src/contexts/UserContext.tsx
@@ -4,6 +4,7 @@ import React, {
   useContext,
   createContext,
   useEffect,
+  useMemo,
   useState,
 } from 'react';
 import { useToast } from '@chakra-ui/react';
@@ -48,25 +49,6 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
   useEffect(() => {
     setUserAddress(address);
   }, [isConnected, address, userAddress]);
-
-  useEffect(() => {
-    // if (isConnected) {
-    console.log('chainId change');
-    console.log('chainid', chainId);
-    // setCurrentChain(chainId);
-    if (chainId && chainId !== '0x64') {
-      console.log('toast');
-      toast({
-        title: 'Unsupported Chain',
-        description: `Please switch to a supported network.`,
-        status: 'error',
-        duration: 6000,
-        isClosable: true,
-        position: 'top-right',
-      });
-      // }
-    }
-  }, [isConnected, chainId]);
 
   const authenticateAddress = useCallback(async () => {
     if (!chainId || !provider) {

--- a/apps/protocol-frontend/src/main.tsx
+++ b/apps/protocol-frontend/src/main.tsx
@@ -45,16 +45,16 @@ const App = () => {
         networks={networks}
         handleModalEvents={(eventName, error) => {
           if (error) {
-            console.error(error.message);
             toast({
               title: 'Unsupported Chain',
-              description: `Please switch to a supported chain (Gnosis Chain). You can switch chains by approving the "Switch network" in MetaMask.`,
+              description: `Please switch to a supported chain (Gnosis Chain). You can switch chains by clicking the "Switch network" button in MetaMask.`,
               status: 'error',
               duration: 3000,
               isClosable: true,
               position: 'top-right',
             });
           }
+          console.log(eventName);
         }}
       >
         <UserContextProvider>

--- a/apps/protocol-frontend/src/main.tsx
+++ b/apps/protocol-frontend/src/main.tsx
@@ -7,7 +7,7 @@ import WalletConnectProvider from '@walletconnect/ethereum-provider';
 import { IProviderOptions } from 'web3modal';
 import { networks } from '../src/utils/networks';
 import { ChakraProvider, useToast } from '@chakra-ui/react';
-import { OverlayContextProvider } from './contexts/OverlayContext';
+import { OverlayContextProvider, useOverlay } from './contexts/OverlayContext';
 
 import { GovrnTheme } from '@govrn/protocol-ui';
 import Routes from './Routes';
@@ -27,32 +27,50 @@ const providerOptions: IProviderOptions = {
   },
 };
 
+const defaultChain = networks['0x64'].chainId; // we can move this and some others to a constants file
+
 const web3modalOptions = {
   cacheProvider: true,
   providerOptions,
   theme: 'dark',
 };
 
-ReactDOM.render(
-  <StrictMode>
-    <ChakraProvider theme={GovrnTheme}>
+const App = () => {
+  const toast = useToast();
+  return (
+    <>
       <WalletProvider
         web3modalOptions={web3modalOptions}
-        // defaultChainId={networks['0x64'].chainId}
+        defaultChainId={defaultChain}
         networks={networks}
         handleModalEvents={(eventName, error) => {
           if (error) {
             console.error(error.message);
+            toast({
+              title: 'Unsupported Chain',
+              description: `Please switch to a supported chain (Gnosis Chain). You can switch chains by approving the "Switch network" in MetaMask.`,
+              status: 'error',
+              duration: 3000,
+              isClosable: true,
+              position: 'top-right',
+            });
           }
-          console.log(eventName);
         }}
       >
-        <OverlayContextProvider>
-          <UserContextProvider>
-            <Routes />
-          </UserContextProvider>
-        </OverlayContextProvider>
+        <UserContextProvider>
+          <Routes />
+        </UserContextProvider>
       </WalletProvider>
+    </>
+  );
+};
+
+ReactDOM.render(
+  <StrictMode>
+    <ChakraProvider theme={GovrnTheme}>
+      <OverlayContextProvider>
+        <App />
+      </OverlayContextProvider>
     </ChakraProvider>
   </StrictMode>,
   document.getElementById('root')

--- a/apps/protocol-frontend/src/main.tsx
+++ b/apps/protocol-frontend/src/main.tsx
@@ -6,7 +6,7 @@ import WalletConnectProvider from '@walletconnect/ethereum-provider';
 
 import { IProviderOptions } from 'web3modal';
 import { networks } from '../src/utils/networks';
-import { ChakraProvider } from '@chakra-ui/react';
+import { ChakraProvider, useToast } from '@chakra-ui/react';
 import { OverlayContextProvider } from './contexts/OverlayContext';
 
 import { GovrnTheme } from '@govrn/protocol-ui';
@@ -38,8 +38,8 @@ ReactDOM.render(
     <ChakraProvider theme={GovrnTheme}>
       <WalletProvider
         web3modalOptions={web3modalOptions}
+        // defaultChainId={networks['0x64'].chainId}
         networks={networks}
-        // Optional but useful to handle events.
         handleModalEvents={(eventName, error) => {
           if (error) {
             console.error(error.message);


### PR DESCRIPTION
## Linear Tickets

- https://linear.app/govrn/issue/PRO-244/give-a-toast-with-the-supported-networks
- https://linear.app/govrn/issue/PRO-245/give-a-toast-with-the-supported-networks

## Description

This adds the `defaultNetwork` (Gnosis Chain) to our provider, so it'll use MetaMask to prompt the user to change when they're on an unsupported chain. It'll also display a toast informing the user about this.

A few things to consider:

- This'll be a good tradeoff for now since we're only supporting GC, but when we want to use multiple networks we'll want to handle the switching with a different UX pattern
- The autoswitch works for MetaMask -- we have another ticket to fix our WalletConnect anyway so we'll want to check any additional implications when we do that
- Having the user switch to GC seems to be the best option for now so that we won't have any unexpected behavior when folks can't use the app

## Screencaptures

https://user-images.githubusercontent.com/9438776/179852330-b3f36c22-249f-4c90-bcd2-2a387ecbe1ee.mp4
