### PR TITLE
This is required- activityType

### DIFF
--- a/apps/protocol-frontend/src/contexts/UserContext.tsx
+++ b/apps/protocol-frontend/src/contexts/UserContext.tsx
@@ -270,6 +270,7 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
         isClosable: true,
         position: 'top-right',
       });
+      console.log(values);
       getUserActivityTypes();
       getUserContributions();
       getDaoContributions();

--- a/apps/protocol-frontend/src/contexts/UserContext.tsx
+++ b/apps/protocol-frontend/src/contexts/UserContext.tsx
@@ -270,7 +270,6 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
         isClosable: true,
         position: 'top-right',
       });
-      console.log(values);
       getUserActivityTypes();
       getUserContributions();
       getDaoContributions();

--- a/apps/protocol-frontend/src/utils/validations.ts
+++ b/apps/protocol-frontend/src/utils/validations.ts
@@ -46,7 +46,7 @@ export const editContributionFormValidation = yup.object({
 export const reportFormValidation = yup.object({
   name: yup.string().required('This field is required.'),
   engagementDate: yup.date(),
-  activityType: yup.string().min(1).required('This field is required.'),
+  activityType: yup.string().required('This field is required.'),
 });
 
 export const addAttestationFormValidation = yup.object({

--- a/apps/protocol-frontend/src/utils/validations.ts
+++ b/apps/protocol-frontend/src/utils/validations.ts
@@ -46,6 +46,7 @@ export const editContributionFormValidation = yup.object({
 export const reportFormValidation = yup.object({
   name: yup.string().required('This field is required.'),
   engagementDate: yup.date(),
+  activityType: yup.string().min(1).required('This field is required.'),
 });
 
 export const addAttestationFormValidation = yup.object({


### PR DESCRIPTION

**PRO-241: Activity Type select throws an error**

### LINK: https://linear.app/govrn/issue/PRO-241/activity-type-select-throws-an-error

## Description
Added 'activityType' field in yup's validation schema (in protocolfrontend/src/utils/validation.ts).
Achieved goal - no longer throws an error on submit when Activity Type field is empty. Instead, message 'This is required'
                           shows below the input box.
**TBD:**     pair up with @jonathanprozzi to add remaining  functions


## Screencaptures

**Before:**  Message below was being displayed

<img width="918" alt="Screen Shot 2022-07-20 at 5 07 18 PM" src="https://user-images.githubusercontent.com/84946242/180103073-8eb921d2-f6d6-4536-914a-05afde973565.png">


**After:** The message is more User friendly

<img width="656" alt="Screen Shot 2022-07-20 at 3 54 20 PM" src="https://user-images.githubusercontent.com/84946242/180102793-d4ecfd1b-7a02-4465-b3fb-cb065dc5d8bb.png">

Before/after screenshots may be helpful when relevant.
