### PR TITLE
feature/user-daos-query (PRO-402)

### DIFF
--- a/apps/airtable-api/Dockerfile
+++ b/apps/airtable-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:17.4.0-alpine as deps
+FROM node:17-alpine as deps
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk add --no-cache libc6-compat yarn
 WORKDIR /usr/src/app
@@ -6,7 +6,7 @@ COPY dist/apps/airtable-api/package*.json ./
 RUN yarn install --only=production
 
 # Production image, copy all the files and run nest
-FROM node:17.4.0-alpine as runner
+FROM node:17-alpine as runner
 RUN apk add --no-cache dumb-init
 ENV NODE_ENV production
 WORKDIR /usr/src/app

--- a/apps/protocol-frontend/src/components/DashboardShell.tsx
+++ b/apps/protocol-frontend/src/components/DashboardShell.tsx
@@ -44,7 +44,7 @@ const DashboardShell = ({ user }: DashboardShellProps) => {
     fetchHeatMapCount();
   }, [user, dateRange, selectedDaos]);
 
-  const allDaoListOptions = allDaos.map(dao => ({
+  const userDaoListOptions = userDaos.map(dao => ({
     value: dao.id,
     label: dao.name ?? '',
   }));
@@ -64,7 +64,7 @@ const DashboardShell = ({ user }: DashboardShellProps) => {
     { value: 52, label: 'Last Year' },
   ];
 
-  const combinedDaoListOptions = [...new Set([...allDaoListOptions])];
+  const combinedDaoListOptions = [...new Set([...userDaoListOptions])];
 
   useEffect(() => {
     if (allDaos) {
@@ -110,7 +110,7 @@ const DashboardShell = ({ user }: DashboardShellProps) => {
               gap={8}
               justifyContent="space-apart"
             >
-              {allDaoListOptions.length > 0 && (
+              {userDaoListOptions.length > 0 && (
                 <ControlledSelect
                   label="Choose DAOs"
                   tip="Choose DAOs to display Contributions from."

--- a/apps/protocol-frontend/src/components/DashboardShell.tsx
+++ b/apps/protocol-frontend/src/components/DashboardShell.tsx
@@ -49,14 +49,6 @@ const DashboardShell = ({ user }: DashboardShellProps) => {
     label: dao.name ?? '',
   }));
 
-  // will include this when we include unassigned -- this is adding some confusion to the UI
-  // const daoReset = [
-  //   {
-  //     value: null,
-  //     label: 'All DAOs',
-  //   },
-  // ];
-
   const dateRangeOptions = [
     { value: 1, label: 'Last Week' },
     { value: 4, label: 'Last Month' },

--- a/apps/protocol-frontend/src/components/DashboardShell.tsx
+++ b/apps/protocol-frontend/src/components/DashboardShell.tsx
@@ -18,7 +18,7 @@ interface DashboardShellProps {
 }
 
 const DashboardShell = ({ user }: DashboardShellProps) => {
-  const { allDaos, getUserContributionsCount } = useUser();
+  const { allDaos, userDaos, getUserContributionsCount } = useUser();
   const [contributionsCount, setContributionsCount] = useState<
     UserContributionsDateRangeCountType[] | null | undefined
   >([]);
@@ -44,7 +44,7 @@ const DashboardShell = ({ user }: DashboardShellProps) => {
     fetchHeatMapCount();
   }, [user, dateRange, selectedDaos]);
 
-  const daoListOptions = allDaos.map(dao => ({
+  const allDaoListOptions = allDaos.map(dao => ({
     value: dao.id,
     label: dao.name ?? '',
   }));
@@ -64,7 +64,7 @@ const DashboardShell = ({ user }: DashboardShellProps) => {
     { value: 52, label: 'Last Year' },
   ];
 
-  const combinedDaoListOptions = [...new Set([...daoListOptions])];
+  const combinedDaoListOptions = [...new Set([...allDaoListOptions])];
 
   useEffect(() => {
     if (allDaos) {
@@ -110,7 +110,7 @@ const DashboardShell = ({ user }: DashboardShellProps) => {
               gap={8}
               justifyContent="space-apart"
             >
-              {daoListOptions.length > 0 && (
+              {allDaoListOptions.length > 0 && (
                 <ControlledSelect
                   label="Choose DAOs"
                   tip="Choose DAOs to display Contributions from."

--- a/apps/protocol-frontend/src/contexts/UserContext.tsx
+++ b/apps/protocol-frontend/src/contexts/UserContext.tsx
@@ -94,6 +94,7 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
     useState(true);
 
   const [allDaos, setAllDaos] = useState<UIGuild[]>([]);
+  const [userDaos, setUserDaos] = useState<UIGuild[]>([]);
   const [userContributionsDateRangeCount, setUserContributionsDateRangeCount] =
     useState<UserContributionsDateRangeCountType[]>([]);
 
@@ -109,9 +110,6 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
         throw new Error('No address for user');
       }
       const userDataResponse = await govrn.user.get(userDataByAddress?.id);
-      const userDaos = userDataResponse?.guild_users.map(guild => {
-        return guild;
-      });
       setUserData(userDataResponse);
       return userDataResponse;
     } catch (error) {
@@ -281,6 +279,32 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
       const allDaosResponse = await govrn.guild.list({ first: 100 });
       setAllDaos(allDaosResponse);
       return allDaosResponse;
+    } catch (error) {
+      console.error(error);
+      return [];
+    }
+  };
+
+  const getUserDaos = async () => {
+    try {
+      if (!userData?.id) {
+        throw new Error('getUserDaos has no userData.id');
+      }
+      const userDaosResponse = await govrn.guild.list({
+        first: 100,
+        where: {
+          users: {
+            some: {
+              user_id: {
+                equals: userData?.id,
+              },
+            },
+          },
+        },
+      });
+      console.log('user daos response', userDaosResponse);
+      setUserDaos(userDaosResponse);
+      return userDaosResponse;
     } catch (error) {
       console.error(error);
       return [];
@@ -727,6 +751,7 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
       getUserActivityTypes();
       getUserAttestations();
       getAllDaos();
+      getUserDaos();
     }
   }, [userData, isAuthenticated]);
 
@@ -749,6 +774,7 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
         getAllDaos,
         getContribution,
         getUserContributionsCount,
+        getUserDaos,
         mintAttestation,
         mintContribution,
         setAllDaos,
@@ -758,6 +784,7 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
         setUserAddress,
         setUserAttestations,
         setUserContributionsDateRangeCount,
+        setUserDaos,
         setUserData,
         setUserDataByAddress,
         updateContribution,
@@ -768,6 +795,7 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
         userAttestations,
         userContributions,
         userContributionsDateRangeCount,
+        userDaos,
         userData,
         userDataByAddress,
       }}
@@ -800,6 +828,7 @@ type UserContextType = {
     endDate: string | Date,
     guildIds?: number[] | null | undefined,
   ) => Promise<UserContributionsDateRangeCountType[] | undefined>;
+  getUserDaos: () => Promise<UIGuilds>;
   getContribution: (id: number) => Promise<UIContribution | null>;
   isCreatingContribution: boolean;
   isDaoContributionLoading: boolean;
@@ -825,6 +854,7 @@ type UserContextType = {
   setUserAttestations: (arg0: UIAttestations) => void;
   setUserData: (arg0: UIUser) => void;
   setUserDataByAddress: (arg0: UIUser) => void;
+  setUserDaos: (data: UIGuild[]) => void;
   updateContribution: (
     contribution: UIContribution,
     values: ContributionFormValues,
@@ -837,6 +867,7 @@ type UserContextType = {
   userAttestations: UIAttestations | null;
   userContributions: UIContribution[];
   userContributionsDateRangeCount: UserContributionsDateRangeCountType[];
+  userDaos: UIGuild[];
   userData: UIUser | null;
   userDataByAddress: UIUser | null;
 };

--- a/apps/protocol-frontend/src/contexts/UserContext.tsx
+++ b/apps/protocol-frontend/src/contexts/UserContext.tsx
@@ -302,7 +302,6 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
           },
         },
       });
-      console.log('user daos response', userDaosResponse);
       setUserDaos(userDaosResponse);
       return userDaosResponse;
     } catch (error) {


### PR DESCRIPTION
## Linear Ticket

- [PRO-402](https://linear.app/govrn/issue/PRO-402/daos-query-to-show-daos-user-is-in-similar-to-activity-types)

## Description

This adds another query for grabbing the user's DAOs instead of _all_ DAOs. I left the all DAOs query in since we also use this elsewhere in the app.

There is a Set in the DashboardShell where this is used -- in this PR it's only the user's DAOs but when #191 is merged in this Set will include the _Unassigned_ option as well in the array.

## Screencaptures

![govrn-dashboard-user-daos](https://user-images.githubusercontent.com/9438776/190198749-c94c5ca6-5b94-4b4a-a787-6569a979fbc7.jpg)
