### PR TITLE
Update Typescript to 4.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "stream-browserify": "^3.0.0",
     "ts-jest": "27.0.5",
     "typechain": "^8.0.0",
-    "typescript": "~4.5.2",
+    "typescript": "^4.7.4",
     "url-loader": "^3.0.0",
     "url-polyfill": "^1.1.12",
     "vite": "^2.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -25244,10 +25244,10 @@ typegraphql-prisma@^0.20.0:
     ts-morph "^15.1.0"
     tslib "^2.4.0"
 
-typescript@~4.5.2:
-  version "4.5.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
-  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
+typescript@^4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 typewise-core@^1.2, typewise-core@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
## Release Notes

- [TypeScript 4.6](https://devblogs.microsoft.com/typescript/announcing-typescript-4-6/)
- [TypeScript 4.7](https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/)
