### PR TITLE
Fix WalletConnect bug: Buffer is not defined

### DIFF
--- a/apps/protocol-frontend/index.html
+++ b/apps/protocol-frontend/index.html
@@ -2,13 +2,13 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/src/assets/favicon.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link href="/src/assets/favicon.png" rel="icon" type="image/svg+xml" />
+    <meta content="width=device-width, initial-scale=1.0" name="viewport" />
     <title>Govrn</title>
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script src="/src/main.tsx" type="module"></script>
     <script>
       window.global = window;
     </script>

--- a/apps/protocol-frontend/src/main.tsx
+++ b/apps/protocol-frontend/src/main.tsx
@@ -2,12 +2,12 @@ import { StrictMode } from 'react';
 import * as ReactDOM from 'react-dom';
 import 'regenerator-runtime/runtime';
 import { WalletProvider } from '@raidguild/quiver';
-import WalletConnectProvider from '@walletconnect/ethereum-provider';
+import WalletConnectProvider from '@walletconnect/web3-provider/dist/umd/index.min.js';
 
 import { IProviderOptions } from 'web3modal';
 import { networks } from '../src/utils/networks';
 import { ChakraProvider, useToast } from '@chakra-ui/react';
-import { OverlayContextProvider, useOverlay } from './contexts/OverlayContext';
+import { OverlayContextProvider } from './contexts/OverlayContext';
 
 import { GovrnTheme } from '@govrn/protocol-ui';
 import Routes from './Routes';
@@ -38,30 +38,28 @@ const web3modalOptions = {
 const App = () => {
   const toast = useToast();
   return (
-    <>
-      <WalletProvider
-        web3modalOptions={web3modalOptions}
-        defaultChainId={defaultChain}
-        networks={networks}
-        handleModalEvents={(eventName, error) => {
-          if (error) {
-            toast({
-              title: 'Unsupported Chain',
-              description: `Please switch to a supported chain (Gnosis Chain). You can switch chains by clicking the "Switch network" button in MetaMask.`,
-              status: 'error',
-              duration: 3000,
-              isClosable: true,
-              position: 'top-right',
-            });
-          }
-          console.log(eventName);
-        }}
-      >
-        <UserContextProvider>
-          <Routes />
-        </UserContextProvider>
-      </WalletProvider>
-    </>
+    <WalletProvider
+      web3modalOptions={web3modalOptions}
+      defaultChainId={defaultChain}
+      networks={networks}
+      handleModalEvents={(eventName, error) => {
+        if (error) {
+          toast({
+            title: 'Unsupported Chain',
+            description: `Please switch to a supported chain (Gnosis Chain). You can switch chains by clicking the "Switch network" button in MetaMask.`,
+            status: 'error',
+            duration: 3000,
+            isClosable: true,
+            position: 'top-right',
+          });
+        }
+        console.log(eventName);
+      }}
+    >
+      <UserContextProvider>
+        <Routes />
+      </UserContextProvider>
+    </WalletProvider>
   );
 };
 

--- a/apps/protocol-frontend/src/types/walletconnect-provider.d.ts
+++ b/apps/protocol-frontend/src/types/walletconnect-provider.d.ts
@@ -1,0 +1,4 @@
+declare module '@walletconnect/web3-provider/dist/umd/index.min.js' {
+  import WalletConnectProvider from '@walletconnect/web3-provider/dist/esm/index';
+  export default WalletConnectProvider;
+}


### PR DESCRIPTION
## Linear Ticket
[PRO-283 - Walletconnect bug](https://linear.app/govrn/issue/PRO-283/walletconnect-bug)

## Description
WalletConnect couldn't operate because buffer is not defined, throwing the following error:
```
ReferenceError: Buffer is not defined
    typedarrayToBuffer index.js:15
    arrayToBuffer index.ts:43
    generateKey index.ts:14
    _generateKey index.ts:1161
    createSession index.ts:464
    create index.ts:172
    open index.ts:77
    open index.ts:68
    open provider.ts:113
    connect provider.ts:30
    connect index.ts:81
    request index.ts:47
    enable index.ts:75
    default walletconnect.ts:43
    o3 tslib.es6.js:102
    o3 tslib.es6.js:83
    l tslib.es6.js:76
    l tslib.es6.js:72
    default walletconnect.ts:16
    default walletconnect.ts:16
    c2 providers.ts:204
    o3 tslib.es6.js:102
    o3 tslib.es6.js:83
    l tslib.es6.js:76
    l tslib.es6.js:72
    connectTo providers.ts:197
    onClick providers.ts:161
    React 12
    unstable_runWithPriority scheduler.production.min.js:19
    React 3
WalletContext.tsx:185:14
``` 


