### PR TITLE
Link ActivityType to Its Creator

### DIFF
--- a/apps/protocol-api/src/main.ts
+++ b/apps/protocol-api/src/main.ts
@@ -79,6 +79,7 @@ const permissions = shield(
     Mutation: {
       '*': deny,
       createActivityType: hasToken,
+      getOrCreateActivityType: isAuthenticated,
       createContribution: hasToken,
       createGuild: hasToken,
       createGuildUser: or(isAuthenticated, hasToken),

--- a/apps/protocol-api/src/prisma/resolvers/ActivityType.ts
+++ b/apps/protocol-api/src/prisma/resolvers/ActivityType.ts
@@ -22,7 +22,7 @@ export class GetOrCreateActivityTypeArgs {
 }
 
 @TypeGraphQL.Resolver(_of => ActivityType)
-export class ActivityTypesCustomResolver {
+export class ActivityTypeCustomResolver {
   @TypeGraphQL.Mutation(_returns => ActivityType, { nullable: false })
   async getOrCreateActivityType(
     @TypeGraphQL.Ctx() { prisma }: Context,

--- a/apps/protocol-api/src/prisma/resolvers/ActivityType.ts
+++ b/apps/protocol-api/src/prisma/resolvers/ActivityType.ts
@@ -62,12 +62,11 @@ export class ActivityTypeCustomResolver {
           },
         },
       },
-    });
-
-    return await prisma.activityType.findUnique({
-      where: {
-        id: userActivityType.activity_type_id,
+      select: {
+        id: true,
+        activity_type: true,
       },
     });
+    return userActivityType.activity_type;
   }
 }

--- a/apps/protocol-api/src/prisma/resolvers/ActivityTypes.ts
+++ b/apps/protocol-api/src/prisma/resolvers/ActivityTypes.ts
@@ -1,0 +1,73 @@
+import * as TypeGraphQL from 'type-graphql';
+import { ActivityType } from '../generated/type-graphql';
+import { Context } from './types';
+
+@TypeGraphQL.InputType('GetOrCreateActivityTypeInput', {
+  isAbstract: true,
+})
+export class GetOrCreateActivityTypeInput {
+  @TypeGraphQL.Field(_type => String)
+  activityTypeName: string;
+
+  @TypeGraphQL.Field(_type => Number, { nullable: true })
+  userId?: number;
+}
+
+@TypeGraphQL.ArgsType()
+export class GetOrCreateActivityTypeArgs {
+  @TypeGraphQL.Field(_type => GetOrCreateActivityTypeInput, {
+    nullable: false,
+  })
+  data!: GetOrCreateActivityTypeInput;
+}
+
+@TypeGraphQL.Resolver(_of => ActivityType)
+export class ActivityTypesCustomResolver {
+  @TypeGraphQL.Mutation(_returns => ActivityType, { nullable: false })
+  async getOrCreateActivityType(
+    @TypeGraphQL.Ctx() { prisma }: Context,
+    @TypeGraphQL.Args() args: GetOrCreateActivityTypeArgs,
+  ) {
+    const activityType = await prisma.activityType.findUnique({
+      where: {
+        name: args.data.activityTypeName,
+      },
+    });
+
+    // ActivityType with the provided name already exists.
+    if (activityType) return activityType;
+
+    // if no user's id provided, create only ActivityType.
+    if (!args.data.userId) {
+      return prisma.activityType.create({
+        data: { name: args.data.activityTypeName },
+      });
+    }
+
+    const userActivityType = await prisma.userActivity.create({
+      data: {
+        activity_type: {
+          connectOrCreate: {
+            create: {
+              name: args.data.activityTypeName,
+            },
+            where: {
+              name: args.data.activityTypeName,
+            },
+          },
+        },
+        user: {
+          connect: {
+            id: args.data.userId,
+          },
+        },
+      },
+    });
+
+    return await prisma.activityType.findUnique({
+      where: {
+        id: userActivityType.activity_type_id,
+      },
+    });
+  }
+}

