### PR TITLE
[Mint Modal] Change Tooltip Background

### DIFF
--- a/apps/protocol-frontend/src/components/MintModal.tsx
+++ b/apps/protocol-frontend/src/components/MintModal.tsx
@@ -92,10 +92,10 @@ const MintModal = ({ contributions }: MintModalProps) => {
           {contributions.length === 1 ? 'Contribution' : 'Contributions'}
         </Text>
         <Tooltip
+          hasArrow
           label={`Why Mint?
         Minting a Contribution makes it immutable and creates a historical record of what's been done that can't be changed.`}
           fontSize="md"
-          bgColor="brand.primary.50"
           placement="right"
         >
           <HStack width="fit-content">


### PR DESCRIPTION
## Linear Ticket

[PRO-500](https://linear.app/govrn/issue/PRO-500/mintmodal-text-in-tooltip-is-hard-to-read)

## Description

Change Tooltip to be more readable. 

## Screencaptures

### Before
<img width="788" alt="Screenshot 2022-11-07 at 9 15 56 PM" src="https://user-images.githubusercontent.com/12991700/200395327-c8c6e820-179f-40e7-a947-9218f1eb327f.png">

### After
<img width="783" alt="Screenshot 2022-11-07 at 9 15 29 PM" src="https://user-images.githubusercontent.com/12991700/200395256-0b9d8e4d-3d73-4ee6-9e12-472906800175.png">
