### PR TITLE
Add Bulk Mint to SDK

### DIFF
--- a/libs/protocol-client/src/lib/client/contribution.ts
+++ b/libs/protocol-client/src/lib/client/contribution.ts
@@ -15,6 +15,7 @@ import {
 } from '@govrn/govrn-contract-client';
 import { GraphQLClient } from 'graphql-request';
 import { paginate } from '../utils/paginate';
+import patch from '../utils/patch';
 
 class ChainIdError extends Error {
   constructor(message?: string) {
@@ -125,7 +126,7 @@ export class Contribution extends BaseClient {
         };
       }, {});
 
-    return await Promise.allSettled(
+    return await patch(
       contributions.map(async (c, idx) => {
         const onChainId = onChainIds[idx];
 
@@ -148,6 +149,7 @@ export class Contribution extends BaseClient {
           txHash: transaction.hash,
         });
       }),
+      1,
     );
   }
 

--- a/libs/protocol-client/src/lib/client/contribution.ts
+++ b/libs/protocol-client/src/lib/client/contribution.ts
@@ -14,7 +14,7 @@ import {
   NetworkConfig,
 } from '@govrn/govrn-contract-client';
 import { GraphQLClient } from 'graphql-request';
-import { paginate } from '../utils';
+import { paginate } from '../utils/paginate';
 
 class ChainIdError extends Error {
   constructor(message?: string) {

--- a/libs/protocol-client/src/lib/client/contribution.ts
+++ b/libs/protocol-client/src/lib/client/contribution.ts
@@ -149,7 +149,6 @@ export class Contribution extends BaseClient {
           txHash: transaction.hash,
         });
       }),
-      1,
     );
   }
 

--- a/libs/protocol-client/src/lib/client/contribution.ts
+++ b/libs/protocol-client/src/lib/client/contribution.ts
@@ -253,22 +253,20 @@ export class Contribution extends BaseClient {
     txHash: string;
     onChainId: number;
   }) {
+    const { args, name, details, proof, onChainId, userId, id, txHash } =
+      contribution;
     return this.sdk.updateUserOnChainContribution({
       data: {
-        name: ethers.utils.toUtf8String(contribution.name),
-        details: ethers.utils.toUtf8String(contribution.details),
-        dateOfSubmission: new Date(
-          contribution.args.dateOfSubmission,
-        ).toString(),
-        dateOfEngagement: new Date(
-          contribution.args.dateOfEngagement,
-        ).toString(),
-        proof: ethers.utils.toUtf8String(contribution.proof),
+        name: ethers.utils.toUtf8String(name),
+        details: ethers.utils.toUtf8String(details),
+        dateOfSubmission: new Date(args.dateOfSubmission).toString(),
+        dateOfEngagement: new Date(args.dateOfSubmission).toString(),
+        proof: ethers.utils.toUtf8String(proof),
         status: 'minted',
-        onChainId: contribution.onChainId,
-        userId: contribution.userId,
-        id: contribution.id,
-        txHash: contribution.txHash,
+        onChainId: onChainId,
+        userId: userId,
+        id: id,
+        txHash: txHash,
       },
     });
   }

--- a/libs/protocol-client/src/lib/client/contribution.ts
+++ b/libs/protocol-client/src/lib/client/contribution.ts
@@ -117,15 +117,13 @@ export class Contribution extends BaseClient {
     const transactionReceipt = await transaction.wait();
 
     const onChainIds: { [index: number]: ethers.BigNumber | null } =
-      transactionReceipt.logs
-        .map(l => contract.govrn.interface.parseLog(l))
-        .reduce(
-          (prev, current, idx) => ({
-            ...prev,
-            [idx]: current.name === 'Mint' ? current.args['id'] : null,
-          }),
-          {},
-        );
+      transactionReceipt.logs.reduce((prev, current, idx) => {
+        const log = contract.govrn.interface.parseLog(current);
+        return {
+          ...prev,
+          [idx]: log.name === 'Mint' ? log.args['id'] : null,
+        };
+      }, {});
 
     return await Promise.allSettled(
       contributions.map(async (c, idx) => {

--- a/libs/protocol-client/src/lib/client/contribution.ts
+++ b/libs/protocol-client/src/lib/client/contribution.ts
@@ -255,8 +255,7 @@ export class Contribution extends BaseClient {
     txHash: string;
     onChainId: number;
   }) {
-    console.log('id in the update:', contribution.id);
-    const updateResponse = this.sdk.updateUserOnChainContribution({
+    return this.sdk.updateUserOnChainContribution({
       data: {
         name: ethers.utils.toUtf8String(contribution.name),
         details: ethers.utils.toUtf8String(contribution.details),
@@ -274,8 +273,6 @@ export class Contribution extends BaseClient {
         txHash: contribution.txHash,
       },
     });
-    console.log('update response:', updateResponse);
-    return updateResponse;
   }
 
   private async _createOnChainUserContribution(contribution: {

--- a/libs/protocol-client/src/lib/client/linear.ts
+++ b/libs/protocol-client/src/lib/client/linear.ts
@@ -10,7 +10,7 @@ import {
   ListLinearUsersQuery,
 } from '../protocol-types';
 import { BaseClient } from './base';
-import { paginate } from '../utils';
+import { paginate } from '../utils/paginate';
 import { GraphQLClient } from 'graphql-request';
 
 export class Linear {

--- a/libs/protocol-client/src/lib/utils/paginate.ts
+++ b/libs/protocol-client/src/lib/utils/paginate.ts
@@ -1,5 +1,5 @@
 import * as Dom from 'graphql-request/dist/types.dom';
-import { SortOrder, InputMaybe, Scalars, IntFilter } from './protocol-types';
+import { SortOrder, InputMaybe, Scalars, IntFilter } from '../protocol-types';
 
 interface WhereArgs {
   AND?: InputMaybe<Array<WhereArgs>>;

--- a/libs/protocol-client/src/lib/utils/patch.ts
+++ b/libs/protocol-client/src/lib/utils/patch.ts
@@ -1,0 +1,28 @@
+const DEFAULT_CHUNK_SIZE = 50;
+
+async function* doPatching<T>(tasks: PromiseLike<T>[], chunk: number) {
+  for (let i = 0; i < tasks.length; i++) {
+    yield await Promise.allSettled(tasks.slice(i, i + chunk));
+  }
+}
+
+/**
+ * Executes tasks into smaller chunks instead of executing all at once.
+ *
+ * @param tasks promises to be executed.
+ * @param chunk the size of single patch.
+ */
+const patch = async <T>(
+  tasks: PromiseLike<T>[],
+  chunk = DEFAULT_CHUNK_SIZE,
+) => {
+  if (chunk <= 0) throw new Error(`Select suitable chunk size: ${chunk}`);
+
+  const result: PromiseSettledResult<Awaited<T>>[] = [];
+  for await (const patch of doPatching(tasks, chunk)) {
+    result.push(...patch);
+  }
+  return result;
+};
+
+export default patch;


### PR DESCRIPTION
## Linear Ticket

Part of [PRO-215 - Use bulkMint for bulk flow](https://linear.app/govrn/issue/PRO-215/use-bulkmint-for-bulk-flow)

## Description

Add `bulkMint` to the SDK as a step to support bulk minting in the front-end layer.

## Known Issues
- Transactions Hash is unique in the db and `bulkMint` violates that, since it mints more than one contribution in single transaction. Solved at #213 
