### PR TITLE
Add Burn Contribution Method

### DIFF
--- a/apps/protocol-api/src/main.ts
+++ b/apps/protocol-api/src/main.ts
@@ -55,6 +55,7 @@ const permissions = shield(
   {
     Query: {
       '*': deny,
+      contribution: or(isAuthenticated, hasToken),
       contributions: or(isAuthenticated, hasToken),
       activityTypes: or(isAuthenticated, hasToken),
       attestations: isAuthenticated,
@@ -80,6 +81,7 @@ const permissions = shield(
       createUserContribution: and(OwnsData, isAuthenticated),
       createUserCustom: or(hasToken, and(OwnsData, isAuthenticated)),
       createUserOnChainAttestation: isAuthenticated,
+      deleteContribution: or(OwnsData, isAuthenticated),
       updateGuild: hasToken,
       updateUser: hasToken,
       updateUserContribution: and(OwnsData, isAuthenticated),

--- a/apps/protocol-api/src/prisma/migrations/20220727185452_/migration.sql
+++ b/apps/protocol-api/src/prisma/migrations/20220727185452_/migration.sql
@@ -1,0 +1,17 @@
+-- DropForeignKey
+ALTER TABLE "Attestation" DROP CONSTRAINT "Attestation_contribution_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "GuildContribution" DROP CONSTRAINT "GuildContribution_contribution_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Partner" DROP CONSTRAINT "Partner_contribution_id_fkey";
+
+-- AddForeignKey
+ALTER TABLE "GuildContribution" ADD CONSTRAINT "GuildContribution_contribution_id_fkey" FOREIGN KEY ("contribution_id") REFERENCES "Contribution"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Partner" ADD CONSTRAINT "Partner_contribution_id_fkey" FOREIGN KEY ("contribution_id") REFERENCES "Contribution"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Attestation" ADD CONSTRAINT "Attestation_contribution_id_fkey" FOREIGN KEY ("contribution_id") REFERENCES "Contribution"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/protocol-api/src/prisma/resolvers/Contribution.ts
+++ b/apps/protocol-api/src/prisma/resolvers/Contribution.ts
@@ -174,12 +174,28 @@ export class UpdateUserOnChainContributionArgs {
   data!: UserOnChainContributionUpdateInput;
 }
 
+@TypeGraphQL.InputType('UserContributionDeleteInput', {
+  isAbstract: true,
+})
+export class UserContributionDeleteInput {
+  @TypeGraphQL.Field((_type) => TypeGraphQL.Int)
+  contributionId: number;
+}
+
+@TypeGraphQL.ArgsType()
+export class DeleteUserContributionArgs {
+  @TypeGraphQL.Field((_type) => UserContributionDeleteInput, {
+    nullable: false,
+  })
+  where!: UserContributionDeleteInput;
+}
+
 @TypeGraphQL.Resolver((_of) => Contribution)
 export class ContributionCustomResolver {
   @TypeGraphQL.Mutation((_returns) => Contribution, { nullable: false })
   async createUserContribution(
     @TypeGraphQL.Ctx() { prisma }: Context,
-    @TypeGraphQL.Args() args: CreateUserContributionArgs
+    @TypeGraphQL.Args() args: CreateUserContributionArgs,
   ) {
     return await prisma.contribution.create({
       data: {
@@ -238,10 +254,11 @@ export class ContributionCustomResolver {
       },
     });
   }
+
   @TypeGraphQL.Mutation((_returns) => Contribution, { nullable: false })
   async createOnChainUserContribution(
     @TypeGraphQL.Ctx() { prisma }: Context,
-    @TypeGraphQL.Args() args: CreateUserOnChainContributionArgs
+    @TypeGraphQL.Args() args: CreateUserOnChainContributionArgs,
   ) {
     return await prisma.contribution.create({
       data: {
@@ -266,7 +283,7 @@ export class ContributionCustomResolver {
   @TypeGraphQL.Mutation((_returns) => Contribution, { nullable: false })
   async updateUserContribution(
     @TypeGraphQL.Ctx() { prisma, req }: Context,
-    @TypeGraphQL.Args() args: UpdateUserContributionArgs
+    @TypeGraphQL.Args() args: UpdateUserContributionArgs,
   ) {
     const address = req.session.siwe.data.address;
     const res = await prisma.contribution.updateMany({
@@ -374,7 +391,7 @@ export class ContributionCustomResolver {
   @TypeGraphQL.Mutation((_returns) => Contribution, { nullable: false })
   async updateUserOnChainContribution(
     @TypeGraphQL.Ctx() { prisma, req }: Context,
-    @TypeGraphQL.Args() args: UpdateUserOnChainContributionArgs
+    @TypeGraphQL.Args() args: UpdateUserOnChainContributionArgs,
   ) {
     const address = req.session.siwe.data.address;
     const update = await prisma.contribution.updateMany({
@@ -421,6 +438,34 @@ export class ContributionCustomResolver {
       where: {
         id: args.data.id,
       },
+    });
+  }
+
+  @TypeGraphQL.Mutation((_returns) => Contribution, { nullable: false })
+  async deleteUserContribution(
+    @TypeGraphQL.Ctx() { prisma, req }: Context,
+    @TypeGraphQL.Args() args: DeleteUserContributionArgs,
+  ) {
+    const contributionId = args.where.contributionId;
+    const address = req.session.siwe.data.address;
+    const query = await prisma.contribution.findMany({
+      include: { user: true },
+      where: {
+        id: { equals: contributionId },
+      },
+    });
+
+    if (query.length === 0) {
+      throw Error("Contribution doesn't exist.");
+    }
+
+    const contribution = query[0];
+    if (address === contribution.user.address) {
+      throw Error("User doesn't own this contribution.");
+    }
+
+    return await prisma.contribution.delete({
+      where: { id: contributionId },
     });
   }
 }

--- a/apps/protocol-api/src/prisma/resolvers/Contribution.ts
+++ b/apps/protocol-api/src/prisma/resolvers/Contribution.ts
@@ -460,7 +460,7 @@ export class ContributionCustomResolver {
     }
 
     const contribution = query[0];
-    if (address === contribution.user.address) {
+    if (address !== contribution.user.address) {
       throw Error("User doesn't own this contribution.");
     }
 

--- a/apps/protocol-api/src/prisma/schema.prisma
+++ b/apps/protocol-api/src/prisma/schema.prisma
@@ -79,7 +79,7 @@ model GuildContribution {
   guild_id Int
   guild Guild @relation(fields: [guild_id], references: [id])
   contribution_id Int
-  contribution Contribution @relation(fields: [contribution_id], references: [id])
+  contribution Contribution @relation(fields: [contribution_id], references: [id], onDelete: Cascade)
 
   @@unique([guild_id, contribution_id])
 }
@@ -137,7 +137,7 @@ model Partner {
   user_id Int
   user User @relation(fields: [user_id], references: [id])
   contribution_id Int
-  contribution Contribution @relation(fields: [contribution_id], references: [id])
+  contribution Contribution @relation(fields: [contribution_id], references: [id], onDelete: Cascade)
 
   @@unique([user_id, contribution_id])
 }
@@ -151,7 +151,7 @@ model Attestation {
   user_id Int
   user User @relation(fields: [user_id], references: [id])
   contribution_id Int
-  contribution Contribution @relation(fields: [contribution_id], references: [id])
+  contribution Contribution @relation(fields: [contribution_id], references: [id], onDelete: Cascade)
   date_of_attestation DateTime @default(now())
 
   @@unique([user_id, contribution_id])

--- a/apps/protocol-frontend/src/contexts/UserContext.tsx
+++ b/apps/protocol-frontend/src/contexts/UserContext.tsx
@@ -16,6 +16,7 @@ import { useAuth } from './AuthContext';
 const protocolUrl = import.meta.env.VITE_PROTOCOL_URL;
 
 export const UserContext: any = createContext(null);
+
 interface UserContextProps {
   children: React.ReactNode;
 }
@@ -288,7 +289,7 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
           ethers.utils.toUtf8Bytes(contribution.details), // contribution details
           ethers.utils.toUtf8Bytes(contribution.proof) // contribution proof
         );
-        getUserContributions();
+        await getUserContributions();
         setMintProgress((prevState) => prevState + 1);
         toast({
           title: 'Contribution Successfully Minted',
@@ -304,6 +305,42 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
       toast({
         title: 'Unable to Mint Contribution',
         description: `Something went wrong. Please try again: ${error}`,
+        status: 'error',
+        duration: 3000,
+        isClosable: true,
+        position: 'top-right',
+      });
+    }
+  };
+
+  const deleteContribution = async (id: number) => {
+    try {
+      if (provider) {
+        await govrn.contribution.burn(
+          {
+            address: networks[chainId].govrnContract,
+            chainId: networks[chainId].chainNumber,
+            name: networks[chainId].name,
+          },
+          signer,
+          id
+        );
+        await getUserContributions();
+
+        toast({
+          title: 'Contribution Successfully deleted',
+          description: 'Your Contribution has been minted.',
+          status: 'success',
+          duration: 3000,
+          isClosable: true,
+          position: 'top-right',
+        });
+      }
+    } catch (e) {
+      console.log('error', e);
+      toast({
+        title: 'Unable to delete contribution',
+        description: `Something went wrong. Please try again: ${e}`,
         status: 'error',
         duration: 3000,
         isClosable: true,
@@ -588,6 +625,7 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
         userAddress,
         setUserAddress,
         userData,
+        deleteContribution,
         setUserData,
         userDataByAddress,
         setUserDataByAddress,
@@ -627,6 +665,7 @@ export const useUser = () => {
     userDataByAddress,
     setUserDataByAddress,
     userData,
+    deleteContribution,
     setUserData,
     userContributions,
     setUserContributions,
@@ -657,6 +696,7 @@ export const useUser = () => {
     userDataByAddress,
     setUserDataByAddress,
     userData,
+    deleteContribution,
     setUserData,
     userContributions,
     setUserContributions,

--- a/apps/protocol-frontend/src/contexts/UserContext.tsx
+++ b/apps/protocol-frontend/src/contexts/UserContext.tsx
@@ -329,7 +329,7 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
 
         toast({
           title: 'Contribution Successfully deleted',
-          description: 'Your Contribution has been minted.',
+          description: 'Your Contribution has been deleted.',
           status: 'success',
           duration: 3000,
           isClosable: true,

--- a/apps/protocol-frontend/src/contexts/UserContext.tsx
+++ b/apps/protocol-frontend/src/contexts/UserContext.tsx
@@ -316,7 +316,7 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
   const deleteContribution = async (id: number) => {
     try {
       if (provider) {
-        await govrn.contribution.burn(
+        await govrn.contribution.delete(
           {
             address: networks[chainId].govrnContract,
             chainId: networks[chainId].chainNumber,

--- a/libs/govrn-contract-client/src/lib/govrn-contract-client.ts
+++ b/libs/govrn-contract-client/src/lib/govrn-contract-client.ts
@@ -39,6 +39,7 @@ export type NetworkConfig = {
 
 export class GovrnContract {
   govrn: Govrn;
+
   constructor(
     networkConfig: NetworkConfig,
     provider: ethers.providers.Provider
@@ -77,5 +78,11 @@ export class GovrnContract {
 
   public async attestations(args: AttestationArgs) {
     return await this.govrn.attestations(args.tokenId, args.address);
+  }
+
+  public async burnContribution(args: ContributionsArgs) {
+    return await this.govrn.burnContribution(args.tokenId, {
+      gasLimit: 2100000,
+    });
   }
 }

--- a/libs/protocol-client/src/lib/client/contribution.ts
+++ b/libs/protocol-client/src/lib/client/contribution.ts
@@ -29,7 +29,15 @@ export class Contribution extends BaseClient {
     return contributions.createContribution;
   }
 
-  public async burn(
+  /**
+   * This method deletes the contribution from the db.
+   * if minted, it burns the contribution.
+   *
+   * @param networkConfig
+   * @param provider
+   * @param id contribution id
+   */
+  public async delete(
     networkConfig: NetworkConfig,
     provider: ethers.providers.Provider,
     id: number

--- a/libs/protocol-client/src/lib/client/contribution.ts
+++ b/libs/protocol-client/src/lib/client/contribution.ts
@@ -40,7 +40,7 @@ export class Contribution extends BaseClient {
   public async delete(
     networkConfig: NetworkConfig,
     provider: ethers.providers.Provider,
-    id: number
+    id: number,
   ) {
     const contract = new GovrnContract(networkConfig, provider);
 
@@ -57,7 +57,7 @@ export class Contribution extends BaseClient {
       await transaction.wait(1);
     }
 
-    return await this.sdk.deleteContribution({ where: { id } });
+    return await this.sdk.deleteContribution({ where: { contributionId: id } });
   }
 
   public async bulkCreate(args: BulkCreateContributionMutationVariables) {
@@ -80,7 +80,7 @@ export class Contribution extends BaseClient {
     args: MintArgs,
     name: string,
     details: string,
-    proof: string
+    proof: string,
   ) {
     const contract = new GovrnContract(networkConfig, provider);
     const transaction = await contract.mint(args);
@@ -140,7 +140,7 @@ export class Contribution extends BaseClient {
     id: number,
     activityTypeId: number,
     userId: number,
-    args: AttestArgs
+    args: AttestArgs,
   ) {
     const contract = new GovrnContract(networkConfig, provider);
     const transaction = await contract.attest(args);

--- a/libs/protocol-client/src/lib/client/contribution.ts
+++ b/libs/protocol-client/src/lib/client/contribution.ts
@@ -29,6 +29,29 @@ export class Contribution extends BaseClient {
     return contributions.createContribution;
   }
 
+  public async burn(
+    networkConfig: NetworkConfig,
+    provider: ethers.providers.Provider,
+    id: number
+  ) {
+    const contract = new GovrnContract(networkConfig, provider);
+
+    const contribution = await this.get(id);
+    if (!contribution) {
+      throw Error(`Contribution doesn't exist: ${id}`);
+    }
+
+    // TODO: Can we avoid hardcoding the event name
+    if (contribution?.status.name === 'minted' && contribution.on_chain_id) {
+      const transaction = await contract.burnContribution({
+        tokenId: contribution.on_chain_id,
+      });
+      await transaction.wait(1);
+    }
+
+    return await this.sdk.deleteContribution({ where: { id } });
+  }
+
   public async bulkCreate(args: BulkCreateContributionMutationVariables) {
     const mutation = await this.sdk.bulkCreateContribution(args);
     return mutation.createManyContribution.count;

--- a/libs/protocol-client/src/lib/graphql/queries.graphql
+++ b/libs/protocol-client/src/lib/graphql/queries.graphql
@@ -396,8 +396,8 @@ mutation createOnChainUserContribution(
   }
 }
 
-mutation deleteContribution($where: ContributionWhereUniqueInput!) {
-  deleteContribution(where: $where) {
+mutation deleteContribution($where: UserContributionDeleteInput!) {
+  deleteUserContribution(where: $where) {
     id
   }
 }

--- a/libs/protocol-client/src/lib/graphql/queries.graphql
+++ b/libs/protocol-client/src/lib/graphql/queries.graphql
@@ -396,6 +396,12 @@ mutation createOnChainUserContribution(
   }
 }
 
+mutation deleteContribution($where: ContributionWhereUniqueInput!) {
+  deleteContribution(where: $where) {
+    id
+  }
+}
+
 mutation updateUserContribution($data: UserContributionUpdateInput!) {
   updateUserContribution(data: $data) {
     ...ContributionFragment

--- a/libs/protocol-client/src/lib/protocol-types.ts
+++ b/libs/protocol-client/src/lib/protocol-types.ts
@@ -8292,7 +8292,7 @@ export type Mutation = {
   deleteTwitterUser?: Maybe<TwitterUser>;
   deleteUser?: Maybe<User>;
   deleteUserActivity?: Maybe<UserActivity>;
-  deleteUserContribution?: Maybe<Contribution>;
+  deleteUserContribution: Contribution;
   updateActivityType?: Maybe<ActivityType>;
   updateAttestation?: Maybe<Attestation>;
   updateAttestationConfidence?: Maybe<AttestationConfidence>;
@@ -8922,6 +8922,11 @@ export type MutationDeleteUserArgs = {
 
 export type MutationDeleteUserActivityArgs = {
   where: UserActivityWhereUniqueInput;
+};
+
+
+export type MutationDeleteUserContributionArgs = {
+  where: UserContributionDeleteInput;
 };
 
 
@@ -12727,6 +12732,10 @@ export type UserContributionCreateInput = {
   userId: Scalars['Float'];
 };
 
+export type UserContributionDeleteInput = {
+  contributionId: Scalars['Int'];
+};
+
 export type UserContributionUpdateInput = {
   activityTypeName: Scalars['String'];
   address: Scalars['String'];
@@ -13935,11 +13944,11 @@ export type CreateOnChainUserContributionMutationVariables = Exact<{
 export type CreateOnChainUserContributionMutation = { createOnChainUserContribution: { date_of_engagement: string | Date, date_of_submission: string | Date, details?: string | null, id: number, name: string, proof?: string | null, updatedAt: string | Date, on_chain_id?: number | null, activity_type: { active: boolean, createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, status: { createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, user: { address: string, createdAt: string | Date, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: string | Date }, attestations: Array<{ id: number, user_id: number, date_of_attestation: string | Date }>, guilds: Array<{ guild: { id: number, name?: string | null } }> } };
 
 export type DeleteContributionMutationVariables = Exact<{
-  where: ContributionWhereUniqueInput;
+  where: UserContributionDeleteInput;
 }>;
 
 
-export type DeleteContributionMutation = { deleteContribution?: { id: number } | null };
+export type DeleteContributionMutation = { deleteUserContribution: { id: number } };
 
 export type UpdateUserContributionMutationVariables = Exact<{
   data: UserContributionUpdateInput;
@@ -14515,8 +14524,8 @@ export const CreateOnChainUserContributionDocument = gql`
 }
     ${ContributionFragmentFragmentDoc}`;
 export const DeleteContributionDocument = gql`
-    mutation deleteContribution($where: ContributionWhereUniqueInput!) {
-  deleteContribution(where: $where) {
+    mutation deleteContribution($where: UserContributionDeleteInput!) {
+  deleteUserContribution(where: $where) {
     id
   }
 }

--- a/libs/protocol-client/src/lib/protocol-types.ts
+++ b/libs/protocol-client/src/lib/protocol-types.ts
@@ -8292,6 +8292,7 @@ export type Mutation = {
   deleteTwitterUser?: Maybe<TwitterUser>;
   deleteUser?: Maybe<User>;
   deleteUserActivity?: Maybe<UserActivity>;
+  deleteUserContribution?: Maybe<Contribution>;
   updateActivityType?: Maybe<ActivityType>;
   updateAttestation?: Maybe<Attestation>;
   updateAttestationConfidence?: Maybe<AttestationConfidence>;
@@ -13933,6 +13934,13 @@ export type CreateOnChainUserContributionMutationVariables = Exact<{
 
 export type CreateOnChainUserContributionMutation = { createOnChainUserContribution: { date_of_engagement: string | Date, date_of_submission: string | Date, details?: string | null, id: number, name: string, proof?: string | null, updatedAt: string | Date, on_chain_id?: number | null, activity_type: { active: boolean, createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, status: { createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, user: { address: string, createdAt: string | Date, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: string | Date }, attestations: Array<{ id: number, user_id: number, date_of_attestation: string | Date }>, guilds: Array<{ guild: { id: number, name?: string | null } }> } };
 
+export type DeleteContributionMutationVariables = Exact<{
+  where: ContributionWhereUniqueInput;
+}>;
+
+
+export type DeleteContributionMutation = { deleteContribution?: { id: number } | null };
+
 export type UpdateUserContributionMutationVariables = Exact<{
   data: UserContributionUpdateInput;
 }>;
@@ -14506,6 +14514,13 @@ export const CreateOnChainUserContributionDocument = gql`
   }
 }
     ${ContributionFragmentFragmentDoc}`;
+export const DeleteContributionDocument = gql`
+    mutation deleteContribution($where: ContributionWhereUniqueInput!) {
+  deleteContribution(where: $where) {
+    id
+  }
+}
+    `;
 export const UpdateUserContributionDocument = gql`
     mutation updateUserContribution($data: UserContributionUpdateInput!) {
   updateUserContribution(data: $data) {
@@ -14715,6 +14730,9 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     },
     createOnChainUserContribution(variables: CreateOnChainUserContributionMutationVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<CreateOnChainUserContributionMutation> {
       return withWrapper((wrappedRequestHeaders) => client.request<CreateOnChainUserContributionMutation>(CreateOnChainUserContributionDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'createOnChainUserContribution', 'mutation');
+    },
+    deleteContribution(variables: DeleteContributionMutationVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<DeleteContributionMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<DeleteContributionMutation>(DeleteContributionDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'deleteContribution', 'mutation');
     },
     updateUserContribution(variables: UpdateUserContributionMutationVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<UpdateUserContributionMutation> {
       return withWrapper((wrappedRequestHeaders) => client.request<UpdateUserContributionMutation>(UpdateUserContributionDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'updateUserContribution', 'mutation');


### PR DESCRIPTION
## Linear Ticket

[PRO-299 - Add delete contribution method to Contribution Resolver](https://linear.app/govrn/issue/PRO-299/add-delete-contribution-method-to-contribution-resolver)

## Description
Support contribution deletion regard the contribution status: 
- Add method that allows a user to delete a `staged` contribution
- And if the contribution is `minted`, it burns the contribution

contains a db migration.
