### PR TITLE
Custom resolver for contribution count

### DIFF
--- a/apps/protocol-api/src/main.ts
+++ b/apps/protocol-api/src/main.ts
@@ -31,7 +31,7 @@ const typeSchema = buildSchemaSync({
 
 // TODO: Figure out is there is a way to genralize this
 //
-const OwnsData = rule()(async (parent, args, ctx, info) => {
+const ownsData = rule()(async (parent, args, ctx, info) => {
   return true;
 });
 
@@ -78,15 +78,15 @@ const permissions = shield(
       createOnChainUserContribution: isAuthenticated,
       createUser: or(isAuthenticated, hasToken),
       createUserActivity: hasToken,
-      createUserAttestation: and(OwnsData, isAuthenticated),
-      createUserContribution: and(OwnsData, isAuthenticated),
-      createUserCustom: or(hasToken, and(OwnsData, isAuthenticated)),
+      createUserAttestation: and(ownsData, isAuthenticated),
+      createUserContribution: and(ownsData, isAuthenticated),
+      createUserCustom: or(hasToken, and(ownsData, isAuthenticated)),
       createUserOnChainAttestation: isAuthenticated,
-      deleteContribution: or(OwnsData, isAuthenticated),
+      deleteContribution: or(ownsData, isAuthenticated),
       updateGuild: hasToken,
       updateUser: hasToken,
-      updateUserContribution: and(OwnsData, isAuthenticated),
-      updateUserCustom: and(OwnsData, isAuthenticated),
+      updateUserContribution: and(ownsData, isAuthenticated),
+      updateUserCustom: and(ownsData, isAuthenticated),
       updateUserOnChainAttestation: isAuthenticated,
       updateUserOnChainContribution: isAuthenticated,
     },

--- a/apps/protocol-api/src/main.ts
+++ b/apps/protocol-api/src/main.ts
@@ -63,6 +63,7 @@ const permissions = shield(
       guild: or(isAuthenticated, hasToken),
       guilds: or(isAuthenticated, hasToken),
       listUserByAddress: isAuthenticated,
+      getContributionCountForUser: or(isAuthenticated, hasToken),
       users: hasToken,
       jobRuns: hasToken,
     },

--- a/apps/protocol-api/src/main.ts
+++ b/apps/protocol-api/src/main.ts
@@ -174,6 +174,7 @@ const permissions = shield(
       twitter_account: or(isAuthenticated, hasToken),
       updatedAt: or(isAuthenticated, hasToken),
       users: or(isAuthenticated, hasToken),
+      contribution_reporting_channel: or(isAuthenticated, hasToken),
     },
     GuildContribution: {
       id: or(isAuthenticated, hasToken),

--- a/apps/protocol-api/src/main.ts
+++ b/apps/protocol-api/src/main.ts
@@ -63,10 +63,11 @@ const permissions = shield(
       guild: or(isAuthenticated, hasToken),
       guilds: or(isAuthenticated, hasToken),
       listUserByAddress: isAuthenticated,
-      getContributionCountForUser: or(isAuthenticated, hasToken),
+      getContributionCountByDateForUserInRange: or(isAuthenticated, hasToken),
       users: hasToken,
       jobRuns: hasToken,
     },
+    ContributionCountByDate: or(isAuthenticated, hasToken),
     Mutation: {
       '*': deny,
       createActivityType: hasToken,

--- a/apps/protocol-api/src/prisma/resolvers/Contribution.ts
+++ b/apps/protocol-api/src/prisma/resolvers/Contribution.ts
@@ -224,7 +224,7 @@ export class ContributionCustomResolver {
   @TypeGraphQL.Mutation((_returns) => Contribution, { nullable: false })
   async createUserContribution(
     @TypeGraphQL.Ctx() { prisma }: Context,
-    @TypeGraphQL.Args() args: CreateUserContributionArgs,
+    @TypeGraphQL.Args() args: CreateUserContributionArgs
   ) {
     return await prisma.contribution.create({
       data: {
@@ -287,7 +287,7 @@ export class ContributionCustomResolver {
   @TypeGraphQL.Mutation((_returns) => Contribution, { nullable: false })
   async createOnChainUserContribution(
     @TypeGraphQL.Ctx() { prisma }: Context,
-    @TypeGraphQL.Args() args: CreateUserOnChainContributionArgs,
+    @TypeGraphQL.Args() args: CreateUserOnChainContributionArgs
   ) {
     return await prisma.contribution.create({
       data: {
@@ -312,7 +312,7 @@ export class ContributionCustomResolver {
   @TypeGraphQL.Mutation((_returns) => Contribution, { nullable: false })
   async updateUserContribution(
     @TypeGraphQL.Ctx() { prisma, req }: Context,
-    @TypeGraphQL.Args() args: UpdateUserContributionArgs,
+    @TypeGraphQL.Args() args: UpdateUserContributionArgs
   ) {
     const address = req.session.siwe.data.address;
     const res = await prisma.contribution.updateMany({
@@ -420,7 +420,7 @@ export class ContributionCustomResolver {
   @TypeGraphQL.Mutation((_returns) => Contribution, { nullable: false })
   async updateUserOnChainContribution(
     @TypeGraphQL.Ctx() { prisma, req }: Context,
-    @TypeGraphQL.Args() args: UpdateUserOnChainContributionArgs,
+    @TypeGraphQL.Args() args: UpdateUserOnChainContributionArgs
   ) {
     const address = req.session.siwe.data.address;
     const update = await prisma.contribution.updateMany({
@@ -473,7 +473,7 @@ export class ContributionCustomResolver {
   @TypeGraphQL.Mutation((_returns) => Contribution, { nullable: false })
   async deleteUserContribution(
     @TypeGraphQL.Ctx() { prisma, req }: Context,
-    @TypeGraphQL.Args() args: DeleteUserContributionArgs,
+    @TypeGraphQL.Args() args: DeleteUserContributionArgs
   ) {
     const contributionId = args.where.contributionId;
     const address = req.session.siwe.data.address;
@@ -498,27 +498,20 @@ export class ContributionCustomResolver {
     });
   }
 
-  @TypeGraphQL.Query((_returns) => [ContributionCountByDate], { nullable: false })
+  @TypeGraphQL.Query((_returns) => [ContributionCountByDate], {
+    nullable: false,
+  })
   async getContributionCountByDateForUserInRange(
     @TypeGraphQL.Ctx() { prisma }: Context,
     @TypeGraphQL.Args() args: GetUserContributionCountArgs
   ) {
-    /*return await getPrismaFromContext(ctx).contribution.count({
-      where: {
-        AND: [
-          { user_id: { equals: args.where.id } },
-          { date_of_engagement: { gte: args.where.start_date } },
-          { date_of_engagement: { lte: args.where.end_date } }
-        ]
-      }
-    })
     // grouping by a derived field not yet supported in prisma
     // would need to group by date, not the datetime as is stored in postg*/
     // YYY-MM-DD hh:mm:ss.sss
-    const user_id  = args.where.id;
-    const start = args.where.start_date
-    const end = args.where.end_date
-      
+    const user_id = args.where.id;
+    const start = args.where.start_date;
+    const end = args.where.end_date;
+
     const result = await prisma.$queryRaw<ContributionCountByDate>`
       SELECT date(date_of_engagement), count(date_of_engagement) as count
       FROM "Contribution"
@@ -526,7 +519,7 @@ export class ContributionCustomResolver {
       AND "Contribution"."user_id" = ${user_id})
       GROUP BY date(date_of_engagement)
       ORDER BY date(date_of_engagement);`;
-    
+
     return result;
   }
 }

--- a/apps/protocol-api/src/prisma/resolvers/User.ts
+++ b/apps/protocol-api/src/prisma/resolvers/User.ts
@@ -35,6 +35,18 @@ export class UserUpdateCustomInput {
   disconnectLinearId?: number;
 }
 
+@TypeGraphQL.InputType('GetUserContributionCountInput')
+export class GetUserContributionCountInput {
+  @TypeGraphQL.Field((_type) => Number)
+  id: number;
+
+  @TypeGraphQL.Field((_type) => Date)
+  start_date: Date;
+
+  @TypeGraphQL.Field((_type) => Date)
+  end_date: Date;
+}
+
 @TypeGraphQL.ArgsType()
 export class UpdateUserCustomArgs {
   @TypeGraphQL.Field((_type) => UserUpdateCustomInput, {
@@ -65,14 +77,10 @@ export class ListUserArgs {
 
 @TypeGraphQL.ArgsType()
 export class GetUserContributionCountArgs {
-  @TypeGraphQL.Field((_type) => Number)
-  id: number;
-
-  @TypeGraphQL.Field((_type) => Date)
-  start_date: Date;
-
-  @TypeGraphQL.Field((_type) => Date)
-  end_date: Date;
+  @TypeGraphQL.Field((_type) => GetUserContributionCountInput, {
+    nullable: false,
+  })
+  where!: GetUserContributionCountInput;
 }
 
 @TypeGraphQL.Resolver((_of) => User)
@@ -149,9 +157,9 @@ export class UserCustomResolver {
     return await getPrismaFromContext(ctx).contribution.count({
       where: {
         AND: [
-          { user_id: { equals: args.id } },
-          { date_of_engagement: { gte: args.start_date } },
-          { date_of_engagement: { lte: args.end_date } }
+          { user_id: { equals: args.where.id } },
+          { date_of_engagement: { gte: args.where.start_date } },
+          { date_of_engagement: { lte: args.where.end_date } }
         ]
       }
     })

--- a/libs/protocol-client/README.md
+++ b/libs/protocol-client/README.md
@@ -7,7 +7,7 @@ This library contains All GraphQL queries & mutation in addition to clients. Cli
 This App is generated using [`@nrwl/node:application`](https://nx.dev/packages/node/generators/application). Check all targets at [`project.json`](./project.json) 
 
 ### Commands
-- `yarn nx run protocol-client:generate-gql`: runs `graphql-codegen`, generating code based on GraphQL schema ([`queries.graphql`](./src/lib/graphql/queries.graphql)).[^1]
+- `yarn nx run protocol-client:generate-gql`: runs `graphql-codegen`, generating code based on both the GraphQL schema ([`queries.graphql`](./src/lib/graphql/queries.graphql)) and on the (custom resolvers)[../../apps/protocol-api/src/prisma/resolvers].[^1]
 
 ### Add new GraphQL Query
 - first add new query to [`queries.graphql`](./src/lib/graphql/queries.graphql) file. 

--- a/libs/protocol-client/src/lib/client/custom.ts
+++ b/libs/protocol-client/src/lib/client/custom.ts
@@ -35,8 +35,8 @@ export class Custom extends BaseClient {
     return attestation.result;
   }
 
-  public async getUserContributionCount(args: GetUserContributionCountInput) {
-    const contributionCount = await this.sdk.getUserContributionCount({ where: args });
+  public async getContributionCountByDateForUserInRange(args: GetUserContributionCountInput) {
+    const contributionCount = await this.sdk.getContributionCountByDateForUserInRange({ where: args });
     return contributionCount.result;
   }
 }

--- a/libs/protocol-client/src/lib/client/custom.ts
+++ b/libs/protocol-client/src/lib/client/custom.ts
@@ -4,6 +4,7 @@ import {
   UserContributionCreateInput,
   UserContributionUpdateInput,
   UserUpdateCustomInput,
+  GetUserContributionCountInput
 } from '../protocol-types';
 
 // get accounts
@@ -32,5 +33,10 @@ export class Custom extends BaseClient {
   public async listUserByAddress(address: string) {
     const attestation = await this.sdk.listUserByAddress({ address });
     return attestation.result;
+  }
+
+  public async getUserContributionCount(args: GetUserContributionCountInput) {
+    const contributionCount = await this.sdk.getUserContributionCount({ where: args });
+    return contributionCount.result;
   }
 }

--- a/libs/protocol-client/src/lib/graphql/queries.graphql
+++ b/libs/protocol-client/src/lib/graphql/queries.graphql
@@ -378,6 +378,10 @@ query listContributions(
   }
 }
 
+query getUserContributionCount($where: GetUserContributionCountInput!) {
+  result: getContributionCountForUser(where: $where)
+}
+
 mutation createContribution($data: ContributionCreateInput!) {
   createContribution(data: $data) {
     ...ContributionFragment

--- a/libs/protocol-client/src/lib/graphql/queries.graphql
+++ b/libs/protocol-client/src/lib/graphql/queries.graphql
@@ -378,8 +378,11 @@ query listContributions(
   }
 }
 
-query getUserContributionCount($where: GetUserContributionCountInput!) {
-  result: getContributionCountForUser(where: $where)
+query getContributionCountByDateForUserInRange($where: GetUserContributionCountInput!) {
+  result: getContributionCountByDateForUserInRange(where: $where) {
+    count
+    date
+  }
 }
 
 mutation createContribution($data: ContributionCreateInput!) {

--- a/libs/protocol-client/src/lib/protocol-types.ts
+++ b/libs/protocol-client/src/lib/protocol-types.ts
@@ -2259,6 +2259,11 @@ export type ContributionCountAggregate = {
   user_id: Scalars['Int'];
 };
 
+export type ContributionCountByDate = {
+  count: Scalars['Float'];
+  date: Scalars['String'];
+};
+
 export type ContributionCountOrderByAggregateInput = {
   activity_type_id?: InputMaybe<SortOrder>;
   date_of_engagement?: InputMaybe<SortOrder>;
@@ -10196,7 +10201,7 @@ export type Query = {
   findFirstTwitterUser?: Maybe<TwitterUser>;
   findFirstUser?: Maybe<User>;
   findFirstUserActivity?: Maybe<UserActivity>;
-  getContributionCountForUser: Scalars['Int'];
+  getContributionCountByDateForUserInRange: Array<ContributionCountByDate>;
   getUser: User;
   groupByActivityType: Array<ActivityTypeGroupBy>;
   groupByAttestation: Array<AttestationGroupBy>;
@@ -10869,7 +10874,7 @@ export type QueryFindFirstUserActivityArgs = {
 };
 
 
-export type QueryGetContributionCountForUserArgs = {
+export type QueryGetContributionCountByDateForUserInRangeArgs = {
   where: GetUserContributionCountInput;
 };
 
@@ -14032,12 +14037,12 @@ export type ListContributionsQueryVariables = Exact<{
 
 export type ListContributionsQuery = { result: Array<{ date_of_engagement: string | Date, date_of_submission: string | Date, details?: string | null, id: number, name: string, proof?: string | null, updatedAt: string | Date, on_chain_id?: number | null, activity_type: { active: boolean, createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, status: { createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, user: { address: string, createdAt: string | Date, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: string | Date }, attestations: Array<{ id: number, user_id: number, date_of_attestation: string | Date }>, guilds: Array<{ guild: { id: number, name?: string | null } }> }> };
 
-export type GetUserContributionCountQueryVariables = Exact<{
+export type GetContributionCountByDateForUserInRangeQueryVariables = Exact<{
   where: GetUserContributionCountInput;
 }>;
 
 
-export type GetUserContributionCountQuery = { result: number };
+export type GetContributionCountByDateForUserInRangeQuery = { result: Array<{ count: number, date: string }> };
 
 export type CreateContributionMutationVariables = Exact<{
   data: ContributionCreateInput;
@@ -14621,9 +14626,12 @@ export const ListContributionsDocument = gql`
   }
 }
     ${ContributionFragmentFragmentDoc}`;
-export const GetUserContributionCountDocument = gql`
-    query getUserContributionCount($where: GetUserContributionCountInput!) {
-  result: getContributionCountForUser(where: $where)
+export const GetContributionCountByDateForUserInRangeDocument = gql`
+    query getContributionCountByDateForUserInRange($where: GetUserContributionCountInput!) {
+  result: getContributionCountByDateForUserInRange(where: $where) {
+    count
+    date
+  }
 }
     `;
 export const CreateContributionDocument = gql`
@@ -14855,8 +14863,8 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     listContributions(variables?: ListContributionsQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<ListContributionsQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<ListContributionsQuery>(ListContributionsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'listContributions', 'query');
     },
-    getUserContributionCount(variables: GetUserContributionCountQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<GetUserContributionCountQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<GetUserContributionCountQuery>(GetUserContributionCountDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getUserContributionCount', 'query');
+    getContributionCountByDateForUserInRange(variables: GetContributionCountByDateForUserInRangeQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<GetContributionCountByDateForUserInRangeQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<GetContributionCountByDateForUserInRangeQuery>(GetContributionCountByDateForUserInRangeDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getContributionCountByDateForUserInRange', 'query');
     },
     createContribution(variables: CreateContributionMutationVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<CreateContributionMutation> {
       return withWrapper((wrappedRequestHeaders) => client.request<CreateContributionMutation>(CreateContributionDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'createContribution', 'mutation');

--- a/libs/protocol-client/src/lib/protocol-types.ts
+++ b/libs/protocol-client/src/lib/protocol-types.ts
@@ -13,7 +13,6 @@ export type Scalars = {
   Boolean: boolean;
   Int: number;
   Float: number;
-  /** The javascript `Date` as string. Type represents date and time as the ISO Date string. */
   DateTime: string | Date;
 };
 
@@ -10191,6 +10190,7 @@ export type Query = {
   findFirstTwitterUser?: Maybe<TwitterUser>;
   findFirstUser?: Maybe<User>;
   findFirstUserActivity?: Maybe<UserActivity>;
+  getContributionCountForUser: Scalars['Int'];
   getUser: User;
   groupByActivityType: Array<ActivityTypeGroupBy>;
   groupByAttestation: Array<AttestationGroupBy>;
@@ -10860,6 +10860,13 @@ export type QueryFindFirstUserActivityArgs = {
   skip?: InputMaybe<Scalars['Int']>;
   take?: InputMaybe<Scalars['Int']>;
   where?: InputMaybe<UserActivityWhereInput>;
+};
+
+
+export type QueryGetContributionCountForUserArgs = {
+  end_date: Scalars['DateTime'];
+  id: Scalars['Float'];
+  start_date: Scalars['DateTime'];
 };
 
 

--- a/libs/protocol-client/src/lib/protocol-types.ts
+++ b/libs/protocol-client/src/lib/protocol-types.ts
@@ -3736,6 +3736,12 @@ export type FloatNullableWithAggregatesFilter = {
   notIn?: InputMaybe<Array<Scalars['Float']>>;
 };
 
+export type GetUserContributionCountInput = {
+  end_date: Scalars['DateTime'];
+  id: Scalars['Float'];
+  start_date: Scalars['DateTime'];
+};
+
 export type Guild = {
   _count?: Maybe<GuildCount>;
   activity_type: Array<GuildActivityType>;
@@ -10864,9 +10870,7 @@ export type QueryFindFirstUserActivityArgs = {
 
 
 export type QueryGetContributionCountForUserArgs = {
-  end_date: Scalars['DateTime'];
-  id: Scalars['Float'];
-  start_date: Scalars['DateTime'];
+  where: GetUserContributionCountInput;
 };
 
 
@@ -14028,6 +14032,13 @@ export type ListContributionsQueryVariables = Exact<{
 
 export type ListContributionsQuery = { result: Array<{ date_of_engagement: string | Date, date_of_submission: string | Date, details?: string | null, id: number, name: string, proof?: string | null, updatedAt: string | Date, on_chain_id?: number | null, activity_type: { active: boolean, createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, status: { createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, user: { address: string, createdAt: string | Date, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: string | Date }, attestations: Array<{ id: number, user_id: number, date_of_attestation: string | Date }>, guilds: Array<{ guild: { id: number, name?: string | null } }> }> };
 
+export type GetUserContributionCountQueryVariables = Exact<{
+  where: GetUserContributionCountInput;
+}>;
+
+
+export type GetUserContributionCountQuery = { result: number };
+
 export type CreateContributionMutationVariables = Exact<{
   data: ContributionCreateInput;
 }>;
@@ -14610,6 +14621,11 @@ export const ListContributionsDocument = gql`
   }
 }
     ${ContributionFragmentFragmentDoc}`;
+export const GetUserContributionCountDocument = gql`
+    query getUserContributionCount($where: GetUserContributionCountInput!) {
+  result: getContributionCountForUser(where: $where)
+}
+    `;
 export const CreateContributionDocument = gql`
     mutation createContribution($data: ContributionCreateInput!) {
   createContribution(data: $data) {
@@ -14838,6 +14854,9 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     },
     listContributions(variables?: ListContributionsQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<ListContributionsQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<ListContributionsQuery>(ListContributionsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'listContributions', 'query');
+    },
+    getUserContributionCount(variables: GetUserContributionCountQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<GetUserContributionCountQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<GetUserContributionCountQuery>(GetUserContributionCountDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getUserContributionCount', 'query');
     },
     createContribution(variables: CreateContributionMutationVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<CreateContributionMutation> {
       return withWrapper((wrappedRequestHeaders) => client.request<CreateContributionMutation>(CreateContributionDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'createContribution', 'mutation');

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "start": "nx serve",
     "build": "nx build",
-    "test": "nx test"
+    "test": "nx test",
+    "protocol": "nx serve protocol-api"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
## Linear Ticket

[Pro-293](https://linear.app/govrn/issue/PRO-293/preprocess-data-for-mvp-contributor-dashboard)

## Description

- Add a custom resolver to preprocess a query to get the number of contributions for a user in a given timeframe
- Update client library readme to reflect that the client needs regeneration if resolvers are edited
- Update permissions for retrieving reporting channel field

## Screencaptures

For frontend changes, considering adding a screenshot or screencapture of the changes.
Before/after screenshots may be helpful when relevant.
