### PR TITLE
fix/refine-report-validation (PRO-247)

### DIFF
--- a/apps/protocol-frontend/src/utils/validations.ts
+++ b/apps/protocol-frontend/src/utils/validations.ts
@@ -46,6 +46,10 @@ export const editContributionFormValidation = yup.object({
 export const reportFormValidation = yup.object({
   name: yup.string().required('This field is required.'),
   engagementDate: yup.date(),
+  activityType: yup.object().shape({
+    label: yup.string().required('Activity Type is required.'),
+    value: yup.string().required('Activity Type is required.'),
+  })
 });
 
 export const addAttestationFormValidation = yup.object({

--- a/apps/protocol-frontend/src/utils/validations.ts
+++ b/apps/protocol-frontend/src/utils/validations.ts
@@ -44,12 +44,9 @@ export const editContributionFormValidation = yup.object({
 });
 
 export const reportFormValidation = yup.object({
-  name: yup.string().required('This field is required.'),
-  engagementDate: yup.date(),
-  activityType: yup.object().shape({
-    label: yup.string().required('Activity Type is required.'),
-    value: yup.string().required('Activity Type is required.'),
-  })
+  name: yup.string().required('Contribution Name is required.'),
+  engagementDate: yup.date().required('Engagement Date is required.'),
+  activityType: yup.string().nullable().required('Activity Type is required.'),
 });
 
 export const addAttestationFormValidation = yup.object({

--- a/libs/protocol-ui/src/components/atoms/ErrorMessage/ErrorMessage.tsx
+++ b/libs/protocol-ui/src/components/atoms/ErrorMessage/ErrorMessage.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { FormErrorMessage as ChakraFormErrorMessage } from '@chakra-ui/react';
 
 export interface ErrorMessageProps {
-  errorMessage: string;
+  errorMessage: string | undefined;
 }
 
 const ErrorMessage: React.FC<ErrorMessageProps> = ({ errorMessage }) => (


### PR DESCRIPTION
## Linear Ticket

- https://linear.app/govrn/issue/PRO-247/if-you-hit-enter-before-the-required-fields-are-filled-out-the-warning

## Description

This refines our validation and updates the error messages a bit. Required fields now match the backend. This will have overlap/conflict with #103 since they are similar. We can merge that one in and then resolve the conflicts on this PR (or i can rebase and update).

This resolves the issue outlined in PRO-247 by making sure that the API is getting the proper required fields, and also simplifies the activityType validation and added the nullable() since it's an object that may not be set yet. This is likely unnecessary because the value being sent to validation uses the `activityType.value` which would always exist. This is more of a safeguard incase the value isn't properly set. We may be able to remove this though but this validation now works and covers all bases with the activity types. We'll test in staging and make sure that it's working well with the migrated data.
