### PR TITLE
Add Attestations to Attestation Feed Modal

### DIFF
--- a/apps/protocol-frontend/src/components/BulkAttestationModal.tsx
+++ b/apps/protocol-frontend/src/components/BulkAttestationModal.tsx
@@ -37,10 +37,12 @@ const BulkAttestationModal = ({ contributions }: BulkAttestationModalProps) => {
 
   return (
     <Stack spacing="4" width="100%" color="gray.800">
-      <Text paddingBottom={2}>Attesting as: {userData.name}</Text>
       <Text paddingBottom={2}>
-        Attesting to {contributions.length}{' '}
-        {contributions.length === 1 ? 'Contribution' : 'Contributions'}
+        Attesting as: <strong>{userData.name}</strong>
+      </Text>
+      <Text>
+        Attesting to <strong>{contributions.length} </strong>
+        {contributions.length === 1 ? 'Contribution' : 'Contributions'}:
       </Text>
       <List variant="primary" paddingBottom={3} spacing={2}>
         {contributions.map(value => {

--- a/apps/protocol-frontend/src/components/BulkAttestationModal.tsx
+++ b/apps/protocol-frontend/src/components/BulkAttestationModal.tsx
@@ -1,7 +1,17 @@
 import { useState } from 'react';
-import { Button, Flex, Progress, Stack, Text } from '@chakra-ui/react';
+import {
+  Button,
+  Flex,
+  List,
+  ListIcon,
+  ListItem,
+  Progress,
+  Stack,
+  Text,
+} from '@chakra-ui/react';
 import { useUser } from '../contexts/UserContext';
 import { UIContribution } from '@govrn/ui-types';
+import { MdCheckCircle } from 'react-icons/all';
 
 interface BulkAttestationModalProps {
   contributions: UIContribution[];
@@ -32,6 +42,17 @@ const BulkAttestationModal = ({ contributions }: BulkAttestationModalProps) => {
         Attesting to {contributions.length}{' '}
         {contributions.length === 1 ? 'Contribution' : 'Contributions'}
       </Text>
+      <List variant="primary" paddingBottom={3} spacing={2}>
+        {contributions.map(value => {
+          return (
+            <ListItem>
+              {' '}
+              <ListIcon as={MdCheckCircle} color="green.500" />
+              {value.name}
+            </ListItem>
+          );
+        })}
+      </List>
       {attesting ? (
         <Progress
           color="brand.primary"


### PR DESCRIPTION
## Linear Ticket
[PRO-252 - In the attestation feed modal that pops up when attesting, it'd be cool to see a line item view of everything i'm attesting too.](https://linear.app/govrn/issue/PRO-252/in-the-attestation-feed-modal-that-pops-up-when-attesting-itd-be-cool)

## Description
In Add-Attestation Modal, it was only showing the contribution count. The selected Attestations are added to the Modal now.

## Screencaptures
![image](https://user-images.githubusercontent.com/12991700/184884472-2c7f90d9-fe73-43f5-b554-a09db8d9c243.png)

