### PR TITLE
Eliminate kebab-case Error when Using Firefox

### DIFF
--- a/apps/protocol-frontend/src/components/Sidebar.tsx
+++ b/apps/protocol-frontend/src/components/Sidebar.tsx
@@ -37,7 +37,7 @@ const Sidebar = () => {
       overflowX="auto"
       css={{
         // Firefox
-        'scrollbar-width': 'none',
+        scrollbarWidth: 'none',
         // Blink- and WebKit-based browsers
         '&::-webkit-scrollbar': {
           display: 'none',


### PR DESCRIPTION
Eliminate kebab-case error that is showing when using Firefox.

```
Using kebab-case for css properties in objects is not supported. Did you mean scrollbarWidth?
```
