### PR TITLE
updates the protocol-frontend README to include the new env vars

### DIFF
--- a/apps/protocol-frontend/README.md
+++ b/apps/protocol-frontend/README.md
@@ -51,8 +51,13 @@ Create a `.env` file in the root directory of the package. Be sure to not put th
 
 The following environment variables are required:
 
-- `VITE_PROTOCOL_URL`: e.g. http://localhost:4000/graphql
-- `VITE_PROTOCOL_BASE_URL`: e.g. http://localhost:4000/
+- `VITE_PROTOCOL_URL`: e.g. http://localhost:4000/graphql for local development
+- `VITE_PROTOCOL_BASE_URL`: e.g. http://localhost:4000/ for local development
+- `VITE_LINEAR_REDIRECT_URI`: e.g. http://localhost:4000/linear/oauth for local development
+  - The redirect URI used by the frontend when authenticating a user via oauth.
+- `VITE_LINEAR_CLIENT_ID`: The client ID of our Linear app
+
+The Linear specific environment variables are also used in the `protocol-api` `.env` file, but the frontend ones need to be prefixed with `VITE_`. If you're having issues with the Linear integration, check that these variables are set properly.
 
 These assume that you're running the `protocol-api` locally on port 4000. If you are not, you'll not be able to fully interact with the frontend for local develpment.s
 


### PR DESCRIPTION
## Linear Ticket

n/a

## Description

- Adds the new `VITE_LINEAR_` items to the env section of the frontend README so folks know that these are also needed for the Linear integration
