### PR TITLE
feature/dao-dashboard-dao-menu-accordion (PRO-637, PRO-639)

### DIFF
--- a/apps/protocol-frontend/src/components/MobileNav.tsx
+++ b/apps/protocol-frontend/src/components/MobileNav.tsx
@@ -129,7 +129,9 @@ const MobileNav = ({ children, isOpen, onClose }: MobileNavProps) => {
                       </Link>
                       {isConnected && isAuthenticated && (
                         <Stack>
-                          {!daosListIsLoading && daosListData && (
+                          {!daosListIsLoading &&
+                          daosListData &&
+                          daosListData.length > 0 ? (
                             <Accordion allowToggle width="100%">
                               <AccordionItem border="none">
                                 <AccordionButton
@@ -161,7 +163,7 @@ const MobileNav = ({ children, isOpen, onClose }: MobileNavProps) => {
                                 </AccordionButton>
                                 <AccordionPanel paddingTop={0}>
                                   <Flex direction="column">
-                                    {daosListData?.slice(0, 5).map(dao => (
+                                    {daosListData?.map(dao => (
                                       <Stack paddingLeft={8} key={dao.id}>
                                         <Link to={`/feature/dao/${dao.id}`}>
                                           <Text
@@ -178,24 +180,19 @@ const MobileNav = ({ children, isOpen, onClose }: MobileNavProps) => {
                                         </Link>
                                       </Stack>
                                     ))}
-                                    {daosListData?.length > 5 && (
-                                      <Stack
-                                        paddingLeft={8}
-                                        transition="all 100ms ease-in-out"
-                                        _hover={{
-                                          fontWeight: 'medium',
-                                          color: 'gray.900',
-                                        }}
-                                      >
-                                        <Link to={`/feature/dao`}>
-                                          <Text>...and more</Text>
-                                        </Link>
-                                      </Stack>
-                                    )}
                                   </Flex>
                                 </AccordionPanel>
                               </AccordionItem>
                             </Accordion>
+                          ) : (
+                            <Link to="/feature/dao">
+                              <NavButton
+                                label="DAOs"
+                                icon={FiGitBranch}
+                                active={location.pathname.includes('/dao/')}
+                                marginBottom={4}
+                              />
+                            </Link>
                           )}
                         </Stack>
                       )}

--- a/apps/protocol-frontend/src/components/MobileNav.tsx
+++ b/apps/protocol-frontend/src/components/MobileNav.tsx
@@ -1,6 +1,11 @@
 import { Link, useLocation } from 'react-router-dom';
 import { TWITTER_LINK, DISCORD_LINK, FEEDBACK_LINK } from '../utils/constants';
 import {
+  Accordion,
+  AccordionItem,
+  AccordionButton,
+  AccordionIcon,
+  AccordionPanel,
   Button,
   Divider,
   Drawer,
@@ -12,10 +17,6 @@ import {
   Flex,
   Icon,
   HStack,
-  Menu,
-  MenuButton,
-  MenuItem,
-  MenuList,
   Stack,
   Text,
 } from '@chakra-ui/react';
@@ -28,7 +29,6 @@ import {
   FiPlusSquare,
   FiTwitter,
   FiUsers,
-  FiChevronDown,
   FiGitBranch,
 } from 'react-icons/fi';
 import { FaDiscord } from 'react-icons/fa';
@@ -129,59 +129,73 @@ const MobileNav = ({ children, isOpen, onClose }: MobileNavProps) => {
                       </Link>
                       {isConnected && isAuthenticated && (
                         <Stack>
-                          {!daosListIsLoading &&
-                          daosListData &&
-                          daosListData.length > 0 ? (
-                            <Menu
-                              placement="bottom-end"
-                              autoSelect={false}
-                              isLazy
-                            >
-                              <MenuButton
-                                as={Button}
-                                rightIcon={<FiChevronDown />}
-                                variant="ghost"
-                                justifyContent="start"
-                                color="gray.800"
-                                transition="all 100ms ease-in-out"
-                                backgroundColor="transparent"
-                                _hover={{ bgColor: 'gray.100' }}
-                                width="100%"
-                              >
-                                <HStack spacing="3">
-                                  <Icon
-                                    as={FiGitBranch}
-                                    boxSize="6"
-                                    color="subtle"
+                          {!daosListIsLoading && daosListData && (
+                            <Accordion allowToggle width="100%">
+                              <AccordionItem border="none">
+                                <AccordionButton
+                                  margin="0"
+                                  padding="0"
+                                  as={Button}
+                                  color="gray.800"
+                                  transition="all 100ms ease-in-out"
+                                  backgroundColor="transparent"
+                                  _hover={{ bgColor: 'gray.100' }}
+                                  width="100%"
+                                  variant="ghost"
+                                  justifyContent="start"
+                                >
+                                  <HStack spacing="3" paddingX={4} width="100%">
+                                    <Icon
+                                      as={FiGitBranch}
+                                      boxSize="6"
+                                      color="subtle"
+                                    />
+                                    <Text>DAOs</Text>
+                                  </HStack>
+                                  <AccordionIcon
+                                    padding="0"
+                                    marginRight={2}
+                                    color="gray.800"
+                                    backgroundColor="none"
                                   />
-                                  <Text>DAOs</Text>
-                                </HStack>
-                              </MenuButton>
-                              <MenuList
-                                backgroundColor="gray.800"
-                                minWidth="none"
-                              >
-                                {daosListData?.map(dao => (
-                                  <Link to={`/feature/dao/${dao.id}`}>
-                                    <MenuItem
-                                      color="white"
-                                      _hover={{ backgroundColor: 'gray.600' }}
-                                    >
-                                      {dao.name}
-                                    </MenuItem>
-                                  </Link>
-                                ))}
-                              </MenuList>
-                            </Menu>
-                          ) : (
-                            <Link to="/feature/dao">
-                              <NavButton
-                                label="DAOs"
-                                icon={FiGitBranch}
-                                active={location.pathname.includes('/dao/')}
-                                marginBottom={4}
-                              />
-                            </Link>
+                                </AccordionButton>
+                                <AccordionPanel paddingTop={0}>
+                                  <Flex direction="column">
+                                    {daosListData?.slice(0, 5).map(dao => (
+                                      <Stack paddingLeft={8} key={dao.id}>
+                                        <Link to={`/feature/dao/${dao.id}`}>
+                                          <Text
+                                            as="span"
+                                            color="gray.800"
+                                            transition="all 100ms ease-in-out"
+                                            _hover={{
+                                              fontWeight: 'medium',
+                                              color: 'gray.900',
+                                            }}
+                                          >
+                                            {dao.name}
+                                          </Text>
+                                        </Link>
+                                      </Stack>
+                                    ))}
+                                    {daosListData?.length > 5 && (
+                                      <Stack
+                                        paddingLeft={8}
+                                        transition="all 100ms ease-in-out"
+                                        _hover={{
+                                          fontWeight: 'medium',
+                                          color: 'gray.900',
+                                        }}
+                                      >
+                                        <Link to={`/feature/dao`}>
+                                          <Text>...and more</Text>
+                                        </Link>
+                                      </Stack>
+                                    )}
+                                  </Flex>
+                                </AccordionPanel>
+                              </AccordionItem>
+                            </Accordion>
                           )}
                         </Stack>
                       )}
@@ -197,7 +211,7 @@ const MobileNav = ({ children, isOpen, onClose }: MobileNavProps) => {
                     width="100%"
                     flex="1 1 auto"
                   >
-                    <Divider />
+                    <Divider marginTop={2} />
                     <Stack shouldWrapChildren>
                       <NavButton
                         label="Discord"

--- a/apps/protocol-frontend/src/components/NavButton.tsx
+++ b/apps/protocol-frontend/src/components/NavButton.tsx
@@ -26,7 +26,7 @@ export const NavButton = ({
   ...buttonProps
 }: NavButtonProps) => {
   return linkTo ? (
-    <ChakraLink href={linkTo} isExternal>
+    <ChakraLink href={linkTo} isExternal _hover={{ textDecoration: 'none' }}>
       <Button
         variant="ghost"
         justifyContent="start"
@@ -39,7 +39,7 @@ export const NavButton = ({
         {...buttonProps}
       >
         <HStack spacing="3">
-          <Icon as={icon} boxSize="6" color="gray.50" />
+          <Icon as={icon} boxSize="6" color="gray.800" />
           <Text>{label}</Text>
         </HStack>
       </Button>
@@ -57,7 +57,7 @@ export const NavButton = ({
       {...buttonProps}
     >
       <HStack spacing="3">
-        <Icon as={icon} boxSize="6" color="subtle" />
+        <Icon as={icon} boxSize="6" color="gray.800" />
         <Text>{label}</Text>
       </HStack>
     </Button>

--- a/apps/protocol-frontend/src/components/NavButton.tsx
+++ b/apps/protocol-frontend/src/components/NavButton.tsx
@@ -39,7 +39,7 @@ export const NavButton = ({
         {...buttonProps}
       >
         <HStack spacing="3">
-          <Icon as={icon} boxSize="6" color="subtle" />
+          <Icon as={icon} boxSize="6" color="gray.50" />
           <Text>{label}</Text>
         </HStack>
       </Button>

--- a/apps/protocol-frontend/src/components/Sidebar.tsx
+++ b/apps/protocol-frontend/src/components/Sidebar.tsx
@@ -115,7 +115,9 @@ const Sidebar = () => {
             </Link>
             {isConnected && isAuthenticated && (
               <Stack>
-                {!daosListIsLoading && daosListData && (
+                {!daosListIsLoading &&
+                daosListData &&
+                daosListData.length > 0 ? (
                   <Accordion allowToggle width="100%">
                     <AccordionItem border="none">
                       <AccordionButton
@@ -143,7 +145,7 @@ const Sidebar = () => {
                       </AccordionButton>
                       <AccordionPanel paddingTop={0}>
                         <Flex direction="column">
-                          {daosListData?.slice(0, 5).map(dao => (
+                          {daosListData?.map(dao => (
                             <Stack paddingLeft={8} key={dao.id}>
                               <Link to={`/feature/dao/${dao.id}`}>
                                 <Text
@@ -160,24 +162,18 @@ const Sidebar = () => {
                               </Link>
                             </Stack>
                           ))}
-                          {daosListData?.length > 5 && (
-                            <Stack
-                              paddingLeft={8}
-                              transition="all 100ms ease-in-out"
-                              _hover={{
-                                fontWeight: 'medium',
-                                color: 'gray.900',
-                              }}
-                            >
-                              <Link to={`/feature/dao`}>
-                                <Text>...and more</Text>
-                              </Link>
-                            </Stack>
-                          )}
                         </Flex>
                       </AccordionPanel>
                     </AccordionItem>
                   </Accordion>
+                ) : (
+                  <Link to="/feature/dao">
+                    <NavButton
+                      label="DAOs"
+                      icon={FiGitBranch}
+                      active={location.pathname.includes('/dao/')}
+                    />
+                  </Link>
                 )}
               </Stack>
             )}

--- a/apps/protocol-frontend/src/components/Sidebar.tsx
+++ b/apps/protocol-frontend/src/components/Sidebar.tsx
@@ -1,6 +1,12 @@
 import { TWITTER_LINK, DISCORD_LINK, FEEDBACK_LINK } from '../utils/constants';
 import { Link, useLocation } from 'react-router-dom';
 import {
+  Accordion,
+  AccordionItem,
+  AccordionButton,
+  AccordionIcon,
+  AccordionPanel,
+  Box,
   Button,
   Divider,
   Flex,
@@ -115,47 +121,51 @@ const Sidebar = () => {
             </Link>
             {isConnected && isAuthenticated && (
               <Stack>
-                {!daosListIsLoading &&
-                daosListData &&
-                daosListData.length > 0 ? (
-                  <Menu placement="bottom-end" autoSelect={false} isLazy>
-                    <MenuButton
-                      as={Button}
-                      rightIcon={<FiChevronDown />}
-                      variant="ghost"
-                      justifyContent="start"
-                      color="gray.800"
-                      transition="all 100ms ease-in-out"
-                      backgroundColor="transparent"
-                      _hover={{ bgColor: 'gray.100' }}
-                      width="100%"
-                    >
-                      <HStack spacing="3">
-                        <Icon as={FiGitBranch} boxSize="6" color="subtle" />
-                        <Text>DAOs</Text>
-                      </HStack>
-                    </MenuButton>
-                    <MenuList backgroundColor="gray.800" minWidth="none">
-                      {daosListData?.map(dao => (
-                        <Link to={`/feature/dao/${dao.id}`}>
-                          <MenuItem
-                            color="white"
-                            _hover={{ backgroundColor: 'gray.600' }}
+                {!daosListIsLoading && daosListData && (
+                  <Accordion allowToggle width="100%" paddingRight={4}>
+                    <AccordionItem border="none">
+                      <h2>
+                        <AccordionButton margin="0" padding="0">
+                          <Button
+                            as={Button}
+                            variant="ghost"
+                            justifyContent="start"
+                            color="gray.800"
+                            transition="all 100ms ease-in-out"
+                            backgroundColor="transparent"
+                            _hover={{ bgColor: 'gray.100' }}
+                            width="100%"
                           >
-                            {dao.name}
-                          </MenuItem>
-                        </Link>
-                      ))}
-                    </MenuList>
-                  </Menu>
-                ) : (
-                  <Link to="/feature/dao">
-                    <NavButton
-                      label="DAOs"
-                      icon={FiGitBranch}
-                      active={location.pathname.includes('/dao/')}
-                    />
-                  </Link>
+                            <HStack spacing="3">
+                              <Icon
+                                as={FiGitBranch}
+                                boxSize="6"
+                                color="subtle"
+                              />
+                              <Text>DAOs</Text>
+                            </HStack>
+                          </Button>
+                          <AccordionIcon />
+                        </AccordionButton>
+                      </h2>
+                      <AccordionPanel>
+                        <Flex direction="column">
+                          {daosListData?.slice(0, 4).map(dao => (
+                            <Link to={`/feature/dao/${dao.id}`}>
+                              <Text as="span" color="gray.800">
+                                {dao.name}
+                              </Text>
+                            </Link>
+                          ))}
+                          {daosListData?.length > 5 && (
+                            <Link to={`/feature/dao`}>
+                              <Text>...and more</Text>
+                            </Link>
+                          )}
+                        </Flex>
+                      </AccordionPanel>
+                    </AccordionItem>
+                  </Accordion>
                 )}
               </Stack>
             )}

--- a/apps/protocol-frontend/src/components/Sidebar.tsx
+++ b/apps/protocol-frontend/src/components/Sidebar.tsx
@@ -6,16 +6,11 @@ import {
   AccordionButton,
   AccordionIcon,
   AccordionPanel,
-  Box,
   Button,
   Divider,
   Flex,
   HStack,
   Icon,
-  Menu,
-  MenuButton,
-  MenuItem,
-  MenuList,
   Stack,
   Text,
 } from '@chakra-ui/react';
@@ -27,7 +22,6 @@ import {
   FiTwitter,
   FiUsers,
   FiMessageSquare,
-  FiChevronDown,
   FiGitBranch,
 } from 'react-icons/fi';
 import { FaDiscord } from 'react-icons/fa';

--- a/apps/protocol-frontend/src/components/Sidebar.tsx
+++ b/apps/protocol-frontend/src/components/Sidebar.tsx
@@ -146,7 +146,7 @@ const Sidebar = () => {
                       <AccordionPanel paddingTop={0}>
                         <Flex direction="column">
                           {daosListData?.map(dao => (
-                            <Stack paddingLeft={8} key={dao.id}>
+                            <Stack paddingLeft={8} paddingY={1} key={dao.id}>
                               <Link to={`/feature/dao/${dao.id}`}>
                                 <Text
                                   as="span"

--- a/apps/protocol-frontend/src/components/Sidebar.tsx
+++ b/apps/protocol-frontend/src/components/Sidebar.tsx
@@ -136,40 +136,49 @@ const Sidebar = () => {
                         variant="ghost"
                         justifyContent="start"
                       >
-                        {/* <Button
-                          variant="ghost"
-                          justifyContent="start"
-                          // color="gray.800"
-                          // transition="all 100ms ease-in-out"
-                          // backgroundColor="transparent"
-                          // _hover={{ bgColor: 'gray.100' }}
-                          width="100%"
-                        > */}
                         <HStack spacing="3" paddingX={4} width="100%">
                           <Icon as={FiGitBranch} boxSize="6" color="subtle" />
                           <Text>DAOs</Text>
                         </HStack>
-                        {/* </Button> */}
                         <AccordionIcon
                           padding="0"
+                          marginRight={2}
                           color="gray.800"
                           backgroundColor="none"
                         />
                       </AccordionButton>
-
-                      <AccordionPanel>
+                      <AccordionPanel paddingTop={0}>
                         <Flex direction="column">
-                          {daosListData?.slice(0, 4).map(dao => (
-                            <Link to={`/feature/dao/${dao.id}`}>
-                              <Text as="span" color="gray.800">
-                                {dao.name}
-                              </Text>
-                            </Link>
+                          {daosListData?.slice(0, 5).map(dao => (
+                            <Stack paddingLeft={8} key={dao.id}>
+                              <Link to={`/feature/dao/${dao.id}`}>
+                                <Text
+                                  as="span"
+                                  color="gray.800"
+                                  transition="all 100ms ease-in-out"
+                                  _hover={{
+                                    fontWeight: 'medium',
+                                    color: 'gray.900',
+                                  }}
+                                >
+                                  {dao.name}
+                                </Text>
+                              </Link>
+                            </Stack>
                           ))}
                           {daosListData?.length > 5 && (
-                            <Link to={`/feature/dao`}>
-                              <Text>...and more</Text>
-                            </Link>
+                            <Stack
+                              paddingLeft={8}
+                              transition="all 100ms ease-in-out"
+                              _hover={{
+                                fontWeight: 'medium',
+                                color: 'gray.900',
+                              }}
+                            >
+                              <Link to={`/feature/dao`}>
+                                <Text>...and more</Text>
+                              </Link>
+                            </Stack>
                           )}
                         </Flex>
                       </AccordionPanel>

--- a/apps/protocol-frontend/src/components/Sidebar.tsx
+++ b/apps/protocol-frontend/src/components/Sidebar.tsx
@@ -122,32 +122,41 @@ const Sidebar = () => {
             {isConnected && isAuthenticated && (
               <Stack>
                 {!daosListIsLoading && daosListData && (
-                  <Accordion allowToggle width="100%" paddingRight={4}>
+                  <Accordion allowToggle width="100%">
                     <AccordionItem border="none">
-                      <h2>
-                        <AccordionButton margin="0" padding="0">
-                          <Button
-                            as={Button}
-                            variant="ghost"
-                            justifyContent="start"
-                            color="gray.800"
-                            transition="all 100ms ease-in-out"
-                            backgroundColor="transparent"
-                            _hover={{ bgColor: 'gray.100' }}
-                            width="100%"
-                          >
-                            <HStack spacing="3">
-                              <Icon
-                                as={FiGitBranch}
-                                boxSize="6"
-                                color="subtle"
-                              />
-                              <Text>DAOs</Text>
-                            </HStack>
-                          </Button>
-                          <AccordionIcon />
-                        </AccordionButton>
-                      </h2>
+                      <AccordionButton
+                        margin="0"
+                        padding="0"
+                        as={Button}
+                        color="gray.800"
+                        transition="all 100ms ease-in-out"
+                        backgroundColor="transparent"
+                        _hover={{ bgColor: 'gray.100' }}
+                        width="100%"
+                        variant="ghost"
+                        justifyContent="start"
+                      >
+                        {/* <Button
+                          variant="ghost"
+                          justifyContent="start"
+                          // color="gray.800"
+                          // transition="all 100ms ease-in-out"
+                          // backgroundColor="transparent"
+                          // _hover={{ bgColor: 'gray.100' }}
+                          width="100%"
+                        > */}
+                        <HStack spacing="3" paddingX={4} width="100%">
+                          <Icon as={FiGitBranch} boxSize="6" color="subtle" />
+                          <Text>DAOs</Text>
+                        </HStack>
+                        {/* </Button> */}
+                        <AccordionIcon
+                          padding="0"
+                          color="gray.800"
+                          backgroundColor="none"
+                        />
+                      </AccordionButton>
+
                       <AccordionPanel>
                         <Flex direction="column">
                           {daosListData?.slice(0, 4).map(dao => (


### PR DESCRIPTION
## Linear Ticket

- [PRO-637](https://linear.app/govrn/issue/PRO-637/dao-menu-dropdown-accordion)
- [PRO-639](https://linear.app/govrn/issue/PRO-639/[bug]-scrolling-issue-on-side-bar-for-daodashboards)

## Description

This changes the DAOs menu item to use an accordion pattern similar to Linear/Notion. If a user is connected and in DAOs, they'll show here and link to the DAO Dashboard.

Shows all of a user's DAOs. We'll change this to only show 5 and a '...and more' option soon. Previous iteration of this included this functionality but I removed it for now.

## Screencaptures

Desktop:

https://user-images.githubusercontent.com/9438776/202503108-fe42a21b-e58f-4939-8bb4-918644351b8d.mp4


Mobile:

https://user-images.githubusercontent.com/9438776/202503143-f2f1974f-8aa3-4989-b31e-af292cae5890.mp4


