### PR TITLE
fix/prevent-attestation-not-minted (PRO-374)

### DIFF
--- a/apps/protocol-frontend/src/components/AttestationsTable.tsx
+++ b/apps/protocol-frontend/src/components/AttestationsTable.tsx
@@ -56,9 +56,18 @@ const AttestationsTable = ({
 }) => {
   const { userData } = useUser();
 
-  const nonUserContributions = _.filter(contributionsData, function (a) {
-    return a.user.id !== userData?.id;
+  const filteredMintedContributions = _.filter(contributionsData, function (a) {
+    return a.status.name === 'minted';
   });
+
+  const nonUserContributions = _.filter(
+    filteredMintedContributions,
+    function (a) {
+      return a.user.id !== userData?.id;
+    },
+  );
+
+  console.log('nonUserContributions', nonUserContributions);
 
   const unattestedContributions = _.filter(nonUserContributions, function (a) {
     return a.attestations?.every(b => b.user_id !== userData?.id) ?? false;

--- a/apps/protocol-frontend/src/components/AttestationsTable.tsx
+++ b/apps/protocol-frontend/src/components/AttestationsTable.tsx
@@ -27,6 +27,7 @@ import IndeterminateCheckbox from './IndeterminateCheckbox';
 import { useUser } from '../contexts/UserContext';
 import GlobalFilter from './GlobalFilter';
 import { UIContribution } from '@govrn/ui-types';
+import EmptyContributions from './EmptyContributions';
 
 type AttestationTableType = {
   id: number;
@@ -66,8 +67,6 @@ const AttestationsTable = ({
       return a.user.id !== userData?.id;
     },
   );
-
-  console.log('nonUserContributions', nonUserContributions);
 
   const unattestedContributions = _.filter(nonUserContributions, function (a) {
     return a.attestations?.every(b => b.user_id !== userData?.id) ?? false;
@@ -133,7 +132,10 @@ const AttestationsTable = ({
           <IndeterminateCheckbox {...getToggleAllRowsSelectedProps()} />
         ),
         Cell: ({ row }: { row: Row<AttestationTableType> }) => (
-          <IndeterminateCheckbox {...row.getToggleRowSelectedProps()} />
+          <IndeterminateCheckbox
+            {...row.getToggleRowSelectedProps()}
+            disabled={row.original.status !== 'minted'}
+          />
         ),
       },
       ...columns,
@@ -164,55 +166,70 @@ const AttestationsTable = ({
   }, [selectedFlatRows, selectedRowIds]);
 
   return (
-    <Stack>
-      <GlobalFilter
-        preGlobalFilteredRows={preGlobalFilteredRows}
-        globalFilter={globalFilter}
-        setGlobalFilter={setGlobalFilter}
-      />
-      <Box width="100%" maxWidth="100vw" overflowX="auto">
-        <Table {...getTableProps()} maxWidth="100vw" overflowX="auto">
-          <Thead backgroundColor="gray.50">
-            {headerGroups.map((headerGroup: any) => (
-              <Tr {...headerGroup.getHeaderGroupProps()}>
-                {headerGroup.headers.map((column: any) => (
-                  <Th
-                    {...column.getHeaderProps(column.getSortByToggleProps())}
-                    isNumeric={column.isNumeric}
-                    borderColor="gray.100"
-                  >
-                    {column.render('Header')}
-                    <chakra.span paddingLeft="4">
-                      {column.isSorted ? (
-                        column.isSortedDesc ? (
-                          <IoArrowDown aria-label="sorted-descending" />
-                        ) : (
-                          <IoArrowUp aria-label="sorted-ascending" />
-                        )
-                      ) : null}
-                    </chakra.span>
-                  </Th>
+    <>
+      {unattestedContributions.length > 0 ? (
+        <Stack>
+          <GlobalFilter
+            preGlobalFilteredRows={preGlobalFilteredRows}
+            globalFilter={globalFilter}
+            setGlobalFilter={setGlobalFilter}
+          />
+          <Box width="100%" maxWidth="100vw" overflowX="auto">
+            <Table {...getTableProps()} maxWidth="100vw" overflowX="auto">
+              <Thead backgroundColor="gray.50">
+                {headerGroups.map((headerGroup: any) => (
+                  <Tr {...headerGroup.getHeaderGroupProps()}>
+                    {headerGroup.headers.map((column: any) => (
+                      <Th
+                        {...column.getHeaderProps(
+                          column.getSortByToggleProps(),
+                        )}
+                        isNumeric={column.isNumeric}
+                        borderColor="gray.100"
+                      >
+                        {column.render('Header')}
+                        <chakra.span paddingLeft="4">
+                          {column.isSorted ? (
+                            column.isSortedDesc ? (
+                              <IoArrowDown aria-label="sorted-descending" />
+                            ) : (
+                              <IoArrowUp aria-label="sorted-ascending" />
+                            )
+                          ) : null}
+                        </chakra.span>
+                      </Th>
+                    ))}
+                  </Tr>
                 ))}
-              </Tr>
-            ))}
-          </Thead>
-          <Tbody {...getTableBodyProps()}>
-            {rows.map(row => {
-              prepareRow(row);
-              return (
-                <Tr {...row.getRowProps()}>
-                  {row.cells.map(cell => (
-                    <Td {...cell.getCellProps()} borderColor="gray.100">
-                      {cell.render('Cell')}
-                    </Td>
-                  ))}
-                </Tr>
-              );
-            })}
-          </Tbody>
-        </Table>
-      </Box>
-    </Stack>
+              </Thead>
+              <Tbody {...getTableBodyProps()}>
+                {rows.map(row => {
+                  prepareRow(row);
+                  return (
+                    <Tr {...row.getRowProps()}>
+                      {row.cells.map(cell => (
+                        <Td {...cell.getCellProps()} borderColor="gray.100">
+                          {cell.render('Cell')}
+                        </Td>
+                      ))}
+                    </Tr>
+                  );
+                })}
+              </Tbody>
+            </Table>
+          </Box>
+        </Stack>
+      ) : (
+        <Box
+          paddingX={{ base: '4', md: '6' }}
+          paddingBottom={{ base: '4', md: '6' }}
+        >
+          <Text fontSize="sm" fontWeight="bolder">
+            None found!
+          </Text>
+        </Box>
+      )}
+    </>
   );
 };
 

--- a/apps/protocol-frontend/src/components/AttestationsTableShell.tsx
+++ b/apps/protocol-frontend/src/components/AttestationsTableShell.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import * as _ from 'lodash';
 import {
   Box,
   Button,

--- a/apps/protocol-frontend/src/components/AttestationsTableShell.tsx
+++ b/apps/protocol-frontend/src/components/AttestationsTableShell.tsx
@@ -70,8 +70,8 @@ const AttestationsTableShell = () => {
                             DAO Contributions
                           </Text>
                           <Text fontSize="md" fontWeight="normal">
-                            These are Contributions that you haven't already
-                            Attested to.
+                            These are minted Contributions that you haven't
+                            already Attested to.
                           </Text>
                         </Stack>
                         <Button
@@ -92,24 +92,6 @@ const AttestationsTableShell = () => {
                       contributionsData={daoContributions}
                       setSelectedContributions={setSelectedContributions}
                     />
-                    {/* <Box px={{ base: '4', md: '6' }} pb="5">
-                <HStack spacing="3" justify="space-between">
-                  {!isMobile && (
-                    <Text color="muted" fontSize="sm">
-                      Showing 1 to (x) of (y) results
-                    </Text>
-                  )}
-                  <ButtonGroup
-                    spacing="3"
-                    justifyContent="space-between"
-                    width={{ base: 'full', md: 'auto' }}
-                    variant="secondary"
-                  >
-                    <Button>Previous</Button>
-                    <Button>Next</Button>
-                  </ButtonGroup>
-                </HStack>
-              </Box> */}
                   </Stack>
                 </Box>
               </TabPanel>

--- a/apps/protocol-frontend/src/components/GlobalFilter.tsx
+++ b/apps/protocol-frontend/src/components/GlobalFilter.tsx
@@ -37,7 +37,7 @@ const GlobalFilter = ({
         </InputLeftElement>
         <Input
           placeholder={`Search ${rowCount} ${
-            rowCount > 1 ? 'Contributions' : 'Contribution'
+            rowCount === 1 ? 'Contribution' : 'Contributions'
           }`}
           value={value || ''}
           onChange={(e) => {

--- a/apps/protocol-frontend/src/components/MyAttestationsTable.tsx
+++ b/apps/protocol-frontend/src/components/MyAttestationsTable.tsx
@@ -45,8 +45,12 @@ const MyAttestationsTable = ({
 }) => {
   const { userData } = useUser();
 
+  const filteredMintedContributions = _.filter(contributionsData, function (a) {
+    return a.status.name === 'minted';
+  });
+
   const nonEmptyContributions = _.filter(
-    contributionsData,
+    filteredMintedContributions,
     a => a.attestations?.length > 0,
   );
 

--- a/apps/protocol-frontend/src/components/MyAttestationsTable.tsx
+++ b/apps/protocol-frontend/src/components/MyAttestationsTable.tsx
@@ -45,12 +45,8 @@ const MyAttestationsTable = ({
 }) => {
   const { userData } = useUser();
 
-  const filteredMintedContributions = _.filter(contributionsData, function (a) {
-    return a.status.name === 'minted';
-  });
-
   const nonEmptyContributions = _.filter(
-    filteredMintedContributions,
+    contributionsData,
     a => a.attestations?.length > 0,
   );
 


### PR DESCRIPTION
## Linear Ticket

- [PRO-374](https://linear.app/govrn/issue/PRO-374/remove-ability-to-attest-to-non-minted-contributions)

## Description

- Filters out non-minted Contributions so users can't Attest to them
- Small UX tweaks to make sure that there wasn't unexpected behavior -- the _My Attestations_ will remain unfiltered so users will see past Attestations

## Screencaptures

![filtered-minted](https://user-images.githubusercontent.com/9438776/186678700-03de00d6-c316-44ea-9854-3b09cd66e72d.jpg)

![filtered-minted-2](https://user-images.githubusercontent.com/9438776/186678710-9b992571-2aa6-47c9-882f-8b59241505b2.jpg)



