### PR TITLE
Pro-266: Surface DAO name on contribution table

### DIFF
--- a/apps/protocol-frontend/src/components/ContributionsTable.tsx
+++ b/apps/protocol-frontend/src/components/ContributionsTable.tsx
@@ -59,12 +59,26 @@ const ContributionsTable = ({
         activityTypeId: contribution.activity_type.id,
         status: contribution.status.name,
         action: '',
+        guildName: !contribution.guilds.map((guildObj: any) => guildObj.guild.name)[0]? '---' : contribution.guilds.map((guildObj: any) => guildObj.guild.name)[0]
+
       })),
     [contributionsData]
   );
-
+ 
   const columns = useMemo(
     () => [
+      {
+        Header: 'DAO',
+        accessor: 'guildName',
+        Cell: ({ value }) => {
+          return (
+            // <Stack direction="row">
+            //   <Checkbox size="lg" />
+            <Text>{value}</Text>
+            // </Stack>
+          );
+        },
+      },
       {
         Header: 'Name',
         accessor: 'name',

--- a/apps/protocol-frontend/src/components/ContributionsTable.tsx
+++ b/apps/protocol-frontend/src/components/ContributionsTable.tsx
@@ -59,7 +59,7 @@ const ContributionsTable = ({
         activityTypeId: contribution.activity_type.id,
         status: contribution.status.name,
         action: '',
-        guildName: !contribution.guilds.map((guildObj: any) => guildObj.guild.name)[0]? '---' : contribution.guilds.map((guildObj: any) => guildObj.guild.name)[0]
+        guildName: contribution.guilds.map((guildObj: any) => guildObj.guild.name)[0]?? '---' ,
 
       })),
     [contributionsData]
@@ -67,18 +67,7 @@ const ContributionsTable = ({
  
   const columns = useMemo(
     () => [
-      {
-        Header: 'DAO',
-        accessor: 'guildName',
-        Cell: ({ value }) => {
-          return (
-            // <Stack direction="row">
-            //   <Checkbox size="lg" />
-            <Text>{value}</Text>
-            // </Stack>
-          );
-        },
-      },
+   
       {
         Header: 'Name',
         accessor: 'name',
@@ -117,6 +106,19 @@ const ContributionsTable = ({
         accessor: 'attestations',
         Cell: ({ value }) => {
           return <Text textTransform="capitalize">{value.length} </Text>;
+        },
+      },
+
+      {
+        Header: 'DAO',
+        accessor: 'guildName',
+        Cell: ({ value }) => {
+          return (
+            // <Stack direction="row">
+            //   <Checkbox size="lg" />
+            <Text>{value}</Text>
+            // </Stack>
+          );
         },
       },
     ],

--- a/apps/protocol-frontend/src/components/ContributionsTable.tsx
+++ b/apps/protocol-frontend/src/components/ContributionsTable.tsx
@@ -73,10 +73,7 @@ const ContributionsTable = ({
         accessor: 'name',
         Cell: ({ value }) => {
           return (
-            // <Stack direction="row">
-            //   <Checkbox size="lg" />
             <Text>{value}</Text>
-            // </Stack>
           );
         },
       },
@@ -114,10 +111,7 @@ const ContributionsTable = ({
         accessor: 'guildName',
         Cell: ({ value }) => {
           return (
-            // <Stack direction="row">
-            //   <Checkbox size="lg" />
             <Text>{value}</Text>
-            // </Stack>
           );
         },
       },


### PR DESCRIPTION
## Linear Ticket
https://linear.app/govrn/issue/PRO-266/surface-dao-name-on-the-contributions-feeds

## Description
-  Added a column(index=0) "DAO" on the contributions table
   Question/Doubt: Since this is a contribution table, does it look weird to have DAO at Column 0? 
                                Then looking at the sequence of the column headings from column 0 -> 1, reading "DAO" then "Name"
                                 may sound confusing to a user. I propose having the contribution name come first then followed by DAO.
                                 What do you think @jonathanprozzi @alexkeating @amrro . 

- Extracted guild name (DAO name) from contribution Data,  then passed the DAO name to its respective contribution

## Screencaptures
<img width="1154" alt="Screen Shot 2022-07-23 at 11 19 41 PM" src="https://user-images.githubusercontent.com/84946242/180635212-cf4819e4-96d9-484c-9431-09145b32d330.png">

