### PR TITLE
Create reusable Toast component

### DIFF
--- a/apps/protocol-frontend/src/components/EditContributionForm.tsx
+++ b/apps/protocol-frontend/src/components/EditContributionForm.tsx
@@ -1,14 +1,7 @@
 import { useEffect, useState, useRef } from 'react';
 import { uploadFileIpfs } from '../libs/ipfs';
 import { MAX_FILE_UPLOAD_SIZE } from '../utils/constants';
-import {
-  Button,
-  Flex,
-  IconButton,
-  Stack,
-  Text,
-  useToast,
-} from '@chakra-ui/react';
+import { Button, Flex, IconButton, Stack, Text } from '@chakra-ui/react';
 import {
   CreatableSelect,
   DatePicker,
@@ -28,6 +21,7 @@ import { HiOutlinePaperClip } from 'react-icons/hi';
 import { useUserActivityTypesList } from '../hooks/useUserActivityTypesList';
 import { useDaosList } from '../hooks/useDaosList';
 import { useContributionUpdate } from '../hooks/useContributionUpdate';
+import useGovrnToast from './toast';
 
 interface EditContributionFormProps {
   contribution: UIContribution;
@@ -45,7 +39,7 @@ const EditContributionForm = ({ contribution }: EditContributionFormProps) => {
     new Date(contribution?.date_of_engagement),
   );
 
-  const toast = useToast();
+  const toast = useGovrnToast();
   const [, setIpfsUri] = useState('');
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const fileInputField = useRef<HTMLInputElement>(null);
@@ -159,13 +153,9 @@ const EditContributionForm = ({ contribution }: EditContributionFormProps) => {
       } catch (error) {
         setSelectedFile(null);
         setIpfsError(true);
-        toast({
+        toast.error({
           title: 'Unable to upload to IPFS.',
           description: `Please select a different proof URL or try to upload another file.`,
-          status: 'error',
-          duration: 3000,
-          isClosable: true,
-          position: 'top-right',
         });
         setIsUploading(false);
       }
@@ -186,13 +176,9 @@ const EditContributionForm = ({ contribution }: EditContributionFormProps) => {
         setIpfsError(false);
       } catch (error) {
         console.error(error);
-        toast({
+        toast.error({
           title: 'Unable to Upload to IPFS',
           description: `Something went wrong. Please try again: ${error}`,
-          status: 'error',
-          duration: 3000,
-          isClosable: true,
-          position: 'top-right',
         });
         return;
       }

--- a/apps/protocol-frontend/src/components/ReportForm.tsx
+++ b/apps/protocol-frontend/src/components/ReportForm.tsx
@@ -10,7 +10,6 @@ import {
   Button,
   Text,
   Switch,
-  useToast,
 } from '@chakra-ui/react';
 import {
   CreatableSelect,
@@ -29,6 +28,7 @@ import { HiOutlinePaperClip } from 'react-icons/hi';
 import { useUserActivityTypesList } from '../hooks/useUserActivityTypesList';
 import { useDaosList } from '../hooks/useDaosList';
 import { useContributionCreate } from '../hooks/useContributionCreate';
+import useGovrnToast from './toast';
 
 function CreateMoreSwitch({
   isChecked,
@@ -59,7 +59,7 @@ function CreateMoreSwitch({
 
 const ReportForm = ({ onFinish }: { onFinish: () => void }) => {
   const { userData } = useUser();
-  const toast = useToast();
+  const toast = useGovrnToast();
   const [, setIpfsUri] = useState('');
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const fileInputField = useRef<HTMLInputElement>(null);
@@ -100,13 +100,9 @@ const ReportForm = ({ onFinish }: { onFinish: () => void }) => {
       } catch (error) {
         setSelectedFile(null);
         setIpfsError(true);
-        toast({
+        toast.error({
           title: 'Unable to upload to IPFS.',
           description: `Please select a different proof URL or try to upload another file.`,
-          status: 'error',
-          duration: 3000,
-          isClosable: true,
-          position: 'top-right',
         });
         setIsUploading(false);
       }
@@ -143,13 +139,9 @@ const ReportForm = ({ onFinish }: { onFinish: () => void }) => {
       } catch (error) {
         console.error(error);
         setIpfsError(true);
-        toast({
+        toast.error({
           title: 'Unable to Upload to IPFS',
           description: `Something went wrong. Please try again: ${error}`,
-          status: 'error',
-          duration: 3000,
-          isClosable: true,
-          position: 'top-right',
         });
         return;
       }

--- a/apps/protocol-frontend/src/components/toast.tsx
+++ b/apps/protocol-frontend/src/components/toast.tsx
@@ -1,0 +1,56 @@
+import { AlertStatus, ToastId, useToast } from '@chakra-ui/react';
+import { CreateToastFnReturn } from '@chakra-ui/toast';
+
+type ToastProps = {
+  title: string;
+  description: string;
+  id?: ToastId;
+  duration?: number;
+  isClosable?: boolean;
+};
+
+const ToastBase = ({
+  toast,
+  description,
+  title,
+  duration,
+  isClosable,
+  status,
+}: ToastProps & { status: AlertStatus; toast: CreateToastFnReturn }) => {
+  toast({
+    title,
+    description,
+    status,
+    duration: duration ?? 3000,
+    isClosable: isClosable ?? true,
+    position: 'top-right',
+    variant: 'left-accent',
+  });
+};
+
+const useGovrnToast = () => {
+  const toast = useToast();
+
+  return {
+    success(props: ToastProps) {
+      ToastBase({ ...props, status: 'success', toast });
+    },
+    error(props: ToastProps) {
+      ToastBase({ ...props, status: 'error', toast });
+    },
+    warning(props: ToastProps) {
+      ToastBase({ ...props, status: 'warning', toast });
+    },
+    info(props: ToastProps) {
+      ToastBase({ ...props, status: 'info', toast });
+    },
+    loading(props: ToastProps) {
+      ToastBase({ ...props, status: 'loading', toast });
+    },
+    isActive(id: ToastId) {
+      return toast.isActive(id);
+    },
+  };
+};
+
+export default useGovrnToast;

--- a/apps/protocol-frontend/src/contexts/ContributionContext.tsx
+++ b/apps/protocol-frontend/src/contexts/ContributionContext.tsx
@@ -1,7 +1,6 @@
 import { Dispatch, SetStateAction } from 'react';
 import { ethers } from 'ethers';
 import React, { createContext, useContext, useEffect, useState } from 'react';
-import { useToast } from '@chakra-ui/react';
 import { useOverlay } from './OverlayContext';
 import { useNetwork, useSigner } from 'wagmi';
 import { UIAttestations, UIContribution } from '@govrn/ui-types';
@@ -14,6 +13,7 @@ import { MintContributionType } from '../types/mint';
 import { UserContext } from './UserContext';
 import { Pagination } from './utils';
 import { PROTOCOL_URL } from '../utils/constants';
+import useGovrnToast from '../components/toast';
 
 const ITEMS_PER_PAGE = 20;
 
@@ -36,7 +36,7 @@ export const ContributionsContextProvider: React.FC<
   ContributionContextProps
 > = ({ children }: ContributionContextProps) => {
   const { userData } = useContext(UserContext);
-  const toast = useToast();
+  const toast = useGovrnToast();
   const { data: signer } = useSigner();
   const { chain } = useNetwork();
   const queryClient = useQueryClient();
@@ -202,24 +202,16 @@ export const ContributionsContextProvider: React.FC<
         queryClient.invalidateQueries(['contributionList']);
         queryClient.invalidateQueries(['contributionInfiniteList']);
         setMintProgress((prevState: number) => prevState + 1);
-        toast({
+        toast.success({
           title: 'Contribution Successfully Minted',
           description: 'Your Contribution has been minted.',
-          status: 'success',
-          duration: 3000,
-          isClosable: true,
-          position: 'top-right',
         });
       }
     } catch (error) {
       console.log('error', error);
-      toast({
+      toast.error({
         title: 'Unable to Mint Contribution',
         description: `Something went wrong. Please try again: ${error}`,
-        status: 'error',
-        duration: 3000,
-        isClosable: true,
-        position: 'top-right',
       });
     }
   };
@@ -239,24 +231,16 @@ export const ContributionsContextProvider: React.FC<
         queryClient.invalidateQueries(['contributionList']);
         queryClient.invalidateQueries(['contributionInfiniteList']);
 
-        toast({
+        toast.success({
           title: 'Contribution Successfully deleted',
           description: 'Your Contribution has been deleted.',
-          status: 'success',
-          duration: 3000,
-          isClosable: true,
-          position: 'top-right',
         });
       }
     } catch (e) {
       console.log('error', e);
-      toast({
+      toast.error({
         title: 'Unable to delete contribution',
         description: `Something went wrong. Please try again: ${e}`,
-        status: 'error',
-        duration: 3000,
-        isClosable: true,
-        position: 'top-right',
       });
     }
   };
@@ -285,24 +269,16 @@ export const ContributionsContextProvider: React.FC<
           },
         );
         await getDaoContributions();
-        toast({
+        toast.success({
           title: 'Attestation Successfully Minted',
           description: 'Your Attestation has been minted.',
-          status: 'success',
-          duration: 3000,
-          isClosable: true,
-          position: 'top-right',
         });
       }
     } catch (error) {
       console.log('error', error);
-      toast({
+      toast.error({
         title: 'Unable to Mint Attestation',
         description: `Something went wrong. Please try again: ${error}`,
-        status: 'error',
-        duration: 3000,
-        isClosable: true,
-        position: 'top-right',
       });
     }
   };
@@ -317,25 +293,17 @@ export const ContributionsContextProvider: React.FC<
           confidenceName: '0',
           contributionId: contribution.id,
         });
-        toast({
+        toast.success({
           title: 'Attestation Successfully Added',
           description: 'Your Attestation has been added.',
-          status: 'success',
-          duration: 3000,
-          isClosable: true,
-          position: 'top-right',
         });
         await getDaoContributions();
       }
     } catch (error) {
       console.log(error);
-      toast({
+      toast.error({
         title: 'Unable to Add Attestation',
         description: `Something went wrong. Please try again: ${error}`,
-        status: 'error',
-        duration: 3000,
-        isClosable: true,
-        position: 'top-right',
       });
     }
   };
@@ -376,7 +344,7 @@ export const ContributionsContextProvider: React.FC<
       queryClient.invalidateQueries(['contributionList']);
       queryClient.invalidateQueries(['contributionInfiniteList']);
       if (!toast.isActive(toastUpdateContributionId)) {
-        toast({
+        toast.success({
           id: toastUpdateContributionId,
           title: `Contribution ${
             bulkItemCount && bulkItemCount > 0 ? 'Reports' : 'Report'
@@ -384,22 +352,14 @@ export const ContributionsContextProvider: React.FC<
           description: `Your Contribution ${
             bulkItemCount && bulkItemCount > 0 ? 'Reports have' : 'Report has'
           } been updated.`,
-          status: 'success',
-          duration: 3000,
-          isClosable: true,
-          position: 'top-right',
         });
       }
       setModals({ editContributionFormModal: false });
     } catch (error) {
       console.log(error);
-      toast({
+      toast.error({
         title: 'Unable to Update Contribution',
         description: `Something went wrong. Please try again: ${error}`,
-        status: 'error',
-        duration: 3000,
-        isClosable: true,
-        position: 'top-right',
       });
     }
   };

--- a/apps/protocol-frontend/src/contexts/UserContext.tsx
+++ b/apps/protocol-frontend/src/contexts/UserContext.tsx
@@ -6,9 +6,8 @@ import React, {
   useState,
 } from 'react';
 import { NavigateFunction } from 'react-router-dom';
-import { useToast } from '@chakra-ui/react';
 import { useAccount } from 'wagmi';
-import { UIGuild, UIUser, UIGuilds } from '@govrn/ui-types';
+import { UIUser } from '@govrn/ui-types';
 import {
   ContributionFormValues,
   CreateUserFormValues,
@@ -17,6 +16,7 @@ import {
 import { useAuth } from './AuthContext';
 import { GovrnProtocol } from '@govrn/protocol-client';
 import { PROTOCOL_URL } from '../utils/constants';
+import useGovrnToast from '../components/toast';
 
 export const UserContext = createContext<UserContextType>(
   {} as UserContextType,
@@ -35,7 +35,7 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
     // onDisconnect:
   });
 
-  const toast = useToast();
+  const toast = useGovrnToast();
   const govrn = new GovrnProtocol(PROTOCOL_URL, { credentials: 'include' });
 
   const [userAddress, setUserAddress] = useState<string | null>(null);
@@ -102,25 +102,17 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
         address: address,
         username: values.username,
       });
-      toast({
+      toast.success({
         title: 'User Created',
         description: `Your username has been created with your address: ${address}. Let's report your first Contribution!`,
-        status: 'success',
-        duration: 3000,
-        isClosable: true,
-        position: 'top-right',
       });
       if (navigate) {
         navigate('/report');
       }
     } catch (error) {
-      toast({
+      toast.error({
         title: 'Unable to Create User',
         description: `Something went wrong. Please try again: ${error}`,
-        status: 'error',
-        duration: 3000,
-        isClosable: true,
-        position: 'top-right',
       });
     }
   };
@@ -136,24 +128,16 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
         email: values.email || '',
         username: values.username || '',
       });
-      toast({
+      toast.success({
         title: 'Successfully Joined Waitlist',
         description: `Thank you for your interest in Govrn! We'll reach out when we open to new users.`,
-        status: 'success',
-        duration: 3000,
-        isClosable: true,
-        position: 'top-right',
       });
       navigate('/', { replace: true });
     } catch (error) {
       console.log(error);
-      toast({
+      toast.error({
         title: 'Unable to Join Waitlist',
         description: `Something went wrong. Please try again: ${error}`,
-        status: 'error',
-        duration: 3000,
-        isClosable: true,
-        position: 'top-right',
       });
     }
   };
@@ -166,23 +150,15 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
         id: userData?.id!,
       });
       await getUser();
-      toast({
+      toast.success({
         title: 'User Profile Updated',
         description: 'Your Profile has been updated',
-        status: 'success',
-        duration: 3000,
-        isClosable: true,
-        position: 'top-right',
       });
     } catch (error) {
       console.error(error);
-      toast({
+      toast.error({
         title: 'Unable to Update Profile',
         description: `Something went wrong. Please try again: ${error}`,
-        status: 'error',
-        duration: 3000,
-        isClosable: true,
-        position: 'top-right',
       });
     }
   };
@@ -199,23 +175,15 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
         disconnectLinearId: args.linearUserId,
       });
       await getUser();
-      toast({
+      toast.success({
         title: 'Disconnected linear user',
         description: 'Your linear user has been disconnected',
-        status: 'success',
-        duration: 3000,
-        isClosable: true,
-        position: 'top-right',
       });
     } catch (error) {
       console.error(error);
-      toast({
+      toast.error({
         title: 'Failed to disconnect linear user',
         description: `Something went wrong. Please try again: ${error}`,
-        status: 'error',
-        duration: 3000,
-        isClosable: true,
-        position: 'top-right',
       });
     }
   };

--- a/apps/protocol-frontend/src/hooks/useContributionCreate.ts
+++ b/apps/protocol-frontend/src/hooks/useContributionCreate.ts
@@ -1,12 +1,13 @@
 import { useUser } from '../contexts/UserContext';
-import { useToast } from '@chakra-ui/react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { ContributionFormValues } from '../types/forms';
+import useGovrnToast from '../components/toast';
 
 export const useContributionCreate = () => {
-  const toast = useToast();
+  const toast = useGovrnToast();
   const { govrnProtocol: govrn, userData } = useUser();
   const queryClient = useQueryClient();
+
   const { mutateAsync, isLoading, isError, isSuccess } = useMutation(
     async (newContribution: ContributionFormValues) => {
       const data = await govrn.custom.createUserContribution({
@@ -31,24 +32,16 @@ export const useContributionCreate = () => {
         queryClient.invalidateQueries(['userDaos']); // invalidate and refetch
         queryClient.invalidateQueries(['contributionList']);
         queryClient.invalidateQueries(['contributionInfiniteList']);
-        toast({
+        toast.success({
           title: 'Contribution Report Added',
           description:
             'Your Contribution report has been recorded. Add another Contribution report or check out your Contributions.',
-          status: 'success',
-          duration: 3000,
-          isClosable: true,
-          position: 'top-right',
         });
       },
       onError: error => {
-        toast({
+        toast.error({
           title: 'Unable to Report Contribution',
           description: `Something went wrong. Please try again: ${error}`,
-          status: 'error',
-          duration: 3000,
-          isClosable: true,
-          position: 'top-right',
         });
       },
     },

--- a/apps/protocol-frontend/src/hooks/useLogout.ts
+++ b/apps/protocol-frontend/src/hooks/useLogout.ts
@@ -1,9 +1,9 @@
-import { useToast } from '@chakra-ui/react';
 import { useDisconnect } from 'wagmi';
 import { BASE_URL } from '../utils/constants';
+import useGovrnToast from '../components/toast';
 
 const useLogout = () => {
-  const toast = useToast();
+  const toast = useGovrnToast();
   const { disconnect } = useDisconnect();
   const logout = async () => {
     try {
@@ -17,13 +17,9 @@ const useLogout = () => {
       await disconnect();
     } catch (err) {
       console.error(err);
-      toast({
+      toast.error({
         title: 'Failed to logout user',
         description: `Something went wrong. Please try again: ${err}`,
-        status: 'error',
-        duration: 3000,
-        isClosable: true,
-        position: 'top-right',
       });
     }
   };

--- a/apps/protocol-frontend/src/main.tsx
+++ b/apps/protocol-frontend/src/main.tsx
@@ -3,7 +3,7 @@ import { createRoot } from 'react-dom/client';
 import 'regenerator-runtime/runtime';
 import { RainbowKitProvider } from '@rainbow-me/rainbowkit';
 import { WagmiConfig } from 'wagmi';
-import { ChakraProvider, useToast } from '@chakra-ui/react';
+import { ChakraProvider } from '@chakra-ui/react';
 import { GovrnTheme } from '@govrn/protocol-ui';
 import {
   QueryClient,
@@ -17,23 +17,20 @@ import { AuthContextProvider } from './contexts/AuthContext';
 import { wagmiClient, chains } from './utils/web3';
 import '@rainbow-me/rainbowkit/styles.css';
 import { UserContextProvider } from './contexts/UserContext';
+import useGovrnToast from './components/toast';
 
 const container = document.getElementById('root');
 const root = createRoot(container!);
 
 const App = () => {
   // we can refactor this to use a standalone toast
-  const toast = useToast();
+  const toast = useGovrnToast();
   const queryClient = new QueryClient({
     queryCache: new QueryCache({
       onError: error => {
-        toast({
+        toast.error({
           title: 'Something went wrong.',
           description: `Please try again: ${error}`,
-          status: 'error',
-          duration: 3000,
-          isClosable: true,
-          position: 'top-right',
         });
       },
     }),


### PR DESCRIPTION
## Linear Ticket

[PRO-448 - Create reusable Toast component](https://linear.app/govrn/issue/PRO-448/create-reusable-toast-component)

## Description
This adds a new wrapper around Chakra's toast to make it reusable and having consistent style without limiting the original Chakra's Toast itself. 

### Here are the comparison for the changes 
First, it has the same style: 
 ```diff 
- const toast = useToast();
+ const toast = useGovrnToast();
```

You need to provide mostly only `title` & `description`; this is the main goal to avoid boilerplate. In addition, :
```diff
+  toast.error({
    title: 'TITLE',
    description: `DESCRIPTION`,
-    status: 'error',
-    duration: 3000,
-    isClosable: true,
-    position: 'top-right',
  });
```
Finally, it's extensible to gain more feature from Chakra's Toast as needed.
```ts
 toast.isActive(toastUpdateContributionId)
``` 

