### PR TITLE
[UserContext] Fix error Message in getUserAttestations 

### DIFF
--- a/apps/protocol-frontend/src/contexts/UserContext.tsx
+++ b/apps/protocol-frontend/src/contexts/UserContext.tsx
@@ -227,7 +227,7 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
   const getUserAttestations = async () => {
     try {
       if (!userData?.id) {
-        throw new Error('getUserActivityTypes has no userData.id');
+        throw new Error('getUserAttestations has no userData.id');
       }
       const userAttestationsResponse = await govrn.attestation.list({
         where: {


### PR DESCRIPTION
## Description
Error Message has the wrong function name in `getUserAttestations`.

