### PR TITLE
Alter Some Columns to CITEXT Types to Avoid Duplicates

### DIFF
--- a/apps/protocol-api/src/prisma/migrations/20220808171325_address_citext/migration.sql
+++ b/apps/protocol-api/src/prisma/migrations/20220808171325_address_citext/migration.sql
@@ -1,0 +1,6 @@
+-- enable citext extension
+CREATE EXTENSION IF NOT EXISTS citext;
+
+-- AlterTable
+ALTER TABLE "User"
+  ALTER COLUMN "address" SET DATA TYPE CITEXT USING address::citext;

--- a/apps/protocol-api/src/prisma/migrations/20220810160145_tx_hash_citext/migration.sql
+++ b/apps/protocol-api/src/prisma/migrations/20220810160145_tx_hash_citext/migration.sql
@@ -1,0 +1,3 @@
+-- Alter tx_hash Type.
+ALTER TABLE "Contribution"
+  ALTER COLUMN "tx_hash" SET DATA TYPE CITEXT USING tx_hash::citext;

--- a/apps/protocol-api/src/prisma/schema.prisma
+++ b/apps/protocol-api/src/prisma/schema.prisma
@@ -136,7 +136,7 @@ model Contribution {
   linear_issue LinearIssue?
   tweet TwitterTweet?
   on_chain_id Int? @unique
-  tx_hash String? @unique
+  tx_hash String? @db.Citext @unique
 }
 
 model Partner {

--- a/apps/protocol-api/src/prisma/schema.prisma
+++ b/apps/protocol-api/src/prisma/schema.prisma
@@ -25,7 +25,7 @@ model User {
   updatedAt DateTime @updatedAt @default(now())
   name  String?
   display_name String?
-  address String @unique
+  address String @db.Citext @unique
   chain_type_id Int
   chain_type ChainType @relation(fields: [chain_type_id], references: [id])
   full_name String?


### PR DESCRIPTION
## Linear Ticket

[PRO-346 - Make address field case insensitive](https://linear.app/govrn/issue/PRO-346/make-address-field-case-insensitive)

## Description
Due to case sensitivity of `address` column, it exploits the uniqueness of it.
Duplicate addresses could be inserted with different lowercase/uppercase.

`User.address` & `Contriubtion.tx_hash`'s type has been altered: `text` -> `citext`.

### Disclaimer
Altering type to `citext` will only work iff there are no duplicated among records.

```
Database error:
ERROR: could not create unique index "User_address_key"
DETAIL: Key (address)=(0x68d36DcBDD7Bbf206e27134F28103abE7cf972df) is duplicated.
```