--- a/apps/protocol-api/src/prisma/resolvers/Contribution.ts
+++ b/apps/protocol-api/src/prisma/resolvers/Contribution.ts
@@ -25,8 +25,8 @@ export class UserContributionCreateInput {
   @TypeGraphQL.Field(_type => String)
   proof: string;
 
-  @TypeGraphQL.Field(_type => String)
-  activityTypeName: string;
+  @TypeGraphQL.Field(_type => Number)
+  activityTypeId: number;
 
   @TypeGraphQL.Field(_type => Date)
   dateOfEngagement: Date;
@@ -262,13 +262,8 @@ export class ContributionCustomResolver {
         details: args.data.details,
         proof: args.data.proof,
         activity_type: {
-          connectOrCreate: {
-            create: {
-              name: args.data.activityTypeName,
-            },
-            where: {
-              name: args.data.activityTypeName,
-            },
+          connect: {
+            id: args.data.activityTypeId,
           },
         },
         date_of_engagement: new Date(args.data.dateOfEngagement).toISOString(),

--- a/apps/protocol-api/src/prisma/resolvers/index.ts
+++ b/apps/protocol-api/src/prisma/resolvers/index.ts
@@ -1,8 +1,10 @@
+import { ActivityTypesCustomResolver } from './ActivityTypes';
 import { AttestationResolver } from './Attestation';
 import { ContributionCustomResolver } from './Contribution';
 import { UserCustomResolver } from './User';
 
 export const customResolvers = [
+  ActivityTypesCustomResolver,
   AttestationResolver,
   ContributionCustomResolver,
   UserCustomResolver,

--- a/apps/protocol-api/src/prisma/resolvers/index.ts
+++ b/apps/protocol-api/src/prisma/resolvers/index.ts
@@ -1,10 +1,10 @@
-import { ActivityTypesCustomResolver } from './ActivityTypes';
+import { ActivityTypeCustomResolver } from './ActivityType';
 import { AttestationResolver } from './Attestation';
 import { ContributionCustomResolver } from './Contribution';
 import { UserCustomResolver } from './User';
 
 export const customResolvers = [
-  ActivityTypesCustomResolver,
+  ActivityTypeCustomResolver,
   AttestationResolver,
   ContributionCustomResolver,
   UserCustomResolver,

--- a/libs/protocol-client/src/lib/client/custom.ts
+++ b/libs/protocol-client/src/lib/client/custom.ts
@@ -16,6 +16,12 @@ export class Custom extends BaseClient {
   }
 
   public async createUserContribution(args: UserContributionCreateInput) {
+    await this.sdk.getOrCreateActivityType({
+      data: {
+        activityTypeName: args.activityTypeName,
+        userId: args.userId,
+      },
+    });
     const contribution = await this.sdk.createUserContribution({ data: args });
     return contribution.createUserContribution;
   }

--- a/libs/protocol-client/src/lib/client/custom.ts
+++ b/libs/protocol-client/src/lib/client/custom.ts
@@ -7,6 +7,13 @@ import {
   GetUserContributionCountInput,
 } from '../protocol-types';
 
+type CreateUserContributionCreateInput = Omit<
+  UserContributionCreateInput,
+  'activityTypeId'
+> & {
+  activityTypeName: string;
+};
+
 // get accounts
 // bulk create
 export class Custom extends BaseClient {
@@ -15,14 +22,19 @@ export class Custom extends BaseClient {
     return attestation.createUserAttestation;
   }
 
-  public async createUserContribution(args: UserContributionCreateInput) {
-    await this.sdk.getOrCreateActivityType({
-      data: {
-        activityTypeName: args.activityTypeName,
-        userId: args.userId,
-      },
+  public async createUserContribution(args: CreateUserContributionCreateInput) {
+    const activityType = (
+      await this.sdk.getOrCreateActivityType({
+        data: {
+          activityTypeName: args.activityTypeName,
+          userId: args.userId,
+        },
+      })
+    ).getOrCreateActivityType;
+
+    const contribution = await this.sdk.createUserContribution({
+      data: { ...args, activityTypeId: activityType.id },
     });
-    const contribution = await this.sdk.createUserContribution({ data: args });
     return contribution.createUserContribution;
   }
 

--- a/libs/protocol-client/src/lib/graphql/queries.graphql
+++ b/libs/protocol-client/src/lib/graphql/queries.graphql
@@ -531,6 +531,12 @@ mutation createActivityType($data: ActivityTypeCreateInput!) {
   }
 }
 
+mutation getOrCreateActivityType($data: GetOrCreateActivityTypeInput!) {
+  getOrCreateActivityType(data: $data) {
+    ...ActivityTypeFragment
+  }
+}
+
 mutation upsertActivityType(
   $create: ActivityTypeCreateInput!
   $update: ActivityTypeUpdateInput!

--- a/libs/protocol-client/src/lib/protocol-types.ts
+++ b/libs/protocol-client/src/lib/protocol-types.ts
@@ -2265,7 +2265,7 @@ export type ContributionCountByDate = {
   count: Scalars['Float'];
   date: Scalars['String'];
   guild_id?: Maybe<Scalars['Float']>;
-  name?: Maybe<Scalars['String']>;
+  name: Scalars['String'];
 };
 
 export type ContributionCountOrderByAggregateInput = {
@@ -3779,6 +3779,11 @@ export type FloatNullableWithAggregatesFilter = {
   lte?: InputMaybe<Scalars['Float']>;
   not?: InputMaybe<NestedFloatNullableWithAggregatesFilter>;
   notIn?: InputMaybe<Array<Scalars['Float']>>;
+};
+
+export type GetOrCreateActivityTypeInput = {
+  activityTypeName: Scalars['String'];
+  userId?: InputMaybe<Scalars['Float']>;
 };
 
 export type GetUserContributionCountInput = {
@@ -8418,6 +8423,7 @@ export type Mutation = {
   deleteUser?: Maybe<User>;
   deleteUserActivity?: Maybe<UserActivity>;
   deleteUserContribution: Contribution;
+  getOrCreateActivityType: ActivityType;
   updateActivityType?: Maybe<ActivityType>;
   updateAttestation?: Maybe<Attestation>;
   updateAttestationConfidence?: Maybe<AttestationConfidence>;
@@ -9052,6 +9058,11 @@ export type MutationDeleteUserActivityArgs = {
 
 export type MutationDeleteUserContributionArgs = {
   where: UserContributionDeleteInput;
+};
+
+
+export type MutationGetOrCreateActivityTypeArgs = {
+  data: GetOrCreateActivityTypeInput;
 };
 
 
@@ -14098,7 +14109,7 @@ export type GetContributionCountByDateForUserInRangeQueryVariables = Exact<{
 }>;
 
 
-export type GetContributionCountByDateForUserInRangeQuery = { result: Array<{ count: number, date: string, guild_id?: number | null, name?: string | null }> };
+export type GetContributionCountByDateForUserInRangeQuery = { result: Array<{ count: number, date: string, guild_id?: number | null, name: string }> };
 
 export type CreateContributionMutationVariables = Exact<{
   data: ContributionCreateInput;
@@ -14183,6 +14194,13 @@ export type CreateActivityTypeMutationVariables = Exact<{
 
 
 export type CreateActivityTypeMutation = { createActivityType: { active: boolean, createdAt: string | Date, id: number, name: string, updatedAt: string | Date } };
+
+export type GetOrCreateActivityTypeMutationVariables = Exact<{
+  data: GetOrCreateActivityTypeInput;
+}>;
+
+
+export type GetOrCreateActivityTypeMutation = { getOrCreateActivityType: { active: boolean, createdAt: string | Date, id: number, name: string, updatedAt: string | Date } };
 
 export type UpsertActivityTypeMutationVariables = Exact<{
   create: ActivityTypeCreateInput;
@@ -14824,6 +14842,13 @@ export const CreateActivityTypeDocument = gql`
   }
 }
     ${ActivityTypeFragmentFragmentDoc}`;
+export const GetOrCreateActivityTypeDocument = gql`
+    mutation getOrCreateActivityType($data: GetOrCreateActivityTypeInput!) {
+  getOrCreateActivityType(data: $data) {
+    ...ActivityTypeFragment
+  }
+}
+    ${ActivityTypeFragmentFragmentDoc}`;
 export const UpsertActivityTypeDocument = gql`
     mutation upsertActivityType($create: ActivityTypeCreateInput!, $update: ActivityTypeUpdateInput!, $where: ActivityTypeWhereUniqueInput!) {
   upsertActivityType(create: $create, update: $update, where: $where) {
@@ -15026,6 +15051,9 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     },
     createActivityType(variables: CreateActivityTypeMutationVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<CreateActivityTypeMutation> {
       return withWrapper((wrappedRequestHeaders) => client.request<CreateActivityTypeMutation>(CreateActivityTypeDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'createActivityType', 'mutation');
+    },
+    getOrCreateActivityType(variables: GetOrCreateActivityTypeMutationVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<GetOrCreateActivityTypeMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<GetOrCreateActivityTypeMutation>(GetOrCreateActivityTypeDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getOrCreateActivityType', 'mutation');
     },
     upsertActivityType(variables: UpsertActivityTypeMutationVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<UpsertActivityTypeMutation> {
       return withWrapper((wrappedRequestHeaders) => client.request<UpsertActivityTypeMutation>(UpsertActivityTypeDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'upsertActivityType', 'mutation');

--- a/libs/protocol-client/src/lib/protocol-types.ts
+++ b/libs/protocol-client/src/lib/protocol-types.ts
@@ -12879,7 +12879,7 @@ export type UserAvgOrderByAggregateInput = {
 };
 
 export type UserContributionCreateInput = {
-  activityTypeName: Scalars['String'];
+  activityTypeId: Scalars['Float'];
   address: Scalars['String'];
   chainName: Scalars['String'];
   dateOfEngagement: Scalars['DateTime'];


### PR DESCRIPTION
## Linear Ticket

[PRO-403 - Reporting Contribution doesn't link the ActivityTypes to its Creator/Guild](https://linear.app/govrn/issue/PRO-403/reporting-contribution-doesnt-link-the-activitytypes-to-its)

## Description

When creating a new `ActivityType`, it updates or link this to its creator by updating `UserActivity` Table. 

A new `getOrCreateActivityType` custom mutation has been added to handle creating `ActivityType`s. 

