### PR TITLE
feature/dao-dashboard-avoid-refetching-on-tab (PRO-590)

### DIFF
--- a/apps/protocol-frontend/src/components/ContributionMembersPieShell.tsx
+++ b/apps/protocol-frontend/src/components/ContributionMembersPieShell.tsx
@@ -17,11 +17,14 @@ const ContributionMembersPieShell = ({
     isLoading,
     isError,
     data: contributionMembersData,
-  } = useDaoContributionCountByUserInRange({
-    startDate: startDate,
-    endDate: endDate,
-    guildId: daoId,
-  });
+  } = useDaoContributionCountByUserInRange(
+    {
+      startDate: startDate,
+      endDate: endDate,
+      guildId: daoId,
+    },
+    false,
+  );
 
   return (
     <ContributionMembersPie

--- a/apps/protocol-frontend/src/components/ContributionTypesPieShell.tsx
+++ b/apps/protocol-frontend/src/components/ContributionTypesPieShell.tsx
@@ -17,11 +17,14 @@ const ContributionTypesPieShell = ({
     isLoading,
     isError,
     data: contributionActivityData,
-  } = useContributionActivityType({
-    startDate: startDate,
-    endDate: endDate,
-    guildId: daoId,
-  });
+  } = useContributionActivityType(
+    {
+      startDate: startDate,
+      endDate: endDate,
+      guildId: daoId,
+    },
+    false,
+  );
 
   return (
     <ContributionTypesPie

--- a/apps/protocol-frontend/src/components/ContributionsByDateShell.tsx
+++ b/apps/protocol-frontend/src/components/ContributionsByDateShell.tsx
@@ -14,13 +14,16 @@ const ContributionByDateShell = ({
     isLoading,
     isError,
     data: contributionsByDate,
-  } = useContributionCountInRange({
-    id: null,
-    startDate: subWeeks(startOfDay(TODAY_DATE), YEAR),
-    endDate: endOfDay(TODAY_DATE),
-    guildIds,
-    excludeUnassigned: true,
-  });
+  } = useContributionCountInRange(
+    {
+      id: null,
+      startDate: subWeeks(startOfDay(TODAY_DATE), YEAR),
+      endDate: endOfDay(TODAY_DATE),
+      guildIds,
+      excludeUnassigned: true,
+    },
+    false,
+  );
 
   return (
     <ContributionsByDateChart

--- a/apps/protocol-frontend/src/components/MonthlyContributionsShell.tsx
+++ b/apps/protocol-frontend/src/components/MonthlyContributionsShell.tsx
@@ -16,11 +16,14 @@ const MonthlyContributionsShell = ({
     isLoading,
     isFetching,
     isError,
-  } = useDaoContributionCountInRange({
-    startDate: subWeeks(startOfDay(TODAY_DATE), MONTH),
-    endDate: endOfDay(TODAY_DATE),
-    guildId: daoId,
-  });
+  } = useDaoContributionCountInRange(
+    {
+      startDate: subWeeks(startOfDay(TODAY_DATE), MONTH),
+      endDate: endOfDay(TODAY_DATE),
+      guildId: daoId,
+    },
+    false,
+  );
 
   return (
     <CountDisplay

--- a/apps/protocol-frontend/src/components/RecentContributionsTableShell.tsx
+++ b/apps/protocol-frontend/src/components/RecentContributionsTableShell.tsx
@@ -19,13 +19,16 @@ const RecentContributionsTableShell = ({
     data: recentContributions,
     isLoading,
     isError,
-  } = useContributionList({
-    where: {
-      guilds: { some: { guild: { is: { id: { equals: daoId } } } } },
+  } = useContributionList(
+    {
+      where: {
+        guilds: { some: { guild: { is: { id: { equals: daoId } } } } },
+      },
+      first: displayNumber,
+      orderBy: { date_of_engagement: SortOrder.Desc },
     },
-    first: displayNumber,
-    orderBy: { date_of_engagement: SortOrder.Desc },
-  });
+    false,
+  );
 
   if (isError) {
     return (

--- a/apps/protocol-frontend/src/components/WeeklyActiveMembersShell.tsx
+++ b/apps/protocol-frontend/src/components/WeeklyActiveMembersShell.tsx
@@ -15,13 +15,16 @@ const WeeklyActiveMembersShell = ({ daoId }: WeeklyActiveMembersShellProps) => {
     isLoading,
     isFetching,
     isError,
-  } = useContributionList({
-    first: 500, //  TODO: want all contributions in range regardless of count -- better way to do this?
-    where: {
-      guilds: { some: { guild: { is: { id: { equals: daoId } } } } },
-      date_of_engagement: { gte: subWeeks(TODAY_DATE, 9) },
+  } = useContributionList(
+    {
+      first: 500, //  TODO: want all contributions in range regardless of count -- better way to do this?
+      where: {
+        guilds: { some: { guild: { is: { id: { equals: daoId } } } } },
+        date_of_engagement: { gte: subWeeks(TODAY_DATE, 9) },
+      },
     },
-  });
+    false,
+  );
 
   const setWeekRange = (weekRange: number) => {
     const weeks = [];

--- a/apps/protocol-frontend/src/hooks/useContributionActivityType.ts
+++ b/apps/protocol-frontend/src/hooks/useContributionActivityType.ts
@@ -6,12 +6,19 @@ export const useContributionActivityType = (
     startDate: Date;
     endDate: Date;
     guildId: number;
-
-  }) => {
-  const { govrnProtocol: govrn } = useUser()
-  const { isLoading, isFetching, isError, error, data } = useQuery(['contributionActivityTypes', args], async () => {
-    const data = await govrn.custom.getContributionCountByActivityType(args ? args : {})
-    return data
-  })
+  },
+  refetchOnWindowFocus?: boolean,
+) => {
+  const { govrnProtocol: govrn } = useUser();
+  const { isLoading, isFetching, isError, error, data } = useQuery({
+    queryKey: ['contributionActivityTypes', args],
+    queryFn: async () => {
+      const data = await govrn.custom.getContributionCountByActivityType(
+        args ? args : {},
+      );
+      return data;
+    },
+    refetchOnWindowFocus,
+  });
   return { isLoading, isError, isFetching, error, data };
-}
+};

--- a/apps/protocol-frontend/src/hooks/useContributionCount.ts
+++ b/apps/protocol-frontend/src/hooks/useContributionCount.ts
@@ -1,21 +1,25 @@
 import { useQuery } from '@tanstack/react-query';
 import { useUser } from '../contexts/UserContext';
 
-const useContributionCountInRange = (args: {
-  id?: number | null;
-  startDate: Date;
-  endDate: Date;
-  guildIds?: number[] | null;
-  excludeUnassigned?: boolean;
-}) => {
+const useContributionCountInRange = (
+  args: {
+    id?: number | null;
+    startDate: Date;
+    endDate: Date;
+    guildIds?: number[] | null;
+    excludeUnassigned?: boolean;
+  },
+  refetchOnWindowFocus?: boolean,
+) => {
   const { govrnProtocol: govrn } = useUser();
 
-  const { isLoading, isFetching, isError, error, data } = useQuery(
-    ['contributionGetCount', args],
-    async () => {
+  const { isLoading, isFetching, isError, error, data } = useQuery({
+    queryKey: ['contributionGetCount', args],
+    queryFn: async () => {
       return await govrn.custom.getContributionCountByDateForUserInRange(args);
     },
-  );
+    refetchOnWindowFocus,
+  });
 
   return { isLoading, isError, isFetching, error, data };
 };

--- a/apps/protocol-frontend/src/hooks/useContributionList.ts
+++ b/apps/protocol-frontend/src/hooks/useContributionList.ts
@@ -4,15 +4,19 @@ import { UIContribution } from '@govrn/ui-types';
 import { ListContributionsQueryVariables } from '@govrn/protocol-client';
 import { formatDate } from '../utils/date';
 
-export const useContributionList = (args?: ListContributionsQueryVariables) => {
+export const useContributionList = (
+  args?: ListContributionsQueryVariables,
+  refetchOnWindowFocus?: boolean,
+) => {
   const { govrnProtocol: govrn } = useUser();
-  const { isLoading, isFetching, isError, error, data } = useQuery(
-    ['contributionList', args],
-    async (): Promise<UIContribution[]> => {
+  const { isLoading, isFetching, isError, error, data } = useQuery({
+    queryKey: ['contributionList', args],
+    queryFn: async (): Promise<UIContribution[]> => {
       const data = await govrn.contribution.list(args || {});
       return data.result;
     },
-  );
+    refetchOnWindowFocus,
+  });
   return { isLoading, isError, isFetching, error, data };
 };
 

--- a/apps/protocol-frontend/src/hooks/useDaoContributionCount.ts
+++ b/apps/protocol-frontend/src/hooks/useDaoContributionCount.ts
@@ -1,23 +1,27 @@
 import { useQuery } from '@tanstack/react-query';
 import { useUser } from '../contexts/UserContext';
 
-const useDaoContributionCountInRange = (args: {
-  startDate: Date;
-  endDate: Date;
-  guildId: number;
-}) => {
+const useDaoContributionCountInRange = (
+  args: {
+    startDate: Date;
+    endDate: Date;
+    guildId: number;
+  },
+  refetchOnWindowFocus?: boolean,
+) => {
   const { govrnProtocol: govrn } = useUser();
 
-  const { isLoading, isFetching, isError, error, data } = useQuery(
-    ['daoContributionGetCount', args],
-    async () => {
+  const { isLoading, isFetching, isError, error, data } = useQuery({
+    queryKey: ['daoContributionGetCount', args],
+    queryFn: async () => {
       return await govrn.custom.getDaoContributionCount({
         startDate: args.startDate,
         endDate: args.endDate,
-        guildId: args.guildId
+        guildId: args.guildId,
       });
     },
-  );
+    refetchOnWindowFocus,
+  });
 
   return { isLoading, isError, isFetching, error, data };
 };

--- a/apps/protocol-frontend/src/hooks/useDaoContributionCountByUser.ts
+++ b/apps/protocol-frontend/src/hooks/useDaoContributionCountByUser.ts
@@ -1,24 +1,27 @@
 import { useQuery } from '@tanstack/react-query';
 import { useUser } from '../contexts/UserContext';
 
-const useDaoContributionCountByUserInRange = (args: {
-  startDate: Date;
-  endDate: Date;
-  guildId: number;
-}) => {
+const useDaoContributionCountByUserInRange = (
+  args: {
+    startDate: Date;
+    endDate: Date;
+    guildId: number;
+  },
+  refetchOnWindowFocus?: boolean,
+) => {
   const { govrnProtocol: govrn } = useUser();
 
-  const { isLoading, isFetching, isError, error, data } = useQuery(
-    ['daoContributionGetCountByUser', args],
-    async () => {
+  const { isLoading, isFetching, isError, error, data } = useQuery({
+    queryKey: ['daoContributionGetCountByUser', args],
+    queryFn: async () => {
       return await govrn.custom.getDaoContributionCountByUser({
         startDate: args.startDate,
         endDate: args.endDate,
         guildId: args.guildId,
       });
     },
-  );
-
+    refetchOnWindowFocus,
+  });
   return { isLoading, isError, isFetching, error, data };
 };
 


### PR DESCRIPTION
## Linear Ticket

- [PRO-590](https://linear.app/govrn/issue/PRO-590/weird-issue-where-page-reloads-when-window-is-focused)

## Description

- Adds a prop to certain queries to set the `refetchOnWindowFocus` to false (default is true). When this is false the query won't refetch stale data on retabbing
- Set the queries on the DAO Dashboard to have this be `false` so we avoid refetching when tabbing back

I started with the impacted queries but this slightly alters how we're passing in values to `useQuery` -- we may want to consider adding this prop to all of our queries to add more flexibility.
