### PR TITLE
feature/attesation-feed-user-daos-pro-362

### DIFF
--- a/apps/protocol-frontend/src/components/AttestationsTable.tsx
+++ b/apps/protocol-frontend/src/components/AttestationsTable.tsx
@@ -41,6 +41,7 @@ type AttestationTableType = {
   guilds?: {
     guild: {
       name?: string | null;
+      guild_id?: number;
     };
   }[];
   action?: ReactNode;
@@ -57,11 +58,11 @@ const AttestationsTable = ({
 }) => {
   const { userData } = useUser();
 
-  const userDaosIds = userData?.guild_users.map(guild => {
+  const userDaoIds = userData?.guild_users.map(guild => {
     return guild.guild_id;
   });
 
-  console.log('userdaos', userDaosIds);
+  console.log('userdaos', userDaoIds);
 
   const filteredMintedContributions = _.filter(contributionsData, function (a) {
     return a.status.name === 'minted';
@@ -81,11 +82,19 @@ const AttestationsTable = ({
     },
   );
 
-  console.log('attributedDaoContributions', attributedDaoContributions);
+  const userDaoContributions = _.filter(nonUserContributions, function (a) {
+    // if (userDaoIds) {
+    return a.guilds.some(guild => userDaoIds?.includes(guild.guild_id));
+    // }
+  });
+  console.log('userdao', userDaoContributions);
 
-  const unattestedContributions = _.filter(nonUserContributions, function (a) {
+  const unattestedContributions = _.filter(userDaoContributions, function (a) {
     return a.attestations?.every(b => b.user_id !== userData?.id) ?? false;
   });
+
+  console.log('attributedDaoContributions', attributedDaoContributions);
+  console.log('user dao contributions', userDaoContributions);
 
   const data = useMemo<AttestationTableType[]>(
     () =>
@@ -94,7 +103,6 @@ const AttestationsTable = ({
         date_of_submission: contribution.date_of_submission,
         date_of_engagement: contribution.date_of_submission,
         attestations: contribution.attestations,
-        // guilds: contribution.guilds,
         guilds:
           contribution.guilds.map((guildObj: any) => guildObj.guild.name)[0] ??
           '---',

--- a/apps/protocol-frontend/src/components/AttestationsTable.tsx
+++ b/apps/protocol-frontend/src/components/AttestationsTable.tsx
@@ -57,6 +57,12 @@ const AttestationsTable = ({
 }) => {
   const { userData } = useUser();
 
+  const userDaosIds = userData?.guild_users.map(guild => {
+    return guild.guild_id;
+  });
+
+  console.log('userdaos', userDaosIds);
+
   const filteredMintedContributions = _.filter(contributionsData, function (a) {
     return a.status.name === 'minted';
   });
@@ -68,11 +74,18 @@ const AttestationsTable = ({
     },
   );
 
+  const attributedDaoContributions = _.filter(
+    nonUserContributions,
+    function (a) {
+      return a.guilds.length !== 0;
+    },
+  );
+
+  console.log('attributedDaoContributions', attributedDaoContributions);
+
   const unattestedContributions = _.filter(nonUserContributions, function (a) {
     return a.attestations?.every(b => b.user_id !== userData?.id) ?? false;
   });
-
-  console.log('unattestedContributions', unattestedContributions);
 
   const data = useMemo<AttestationTableType[]>(
     () =>
@@ -82,7 +95,7 @@ const AttestationsTable = ({
         date_of_engagement: contribution.date_of_submission,
         attestations: contribution.attestations,
         // guilds: contribution.guilds,
-        guildName:
+        guilds:
           contribution.guilds.map((guildObj: any) => guildObj.guild.name)[0] ??
           '---',
         status: contribution.status.name,
@@ -127,7 +140,7 @@ const AttestationsTable = ({
       },
       {
         Header: 'DAOs',
-        accessor: 'guildName',
+        accessor: 'guilds',
       },
     ],
     [],

--- a/apps/protocol-frontend/src/components/AttestationsTable.tsx
+++ b/apps/protocol-frontend/src/components/AttestationsTable.tsx
@@ -81,7 +81,10 @@ const AttestationsTable = ({
         date_of_submission: contribution.date_of_submission,
         date_of_engagement: contribution.date_of_submission,
         attestations: contribution.attestations,
-        guilds: contribution.guilds,
+        // guilds: contribution.guilds,
+        guildName:
+          contribution.guilds.map((guildObj: any) => guildObj.guild.name)[0] ??
+          '---',
         status: contribution.status.name,
         action: '',
         name: contribution.name,
@@ -121,6 +124,10 @@ const AttestationsTable = ({
       {
         Header: 'Contributor',
         accessor: 'contributor',
+      },
+      {
+        Header: 'DAOs',
+        accessor: 'guildName',
       },
     ],
     [],

--- a/apps/protocol-frontend/src/components/AttestationsTable.tsx
+++ b/apps/protocol-frontend/src/components/AttestationsTable.tsx
@@ -72,6 +72,8 @@ const AttestationsTable = ({
     return a.attestations?.every(b => b.user_id !== userData?.id) ?? false;
   });
 
+  console.log('unattestedContributions', unattestedContributions);
+
   const data = useMemo<AttestationTableType[]>(
     () =>
       unattestedContributions.map(contribution => ({

--- a/apps/protocol-frontend/src/components/AttestationsTable.tsx
+++ b/apps/protocol-frontend/src/components/AttestationsTable.tsx
@@ -61,16 +61,10 @@ const AttestationsTable = ({
 }) => {
   const { userData } = useUser();
   const [showAllDaos, setShowAllDaos] = useState(false);
-  const [displayedContributions, setDisplayedContributions] = useState<
-    UIContribution[]
-  >([]);
 
   const userDaoIds = userData?.guild_users.map(guild => {
     return guild.guild_id;
   });
-
-  console.log('userdaos', userDaoIds);
-
   const filteredMintedContributions = _.filter(contributionsData, function (a) {
     return a.status.name === 'minted';
   });
@@ -90,13 +84,10 @@ const AttestationsTable = ({
   );
 
   const userDaoContributions = _.filter(nonUserContributions, function (a) {
-    // if (userDaoIds) {
     return a.guilds.some(guild => userDaoIds?.includes(guild.guild_id));
-    // }
   });
-  console.log('userdao', userDaoContributions);
 
-  const unattestedDaoContributions = _.filter(
+  const unattestedUserDaoContributions = _.filter(
     userDaoContributions,
     function (a) {
       return a.attestations?.every(b => b.user_id !== userData?.id) ?? false;
@@ -107,12 +98,22 @@ const AttestationsTable = ({
     return a.attestations?.every(b => b.user_id !== userData?.id) ?? false;
   });
 
-  console.log('attributedDaoContributions', attributedDaoContributions);
-  console.log('user dao contributions', userDaoContributions);
+  const [displayedContributions, setDisplayedContributions] =
+    useState(userDaoContributions);
 
   const toggleShowAllDaos = () => {
     setShowAllDaos(!showAllDaos);
   };
+
+  useEffect(() => {
+    if (showAllDaos === false) {
+      console.log('setting to user daos', unattestedUserDaoContributions);
+      setDisplayedContributions(unattestedUserDaoContributions);
+    } else {
+      console.log('setting to all daos', unattestedContributions);
+      setDisplayedContributions(unattestedContributions);
+    }
+  }, [showAllDaos]);
 
   function AllDaosSwitch({
     isChecked,
@@ -164,7 +165,7 @@ const AttestationsTable = ({
         onChainId: contribution.on_chain_id,
         contributor: contribution.user.name,
       })),
-    [contributionsData],
+    [displayedContributions],
   );
 
   const columns = useMemo<Column<AttestationTableType>[]>(

--- a/apps/protocol-frontend/src/components/AttestationsTable.tsx
+++ b/apps/protocol-frontend/src/components/AttestationsTable.tsx
@@ -65,6 +65,7 @@ const AttestationsTable = ({
   const userDaoIds = userData?.guild_users.map(guild => {
     return guild.guild_id;
   });
+
   const filteredMintedContributions = _.filter(contributionsData, function (a) {
     return a.status.name === 'minted';
   });
@@ -73,13 +74,6 @@ const AttestationsTable = ({
     filteredMintedContributions,
     function (a) {
       return a.user.id !== userData?.id;
-    },
-  );
-
-  const attributedDaoContributions = _.filter(
-    nonUserContributions,
-    function (a) {
-      return a.guilds.length !== 0;
     },
   );
 
@@ -107,10 +101,8 @@ const AttestationsTable = ({
 
   useEffect(() => {
     if (showAllDaos === false) {
-      console.log('setting to user daos', unattestedUserDaoContributions);
       setDisplayedContributions(unattestedUserDaoContributions);
     } else {
-      console.log('setting to all daos', unattestedContributions);
       setDisplayedContributions(unattestedContributions);
     }
   }, [showAllDaos]);

--- a/apps/protocol-frontend/src/components/AttestationsTable.tsx
+++ b/apps/protocol-frontend/src/components/AttestationsTable.tsx
@@ -1,9 +1,12 @@
-import { useEffect, useMemo, ReactNode } from 'react';
+import { useEffect, useMemo, useState, ReactNode } from 'react';
 import * as _ from 'lodash';
 import {
   Box,
   chakra,
+  Flex,
+  FormLabel,
   Stack,
+  Switch,
   Table,
   Tbody,
   Td,
@@ -57,6 +60,10 @@ const AttestationsTable = ({
   setSelectedContributions: (contrs: any[]) => void;
 }) => {
   const { userData } = useUser();
+  const [showAllDaos, setShowAllDaos] = useState(false);
+  const [displayedContributions, setDisplayedContributions] = useState<
+    UIContribution[]
+  >([]);
 
   const userDaoIds = userData?.guild_users.map(guild => {
     return guild.guild_id;
@@ -89,16 +96,61 @@ const AttestationsTable = ({
   });
   console.log('userdao', userDaoContributions);
 
-  const unattestedContributions = _.filter(userDaoContributions, function (a) {
+  const unattestedDaoContributions = _.filter(
+    userDaoContributions,
+    function (a) {
+      return a.attestations?.every(b => b.user_id !== userData?.id) ?? false;
+    },
+  );
+
+  const unattestedContributions = _.filter(nonUserContributions, function (a) {
     return a.attestations?.every(b => b.user_id !== userData?.id) ?? false;
   });
 
   console.log('attributedDaoContributions', attributedDaoContributions);
   console.log('user dao contributions', userDaoContributions);
 
+  const toggleShowAllDaos = () => {
+    setShowAllDaos(!showAllDaos);
+  };
+
+  function AllDaosSwitch({
+    isChecked,
+    onChange,
+  }: {
+    isChecked: boolean;
+    onChange: () => void;
+  }) {
+    return (
+      <Flex
+        marginX={1}
+        alignItems="center"
+        justifyContent="center"
+        alignSelf="flex-start"
+      >
+        <FormLabel
+          fontSize="sm"
+          fontWeight="md"
+          color="gray.800"
+          margin={2}
+          htmlFor="show-all-daos"
+        >
+          Show All DAOs
+        </FormLabel>
+        <Switch
+          id="show-all-daos"
+          size="sm"
+          colorScheme={'brand.primary'}
+          isChecked={isChecked}
+          onChange={onChange}
+        />
+      </Flex>
+    );
+  }
+
   const data = useMemo<AttestationTableType[]>(
     () =>
-      unattestedContributions.map(contribution => ({
+      displayedContributions.map(contribution => ({
         id: contribution.id,
         date_of_submission: contribution.date_of_submission,
         date_of_engagement: contribution.date_of_submission,
@@ -197,13 +249,19 @@ const AttestationsTable = ({
 
   return (
     <>
-      {unattestedContributions.length > 0 ? (
+      {displayedContributions.length > 0 ? (
         <Stack>
-          <GlobalFilter
-            preGlobalFilteredRows={preGlobalFilteredRows}
-            globalFilter={globalFilter}
-            setGlobalFilter={setGlobalFilter}
-          />
+          <Flex alignItems="center">
+            <GlobalFilter
+              preGlobalFilteredRows={preGlobalFilteredRows}
+              globalFilter={globalFilter}
+              setGlobalFilter={setGlobalFilter}
+            />
+            <AllDaosSwitch
+              isChecked={showAllDaos}
+              onChange={() => toggleShowAllDaos()}
+            />
+          </Flex>
           <Box width="100%" maxWidth="100vw" overflowX="auto">
             <Table {...getTableProps()} maxWidth="100vw" overflowX="auto">
               <Thead backgroundColor="gray.50">

--- a/apps/protocol-frontend/src/components/ReportForm.tsx
+++ b/apps/protocol-frontend/src/components/ReportForm.tsx
@@ -186,17 +186,19 @@ const ReportForm = ({ onFinish }: { onFinish: () => void }) => {
                 backgroundColor="brand.primary.50"
                 transition="all 100ms ease-in-out"
                 _hover={{ bgColor: 'brand.primary.100' }}
-                isLoading={isCreatingContribution}>
-              Add Contribution
-            </Button>
-          </Flex>
+                isLoading={isCreatingContribution}
+              >
+                Add Contribution
+              </Button>
+            </Flex>
 
-          <CreateMoreSwitch
-            isChecked={isUserCreatingMore}
-            onChange={() => toggleCreateMoreSwitch()}
-          />
-        </form>
-      </FormProvider>)}
+            <CreateMoreSwitch
+              isChecked={isUserCreatingMore}
+              onChange={() => toggleCreateMoreSwitch()}
+            />
+          </form>
+        </FormProvider>
+      )}
     </Stack>
   );
 };

--- a/apps/protocol-frontend/src/contexts/UserContext.tsx
+++ b/apps/protocol-frontend/src/contexts/UserContext.tsx
@@ -110,6 +110,10 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
       }
       const userDataResponse = await govrn.user.get(userDataByAddress?.id);
       console.log('userDataResponse', userDataResponse);
+      const userDaosIds = userDataResponse?.guild_users.map(guild => {
+        return guild.guild_id;
+      });
+      console.log('userDaosIds', userDaosIds);
       setUserData(userDataResponse);
       return userDataResponse;
     } catch (error) {

--- a/apps/protocol-frontend/src/contexts/UserContext.tsx
+++ b/apps/protocol-frontend/src/contexts/UserContext.tsx
@@ -109,7 +109,6 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
         throw new Error('No address for user');
       }
       const userDataResponse = await govrn.user.get(userDataByAddress?.id);
-      console.log('userDataResponse', userDataResponse);
       const userDaosIds = userDataResponse?.guild_users.map(guild => {
         return guild.guild_id;
       });

--- a/apps/protocol-frontend/src/contexts/UserContext.tsx
+++ b/apps/protocol-frontend/src/contexts/UserContext.tsx
@@ -109,10 +109,10 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
         throw new Error('No address for user');
       }
       const userDataResponse = await govrn.user.get(userDataByAddress?.id);
-      const userDaosIds = userDataResponse?.guild_users.map(guild => {
-        return guild.guild_id;
-      });
-      console.log('userDaosIds', userDaosIds);
+      // const userDaosIds = userDataResponse?.guild_users.map(guild => {
+      //   return guild.guild_id;
+      // });
+      // console.log('userDaosIds', userDaosIds);
       setUserData(userDataResponse);
       return userDataResponse;
     } catch (error) {

--- a/apps/protocol-frontend/src/contexts/UserContext.tsx
+++ b/apps/protocol-frontend/src/contexts/UserContext.tsx
@@ -109,10 +109,9 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
         throw new Error('No address for user');
       }
       const userDataResponse = await govrn.user.get(userDataByAddress?.id);
-      // const userDaosIds = userDataResponse?.guild_users.map(guild => {
-      //   return guild.guild_id;
-      // });
-      // console.log('userDaosIds', userDaosIds);
+      const userDaos = userDataResponse?.guild_users.map(guild => {
+        return guild;
+      });
       setUserData(userDataResponse);
       return userDataResponse;
     } catch (error) {

--- a/apps/protocol-frontend/src/contexts/UserContext.tsx
+++ b/apps/protocol-frontend/src/contexts/UserContext.tsx
@@ -109,7 +109,7 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
         throw new Error('No address for user');
       }
       const userDataResponse = await govrn.user.get(userDataByAddress?.id);
-
+      console.log('userDataResponse', userDataResponse);
       setUserData(userDataResponse);
       return userDataResponse;
     } catch (error) {

--- a/libs/protocol-client/src/lib/graphql/queries.graphql
+++ b/libs/protocol-client/src/lib/graphql/queries.graphql
@@ -397,6 +397,8 @@ fragment ContributionFragment on Contribution {
     }
   }
   guilds {
+    id
+    guild_id
     guild {
       id
       name

--- a/libs/protocol-client/src/lib/graphql/queries.graphql
+++ b/libs/protocol-client/src/lib/graphql/queries.graphql
@@ -295,6 +295,11 @@ fragment UserFragment on User {
     id
     active_token
   }
+  guild_users {
+    id
+    user_id
+    guild_id
+  }
 }
 
 query getUser($where: UserWhereUniqueInput!) {

--- a/libs/protocol-client/src/lib/protocol-types.ts
+++ b/libs/protocol-client/src/lib/protocol-types.ts
@@ -2265,7 +2265,7 @@ export type ContributionCountByDate = {
   count: Scalars['Float'];
   date: Scalars['String'];
   guild_id?: Maybe<Scalars['Float']>;
-  name?: Maybe<Scalars['String']>;
+  name: Scalars['String'];
 };
 
 export type ContributionCountOrderByAggregateInput = {
@@ -13979,7 +13979,7 @@ export type ListGuildsQueryVariables = Exact<{
 
 export type ListGuildsQuery = { result: Array<{ congrats_channel?: string | null, createdAt: string | Date, discord_id?: string | null, id: number, logo?: string | null, name?: string | null, updatedAt: string | Date, contribution_reporting_channel?: string | null, status: GuildStatus }> };
 
-export type TwitterTweetFragmentFragment = { id: number, updatedAt: string | Date, createdAt: string | Date, text: string, twitter_tweet_id: number, twitter_user?: { id: number, name?: string | null, createdAt: string | Date, updatedAt: string | Date, username: string } | null, contribution?: { date_of_engagement: string | Date, date_of_submission: string | Date, details?: string | null, id: number, name: string, proof?: string | null, updatedAt: string | Date, on_chain_id?: number | null, tx_hash?: string | null, activity_type: { active: boolean, createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, status: { createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, user: { address: string, createdAt: string | Date, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: string | Date }, attestations: Array<{ id: number, user_id: number, date_of_attestation: string | Date, user: { name?: string | null, address: string, id: number } }>, guilds: Array<{ guild: { id: number, name?: string | null } }> } | null };
+export type TwitterTweetFragmentFragment = { id: number, updatedAt: string | Date, createdAt: string | Date, text: string, twitter_tweet_id: number, twitter_user?: { id: number, name?: string | null, createdAt: string | Date, updatedAt: string | Date, username: string } | null, contribution?: { date_of_engagement: string | Date, date_of_submission: string | Date, details?: string | null, id: number, name: string, proof?: string | null, updatedAt: string | Date, on_chain_id?: number | null, tx_hash?: string | null, activity_type: { active: boolean, createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, status: { createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, user: { address: string, createdAt: string | Date, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: string | Date }, attestations: Array<{ id: number, user_id: number, date_of_attestation: string | Date, user: { name?: string | null, address: string, id: number } }>, guilds: Array<{ id: number, guild_id: number, guild: { id: number, name?: string | null } }> } | null };
 
 export type BulkCreateTwitterTweetMutationVariables = Exact<{
   data: Array<TwitterTweetCreateManyInput> | TwitterTweetCreateManyInput;
@@ -14074,14 +14074,14 @@ export type CreateUserCustomMutationVariables = Exact<{
 
 export type CreateUserCustomMutation = { createUserCustom: { address: string, active: boolean, createdAt: string | Date, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: string | Date, chain_type: { id: number, name: string, createdAt: string | Date, updatedAt: string | Date }, linear_users: Array<{ id: number, active_token?: boolean | null }>, guild_users: Array<{ id: number, user_id: number, guild_id: number }> } };
 
-export type ContributionFragmentFragment = { date_of_engagement: string | Date, date_of_submission: string | Date, details?: string | null, id: number, name: string, proof?: string | null, updatedAt: string | Date, on_chain_id?: number | null, tx_hash?: string | null, activity_type: { active: boolean, createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, status: { createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, user: { address: string, createdAt: string | Date, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: string | Date }, attestations: Array<{ id: number, user_id: number, date_of_attestation: string | Date, user: { name?: string | null, address: string, id: number } }>, guilds: Array<{ guild: { id: number, name?: string | null } }> };
+export type ContributionFragmentFragment = { date_of_engagement: string | Date, date_of_submission: string | Date, details?: string | null, id: number, name: string, proof?: string | null, updatedAt: string | Date, on_chain_id?: number | null, tx_hash?: string | null, activity_type: { active: boolean, createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, status: { createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, user: { address: string, createdAt: string | Date, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: string | Date }, attestations: Array<{ id: number, user_id: number, date_of_attestation: string | Date, user: { name?: string | null, address: string, id: number } }>, guilds: Array<{ id: number, guild_id: number, guild: { id: number, name?: string | null } }> };
 
 export type GetContributionQueryVariables = Exact<{
   where: ContributionWhereUniqueInput;
 }>;
 
 
-export type GetContributionQuery = { result?: { date_of_engagement: string | Date, date_of_submission: string | Date, details?: string | null, id: number, name: string, proof?: string | null, updatedAt: string | Date, on_chain_id?: number | null, tx_hash?: string | null, activity_type: { active: boolean, createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, status: { createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, user: { address: string, createdAt: string | Date, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: string | Date }, attestations: Array<{ id: number, user_id: number, date_of_attestation: string | Date, user: { name?: string | null, address: string, id: number } }>, guilds: Array<{ guild: { id: number, name?: string | null } }> } | null };
+export type GetContributionQuery = { result?: { date_of_engagement: string | Date, date_of_submission: string | Date, details?: string | null, id: number, name: string, proof?: string | null, updatedAt: string | Date, on_chain_id?: number | null, tx_hash?: string | null, activity_type: { active: boolean, createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, status: { createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, user: { address: string, createdAt: string | Date, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: string | Date }, attestations: Array<{ id: number, user_id: number, date_of_attestation: string | Date, user: { name?: string | null, address: string, id: number } }>, guilds: Array<{ id: number, guild_id: number, guild: { id: number, name?: string | null } }> } | null };
 
 export type ListContributionsQueryVariables = Exact<{
   where?: ContributionWhereInput;
@@ -14091,35 +14091,35 @@ export type ListContributionsQueryVariables = Exact<{
 }>;
 
 
-export type ListContributionsQuery = { result: Array<{ date_of_engagement: string | Date, date_of_submission: string | Date, details?: string | null, id: number, name: string, proof?: string | null, updatedAt: string | Date, on_chain_id?: number | null, tx_hash?: string | null, activity_type: { active: boolean, createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, status: { createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, user: { address: string, createdAt: string | Date, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: string | Date }, attestations: Array<{ id: number, user_id: number, date_of_attestation: string | Date, user: { name?: string | null, address: string, id: number } }>, guilds: Array<{ guild: { id: number, name?: string | null } }> }> };
+export type ListContributionsQuery = { result: Array<{ date_of_engagement: string | Date, date_of_submission: string | Date, details?: string | null, id: number, name: string, proof?: string | null, updatedAt: string | Date, on_chain_id?: number | null, tx_hash?: string | null, activity_type: { active: boolean, createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, status: { createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, user: { address: string, createdAt: string | Date, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: string | Date }, attestations: Array<{ id: number, user_id: number, date_of_attestation: string | Date, user: { name?: string | null, address: string, id: number } }>, guilds: Array<{ id: number, guild_id: number, guild: { id: number, name?: string | null } }> }> };
 
 export type GetContributionCountByDateForUserInRangeQueryVariables = Exact<{
   where: GetUserContributionCountInput;
 }>;
 
 
-export type GetContributionCountByDateForUserInRangeQuery = { result: Array<{ count: number, date: string, guild_id?: number | null, name?: string | null }> };
+export type GetContributionCountByDateForUserInRangeQuery = { result: Array<{ count: number, date: string, guild_id?: number | null, name: string }> };
 
 export type CreateContributionMutationVariables = Exact<{
   data: ContributionCreateInput;
 }>;
 
 
-export type CreateContributionMutation = { createContribution: { date_of_engagement: string | Date, date_of_submission: string | Date, details?: string | null, id: number, name: string, proof?: string | null, updatedAt: string | Date, on_chain_id?: number | null, tx_hash?: string | null, activity_type: { active: boolean, createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, status: { createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, user: { address: string, createdAt: string | Date, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: string | Date }, attestations: Array<{ id: number, user_id: number, date_of_attestation: string | Date, user: { name?: string | null, address: string, id: number } }>, guilds: Array<{ guild: { id: number, name?: string | null } }> } };
+export type CreateContributionMutation = { createContribution: { date_of_engagement: string | Date, date_of_submission: string | Date, details?: string | null, id: number, name: string, proof?: string | null, updatedAt: string | Date, on_chain_id?: number | null, tx_hash?: string | null, activity_type: { active: boolean, createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, status: { createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, user: { address: string, createdAt: string | Date, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: string | Date }, attestations: Array<{ id: number, user_id: number, date_of_attestation: string | Date, user: { name?: string | null, address: string, id: number } }>, guilds: Array<{ id: number, guild_id: number, guild: { id: number, name?: string | null } }> } };
 
 export type CreateUserContributionMutationVariables = Exact<{
   data: UserContributionCreateInput;
 }>;
 
 
-export type CreateUserContributionMutation = { createUserContribution: { date_of_engagement: string | Date, date_of_submission: string | Date, details?: string | null, id: number, name: string, proof?: string | null, updatedAt: string | Date, on_chain_id?: number | null, tx_hash?: string | null, activity_type: { active: boolean, createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, status: { createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, user: { address: string, createdAt: string | Date, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: string | Date }, attestations: Array<{ id: number, user_id: number, date_of_attestation: string | Date, user: { name?: string | null, address: string, id: number } }>, guilds: Array<{ guild: { id: number, name?: string | null } }> } };
+export type CreateUserContributionMutation = { createUserContribution: { date_of_engagement: string | Date, date_of_submission: string | Date, details?: string | null, id: number, name: string, proof?: string | null, updatedAt: string | Date, on_chain_id?: number | null, tx_hash?: string | null, activity_type: { active: boolean, createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, status: { createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, user: { address: string, createdAt: string | Date, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: string | Date }, attestations: Array<{ id: number, user_id: number, date_of_attestation: string | Date, user: { name?: string | null, address: string, id: number } }>, guilds: Array<{ id: number, guild_id: number, guild: { id: number, name?: string | null } }> } };
 
 export type CreateOnChainUserContributionMutationVariables = Exact<{
   data: UserOnChainContributionCreateInput;
 }>;
 
 
-export type CreateOnChainUserContributionMutation = { createOnChainUserContribution: { date_of_engagement: string | Date, date_of_submission: string | Date, details?: string | null, id: number, name: string, proof?: string | null, updatedAt: string | Date, on_chain_id?: number | null, tx_hash?: string | null, activity_type: { active: boolean, createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, status: { createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, user: { address: string, createdAt: string | Date, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: string | Date }, attestations: Array<{ id: number, user_id: number, date_of_attestation: string | Date, user: { name?: string | null, address: string, id: number } }>, guilds: Array<{ guild: { id: number, name?: string | null } }> } };
+export type CreateOnChainUserContributionMutation = { createOnChainUserContribution: { date_of_engagement: string | Date, date_of_submission: string | Date, details?: string | null, id: number, name: string, proof?: string | null, updatedAt: string | Date, on_chain_id?: number | null, tx_hash?: string | null, activity_type: { active: boolean, createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, status: { createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, user: { address: string, createdAt: string | Date, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: string | Date }, attestations: Array<{ id: number, user_id: number, date_of_attestation: string | Date, user: { name?: string | null, address: string, id: number } }>, guilds: Array<{ id: number, guild_id: number, guild: { id: number, name?: string | null } }> } };
 
 export type DeleteContributionMutationVariables = Exact<{
   where: UserContributionDeleteInput;
@@ -14133,14 +14133,14 @@ export type UpdateUserContributionMutationVariables = Exact<{
 }>;
 
 
-export type UpdateUserContributionMutation = { updateUserContribution: { date_of_engagement: string | Date, date_of_submission: string | Date, details?: string | null, id: number, name: string, proof?: string | null, updatedAt: string | Date, on_chain_id?: number | null, tx_hash?: string | null, activity_type: { active: boolean, createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, status: { createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, user: { address: string, createdAt: string | Date, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: string | Date }, attestations: Array<{ id: number, user_id: number, date_of_attestation: string | Date, user: { name?: string | null, address: string, id: number } }>, guilds: Array<{ guild: { id: number, name?: string | null } }> } };
+export type UpdateUserContributionMutation = { updateUserContribution: { date_of_engagement: string | Date, date_of_submission: string | Date, details?: string | null, id: number, name: string, proof?: string | null, updatedAt: string | Date, on_chain_id?: number | null, tx_hash?: string | null, activity_type: { active: boolean, createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, status: { createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, user: { address: string, createdAt: string | Date, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: string | Date }, attestations: Array<{ id: number, user_id: number, date_of_attestation: string | Date, user: { name?: string | null, address: string, id: number } }>, guilds: Array<{ id: number, guild_id: number, guild: { id: number, name?: string | null } }> } };
 
 export type UpdateUserOnChainContributionMutationVariables = Exact<{
   data: UserOnChainContributionUpdateInput;
 }>;
 
 
-export type UpdateUserOnChainContributionMutation = { updateUserOnChainContribution: { date_of_engagement: string | Date, date_of_submission: string | Date, details?: string | null, id: number, name: string, proof?: string | null, updatedAt: string | Date, on_chain_id?: number | null, tx_hash?: string | null, activity_type: { active: boolean, createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, status: { createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, user: { address: string, createdAt: string | Date, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: string | Date }, attestations: Array<{ id: number, user_id: number, date_of_attestation: string | Date, user: { name?: string | null, address: string, id: number } }>, guilds: Array<{ guild: { id: number, name?: string | null } }> } };
+export type UpdateUserOnChainContributionMutation = { updateUserOnChainContribution: { date_of_engagement: string | Date, date_of_submission: string | Date, details?: string | null, id: number, name: string, proof?: string | null, updatedAt: string | Date, on_chain_id?: number | null, tx_hash?: string | null, activity_type: { active: boolean, createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, status: { createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, user: { address: string, createdAt: string | Date, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: string | Date }, attestations: Array<{ id: number, user_id: number, date_of_attestation: string | Date, user: { name?: string | null, address: string, id: number } }>, guilds: Array<{ id: number, guild_id: number, guild: { id: number, name?: string | null } }> } };
 
 export type BulkCreateContributionMutationVariables = Exact<{
   data: Array<ContributionCreateManyInput> | ContributionCreateManyInput;
@@ -14156,7 +14156,7 @@ export type UpdateContributionMutationVariables = Exact<{
 }>;
 
 
-export type UpdateContributionMutation = { updateContribution?: { date_of_engagement: string | Date, date_of_submission: string | Date, details?: string | null, id: number, name: string, proof?: string | null, updatedAt: string | Date, on_chain_id?: number | null, tx_hash?: string | null, activity_type: { active: boolean, createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, status: { createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, user: { address: string, createdAt: string | Date, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: string | Date }, attestations: Array<{ id: number, user_id: number, date_of_attestation: string | Date, user: { name?: string | null, address: string, id: number } }>, guilds: Array<{ guild: { id: number, name?: string | null } }> } | null };
+export type UpdateContributionMutation = { updateContribution?: { date_of_engagement: string | Date, date_of_submission: string | Date, details?: string | null, id: number, name: string, proof?: string | null, updatedAt: string | Date, on_chain_id?: number | null, tx_hash?: string | null, activity_type: { active: boolean, createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, status: { createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, user: { address: string, createdAt: string | Date, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: string | Date }, attestations: Array<{ id: number, user_id: number, date_of_attestation: string | Date, user: { name?: string | null, address: string, id: number } }>, guilds: Array<{ id: number, guild_id: number, guild: { id: number, name?: string | null } }> } | null };
 
 export type GetContributionStatusQueryVariables = Exact<{
   name: Scalars['String'];
@@ -14355,6 +14355,8 @@ export const ContributionFragmentFragmentDoc = gql`
     }
   }
   guilds {
+    id
+    guild_id
     guild {
       id
       name

--- a/libs/protocol-client/src/lib/protocol-types.ts
+++ b/libs/protocol-client/src/lib/protocol-types.ts
@@ -14012,21 +14012,21 @@ export type UpsertTwitterUserMutationVariables = Exact<{
 
 export type UpsertTwitterUserMutation = { upsertTwitterUser: { createdAt: string | Date, updatedAt: string | Date, description?: string | null, id: number, twitter_user_id?: string | null, username: string, user?: { id: number } | null } };
 
-export type UserFragmentFragment = { address: string, active: boolean, createdAt: string | Date, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: string | Date, chain_type: { id: number, name: string, createdAt: string | Date, updatedAt: string | Date }, linear_users: Array<{ id: number, active_token?: boolean | null }> };
+export type UserFragmentFragment = { address: string, active: boolean, createdAt: string | Date, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: string | Date, chain_type: { id: number, name: string, createdAt: string | Date, updatedAt: string | Date }, linear_users: Array<{ id: number, active_token?: boolean | null }>, guild_users: Array<{ id: number, user_id: number, guild_id: number }> };
 
 export type GetUserQueryVariables = Exact<{
   where: UserWhereUniqueInput;
 }>;
 
 
-export type GetUserQuery = { result?: { address: string, active: boolean, createdAt: string | Date, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: string | Date, chain_type: { id: number, name: string, createdAt: string | Date, updatedAt: string | Date }, linear_users: Array<{ id: number, active_token?: boolean | null }> } | null };
+export type GetUserQuery = { result?: { address: string, active: boolean, createdAt: string | Date, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: string | Date, chain_type: { id: number, name: string, createdAt: string | Date, updatedAt: string | Date }, linear_users: Array<{ id: number, active_token?: boolean | null }>, guild_users: Array<{ id: number, user_id: number, guild_id: number }> } | null };
 
 export type GetUserCustomQueryVariables = Exact<{
   id: Scalars['Float'];
 }>;
 
 
-export type GetUserCustomQuery = { result: { address: string, active: boolean, createdAt: string | Date, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: string | Date, chain_type: { id: number, name: string, createdAt: string | Date, updatedAt: string | Date }, linear_users: Array<{ id: number, active_token?: boolean | null }> } };
+export type GetUserCustomQuery = { result: { address: string, active: boolean, createdAt: string | Date, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: string | Date, chain_type: { id: number, name: string, createdAt: string | Date, updatedAt: string | Date }, linear_users: Array<{ id: number, active_token?: boolean | null }>, guild_users: Array<{ id: number, user_id: number, guild_id: number }> } };
 
 export type ListUsersQueryVariables = Exact<{
   where?: UserWhereInput;
@@ -14036,14 +14036,14 @@ export type ListUsersQueryVariables = Exact<{
 }>;
 
 
-export type ListUsersQuery = { result: Array<{ address: string, active: boolean, createdAt: string | Date, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: string | Date, chain_type: { id: number, name: string, createdAt: string | Date, updatedAt: string | Date }, linear_users: Array<{ id: number, active_token?: boolean | null }> }> };
+export type ListUsersQuery = { result: Array<{ address: string, active: boolean, createdAt: string | Date, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: string | Date, chain_type: { id: number, name: string, createdAt: string | Date, updatedAt: string | Date }, linear_users: Array<{ id: number, active_token?: boolean | null }>, guild_users: Array<{ id: number, user_id: number, guild_id: number }> }> };
 
 export type ListUserByAddressQueryVariables = Exact<{
   address: Scalars['String'];
 }>;
 
 
-export type ListUserByAddressQuery = { result: Array<{ address: string, active: boolean, createdAt: string | Date, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: string | Date, chain_type: { id: number, name: string, createdAt: string | Date, updatedAt: string | Date }, linear_users: Array<{ id: number, active_token?: boolean | null }> }> };
+export type ListUserByAddressQuery = { result: Array<{ address: string, active: boolean, createdAt: string | Date, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: string | Date, chain_type: { id: number, name: string, createdAt: string | Date, updatedAt: string | Date }, linear_users: Array<{ id: number, active_token?: boolean | null }>, guild_users: Array<{ id: number, user_id: number, guild_id: number }> }> };
 
 export type UpdateUserMutationVariables = Exact<{
   data: UserUpdateInput;
@@ -14051,28 +14051,28 @@ export type UpdateUserMutationVariables = Exact<{
 }>;
 
 
-export type UpdateUserMutation = { updateUser?: { address: string, active: boolean, createdAt: string | Date, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: string | Date, chain_type: { id: number, name: string, createdAt: string | Date, updatedAt: string | Date }, linear_users: Array<{ id: number, active_token?: boolean | null }> } | null };
+export type UpdateUserMutation = { updateUser?: { address: string, active: boolean, createdAt: string | Date, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: string | Date, chain_type: { id: number, name: string, createdAt: string | Date, updatedAt: string | Date }, linear_users: Array<{ id: number, active_token?: boolean | null }>, guild_users: Array<{ id: number, user_id: number, guild_id: number }> } | null };
 
 export type UpdateUserCustomMutationVariables = Exact<{
   data: UserUpdateCustomInput;
 }>;
 
 
-export type UpdateUserCustomMutation = { updateUserCustom: { address: string, active: boolean, createdAt: string | Date, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: string | Date, chain_type: { id: number, name: string, createdAt: string | Date, updatedAt: string | Date }, linear_users: Array<{ id: number, active_token?: boolean | null }> } };
+export type UpdateUserCustomMutation = { updateUserCustom: { address: string, active: boolean, createdAt: string | Date, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: string | Date, chain_type: { id: number, name: string, createdAt: string | Date, updatedAt: string | Date }, linear_users: Array<{ id: number, active_token?: boolean | null }>, guild_users: Array<{ id: number, user_id: number, guild_id: number }> } };
 
 export type CreateUserMutationVariables = Exact<{
   data: UserCreateInput;
 }>;
 
 
-export type CreateUserMutation = { createUser: { address: string, active: boolean, createdAt: string | Date, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: string | Date, chain_type: { id: number, name: string, createdAt: string | Date, updatedAt: string | Date }, linear_users: Array<{ id: number, active_token?: boolean | null }> } };
+export type CreateUserMutation = { createUser: { address: string, active: boolean, createdAt: string | Date, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: string | Date, chain_type: { id: number, name: string, createdAt: string | Date, updatedAt: string | Date }, linear_users: Array<{ id: number, active_token?: boolean | null }>, guild_users: Array<{ id: number, user_id: number, guild_id: number }> } };
 
 export type CreateUserCustomMutationVariables = Exact<{
   data: UserCreateCustomInput;
 }>;
 
 
-export type CreateUserCustomMutation = { createUserCustom: { address: string, active: boolean, createdAt: string | Date, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: string | Date, chain_type: { id: number, name: string, createdAt: string | Date, updatedAt: string | Date }, linear_users: Array<{ id: number, active_token?: boolean | null }> } };
+export type CreateUserCustomMutation = { createUserCustom: { address: string, active: boolean, createdAt: string | Date, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: string | Date, chain_type: { id: number, name: string, createdAt: string | Date, updatedAt: string | Date }, linear_users: Array<{ id: number, active_token?: boolean | null }>, guild_users: Array<{ id: number, user_id: number, guild_id: number }> } };
 
 export type ContributionFragmentFragment = { date_of_engagement: string | Date, date_of_submission: string | Date, details?: string | null, id: number, name: string, proof?: string | null, updatedAt: string | Date, on_chain_id?: number | null, tx_hash?: string | null, activity_type: { active: boolean, createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, status: { createdAt: string | Date, id: number, name: string, updatedAt: string | Date }, user: { address: string, createdAt: string | Date, display_name?: string | null, full_name?: string | null, id: number, name?: string | null, updatedAt: string | Date }, attestations: Array<{ id: number, user_id: number, date_of_attestation: string | Date, user: { name?: string | null, address: string, id: number } }>, guilds: Array<{ guild: { id: number, name?: string | null } }> };
 
@@ -14427,6 +14427,11 @@ export const UserFragmentFragmentDoc = gql`
   linear_users {
     id
     active_token
+  }
+  guild_users {
+    id
+    user_id
+    guild_id
   }
 }
     `;


### PR DESCRIPTION
## Linear Ticket

- [PRO-362](https://linear.app/govrn/issue/PRO-362/show-only-my-daos-in-the-attestation-feed)

## Description

- This adds the ability for a user to toggle _Show All DAOs_ and showing only the DAOs they're in the Attestations Feed
- Definitely think we can streamline the filtering process with some lodash chaining, but I left them all as their own variables incase we want to add additional views/filtering options
- Can also pull the toggle Switch component into the UI library since we've now used it a few times. I made a ticket for this

## Screencaptures

https://user-images.githubusercontent.com/9438776/187814262-63efcff7-cdf8-4f19-a2a3-d76dd14abec3.mp4




