### PR TITLE
Drop Uniquness Contraint from Contribution's `tx_hash` Column

### DIFF
--- a/apps/protocol-api/src/prisma/generated/type-graphql/enhance.ts
+++ b/apps/protocol-api/src/prisma/generated/type-graphql/enhance.ts
@@ -1263,7 +1263,7 @@ const inputsInfo = {
   ChainTypeScalarWhereWithAggregatesInput: ["AND", "OR", "NOT", "id", "createdAt", "updatedAt", "name"],
   ContributionWhereInput: ["AND", "OR", "NOT", "id", "updatedAt", "name", "status_id", "status", "activity_type_id", "activity_type", "user_id", "user", "date_of_submission", "date_of_engagement", "details", "proof", "attestations", "partners", "guilds", "linear_issue", "tweet", "on_chain_id", "tx_hash"],
   ContributionOrderByWithRelationInput: ["id", "updatedAt", "name", "status_id", "status", "activity_type_id", "activity_type", "user_id", "user", "date_of_submission", "date_of_engagement", "details", "proof", "attestations", "partners", "guilds", "linear_issue", "tweet", "on_chain_id", "tx_hash"],
-  ContributionWhereUniqueInput: ["id", "on_chain_id", "tx_hash"],
+  ContributionWhereUniqueInput: ["id", "on_chain_id"],
   ContributionOrderByWithAggregationInput: ["id", "updatedAt", "name", "status_id", "activity_type_id", "user_id", "date_of_submission", "date_of_engagement", "details", "proof", "on_chain_id", "tx_hash", "_count", "_avg", "_max", "_min", "_sum"],
   ContributionScalarWhereWithAggregatesInput: ["AND", "OR", "NOT", "id", "updatedAt", "name", "status_id", "activity_type_id", "user_id", "date_of_submission", "date_of_engagement", "details", "proof", "on_chain_id", "tx_hash"],
   PartnerWhereInput: ["AND", "OR", "NOT", "id", "createdAt", "updatedAt", "user_id", "user", "contribution_id", "contribution"],

--- a/apps/protocol-api/src/prisma/generated/type-graphql/resolvers/inputs/ContributionWhereUniqueInput.ts
+++ b/apps/protocol-api/src/prisma/generated/type-graphql/resolvers/inputs/ContributionWhereUniqueInput.ts
@@ -16,9 +16,4 @@ export class ContributionWhereUniqueInput {
     nullable: true
   })
   on_chain_id?: number | undefined;
-
-  @TypeGraphQL.Field(_type => String, {
-    nullable: true
-  })
-  tx_hash?: string | undefined;
 }

--- a/apps/protocol-api/src/prisma/migrations/20220926091923_tx_hash_not_unique/migration.sql
+++ b/apps/protocol-api/src/prisma/migrations/20220926091923_tx_hash_not_unique/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX "Contribution_tx_hash_key";

--- a/apps/protocol-api/src/prisma/schema.prisma
+++ b/apps/protocol-api/src/prisma/schema.prisma
@@ -136,7 +136,7 @@ model Contribution {
   linear_issue LinearIssue?
   tweet TwitterTweet?
   on_chain_id Int? @unique
-  tx_hash String? @db.Citext @unique
+  tx_hash String? @db.Citext
 }
 
 model Partner {

--- a/libs/protocol-client/src/lib/protocol-types.ts
+++ b/libs/protocol-client/src/lib/protocol-types.ts
@@ -3391,7 +3391,6 @@ export type ContributionWhereInput = {
 export type ContributionWhereUniqueInput = {
   id?: InputMaybe<Scalars['Int']>;
   on_chain_id?: InputMaybe<Scalars['Int']>;
-  tx_hash?: InputMaybe<Scalars['String']>;
 };
 
 export type DateTimeFieldUpdateOperationsInput = {


### PR DESCRIPTION
## Linear Ticket

[PRO-215 - Use bulkMint for bulk flow](https://linear.app/govrn/issue/PRO-215/use-bulkmint-for-bulk-flow)

## Description

`tx_hash` column in `Contribution` table is having a unique constraint that collides with `bulkMint` on the govrn contract. Since many contributions are minted together with `bulkMint`, they will share the same tx hash.

---
Related #212  

