### PR TITLE
fix cypress flackiness

### DIFF
--- a/apps/protocol-frontend-e2e/src/support/commands.ts
+++ b/apps/protocol-frontend-e2e/src/support/commands.ts
@@ -22,7 +22,7 @@ Cypress.Commands.add('login', (address, privateKey) => {
         'be.visible',
       );
     } else if (text === 'Connect Wallet') {
-      cy.get('[data-cy=connect-wallet]', { timeout: 10000 }).click();
+      cy.get('[data-cy=connect-wallet]', { timeout: 10000 }).should('be.visible').click();
       cy.contains('MetaMask').click();
     }
   });


### PR DESCRIPTION
## Linear Ticket

Add the link to the Linear ticket here.

## Description

The goal is to fix flaky tests in Cypress and investigate the code app for potential bugs

**1. Unprepared Element:**  
      DOM element is present but it doesn't behave the way it does in manual testing
   - Root Cause: an element is added to the DOM before the data is ready for it to be interacted with
   - Solution: don't render the element as interactable until it's prepared. e.g disabling
   
**2. Flickering Element:** 
        cy. click() failed because this element is detached from the DOM, but the element is not visible on the page. 
        It's a bug since, on a slower device, the flicker will be more noticeable.
   - Root Cause: the element is added to the DOM, then removed, then a second similar element is added.
                           Declarative rendering
   - Solution:  rework the flow of data so that the element no longer flickers
           : cy.click({force:true}). -but this doesn't fix the flicker

**3. Impatient Test:** 
Test fails without waiting for the condition that would cause it to succeed.
   - Root Cause: The next element to interact with is already present and Cypress doesn't know how to wait
   -  Solution: 
       - Change the app code so the test can proceed immediately
       - Prevent interaction with the element
       - check a "green light"
             - check an element (using` should('be.visible')`)
             - check network request
           

Resource:  https://www.youtube.com/watch?v=JlBCdRlvPWk


