### PR TITLE
attestation-state-reset (PRO-655)

### DIFF
--- a/apps/protocol-frontend/src/components/AttestationsTable.tsx
+++ b/apps/protocol-frontend/src/components/AttestationsTable.tsx
@@ -68,6 +68,10 @@ const AttestationsTable = ({
     [contributionsData, userData?.id],
   );
 
+  const toggleSelected = () => {
+    toggleAllRowsSelected(false);
+  };
+
   const columns = useMemo<Column<AttestationTableType>[]>(
     () => [
       {
@@ -147,6 +151,7 @@ const AttestationsTable = ({
     setGlobalFilter,
     selectedFlatRows,
     prepareRow,
+    toggleAllRowsSelected,
   } = useTable(
     { columns, data, autoResetSelectedRows: false },
     useFilters,
@@ -297,7 +302,10 @@ const AttestationsTable = ({
           localOverlay={localOverlay}
           size="3xl"
           content={
-            <AttestationModal contribution={selectedFlatRows[0].original} />
+            <AttestationModal
+              contribution={selectedFlatRows[0].original}
+              onFinish={toggleSelected}
+            />
           }
         />
       )}

--- a/apps/protocol-frontend/src/components/AttestationsTable.tsx
+++ b/apps/protocol-frontend/src/components/AttestationsTable.tsx
@@ -68,10 +68,6 @@ const AttestationsTable = ({
     [contributionsData, userData?.id],
   );
 
-  const toggleSelected = () => {
-    toggleAllRowsSelected(false);
-  };
-
   const columns = useMemo<Column<AttestationTableType>[]>(
     () => [
       {
@@ -90,7 +86,6 @@ const AttestationsTable = ({
         accessor: 'attestations',
         Cell: ({ value }) => {
           let status = 'Unattested';
-          console.log(value);
           if (value && value.length > 0) {
             status = value[0].attestation_status?.name || 'Unattested';
           }
@@ -160,6 +155,10 @@ const AttestationsTable = ({
     useRowSelect,
     tableHooks,
   );
+
+  const toggleSelected = () => {
+    toggleAllRowsSelected(false);
+  };
 
   const attestationsModalHandler = useCallback(() => {
     if (selectedFlatRows.length > 1) {
@@ -292,6 +291,7 @@ const AttestationsTable = ({
         content={
           <BulkAttestationModal
             contributions={selectedFlatRows.map(r => r.original)}
+            onFinish={toggleSelected}
           />
         }
       />

--- a/apps/protocol-frontend/src/components/BulkAttestationModal.tsx
+++ b/apps/protocol-frontend/src/components/BulkAttestationModal.tsx
@@ -1,5 +1,4 @@
-import { useState } from 'react';
-import { Button, Flex, Progress, Stack, Text } from '@chakra-ui/react';
+import { Button, Flex, Stack, Text } from '@chakra-ui/react';
 import { useUser } from '../contexts/UserContext';
 import { useOverlay } from '../contexts/OverlayContext';
 import { AttestationTableType } from '../types/table';
@@ -86,7 +85,6 @@ export const BulkAttestationModal = ({
   const { userData } = useUser();
   const { isLoading: attesting, mutateAsync: bulkMintAttestation } =
     useAttestationBulkMint();
-  const [currentAttestation] = useState(1);
   const { setModals } = useOverlay();
 
   const createAttestationsHandler = async (
@@ -126,12 +124,6 @@ export const BulkAttestationModal = ({
           text: c.name,
         }))}
       />
-      {attesting ? (
-        <Progress
-          color="brand.primary"
-          value={currentAttestation % contributions.length}
-        />
-      ) : null}
       <Flex align="flex-end" marginTop={4}>
         <Button
           type="submit"

--- a/apps/protocol-frontend/src/components/BulkAttestationModal.tsx
+++ b/apps/protocol-frontend/src/components/BulkAttestationModal.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Button, Flex, Progress, Stack, Text } from '@chakra-ui/react';
 import { useUser } from '../contexts/UserContext';
+import { useOverlay } from '../contexts/OverlayContext';
 import { AttestationTableType } from '../types/table';
 import pluralize from 'pluralize';
 import useAttestationBulkMint from '../hooks/useAttestationBulkMint';
@@ -21,8 +22,8 @@ export const AttestationModal = ({
 }) => {
   const { userData } = useUser();
   const { isLoading: attesting, mutateAsync: mintAttestation } =
-    // useAttestationMint(onFinish);
     useAttestationMint();
+  const { setModals } = useOverlay();
 
   const createAttestationsHandler = async (
     contributions: AttestationTableType,
@@ -35,6 +36,8 @@ export const AttestationModal = ({
         onChainId: contribution.onChainId,
         contributionId: contribution.id,
       });
+      setModals({ attestationModal: false });
+      if (onFinish) onFinish();
     } catch (e) {
       console.error(e);
     }
@@ -82,8 +85,9 @@ export const BulkAttestationModal = ({
 }: BulkAttestationModalProps) => {
   const { userData } = useUser();
   const { isLoading: attesting, mutateAsync: bulkMintAttestation } =
-    useAttestationBulkMint(onFinish);
+    useAttestationBulkMint();
   const [currentAttestation] = useState(1);
+  const { setModals } = useOverlay();
 
   const createAttestationsHandler = async (
     contributions: AttestationTableType[],
@@ -100,6 +104,8 @@ export const BulkAttestationModal = ({
         });
       }
       await bulkMintAttestation(attestationInput);
+      setModals({ bulkAttestationModal: false });
+      if (onFinish) onFinish();
     } catch (e) {
       console.error(e);
     }

--- a/apps/protocol-frontend/src/components/BulkAttestationModal.tsx
+++ b/apps/protocol-frontend/src/components/BulkAttestationModal.tsx
@@ -9,15 +9,19 @@ import { TextList } from './TextList';
 
 interface BulkAttestationModalProps {
   contributions: AttestationTableType[];
+  onFinish?: (() => void) | undefined;
 }
 
 export const AttestationModal = ({
   contribution,
+  onFinish,
 }: {
   contribution: AttestationTableType;
+  onFinish?: (() => void) | undefined;
 }) => {
   const { userData } = useUser();
   const { isLoading: attesting, mutateAsync: mintAttestation } =
+    // useAttestationMint(onFinish);
     useAttestationMint();
 
   const createAttestationsHandler = async (
@@ -74,10 +78,11 @@ export const AttestationModal = ({
 
 export const BulkAttestationModal = ({
   contributions,
+  onFinish,
 }: BulkAttestationModalProps) => {
   const { userData } = useUser();
   const { isLoading: attesting, mutateAsync: bulkMintAttestation } =
-    useAttestationBulkMint();
+    useAttestationBulkMint(onFinish);
   const [currentAttestation] = useState(1);
 
   const createAttestationsHandler = async (

--- a/apps/protocol-frontend/src/components/ContributionsTable.tsx
+++ b/apps/protocol-frontend/src/components/ContributionsTable.tsx
@@ -88,14 +88,6 @@ const ContributionsTable = ({
     setModals({ editContributionFormModal: true });
   };
 
-  const mintModalHandler = () => {
-    setModals({ mintModal: true });
-  };
-
-  const bulkDaoAttributeHandler = () => {
-    setModals({ bulkDaoAttributeModal: true });
-  };
-
   const [dialog, setDialog] = useState<DialogProps>({
     isOpen: false,
     title: '',
@@ -437,6 +429,7 @@ const ContributionsTable = ({
           content={
             <BulkDaoAttributeModal
               contributions={selectedFlatRows.map(r => r.original)}
+              onFinish={toggleSelected}
             />
           }
         />

--- a/apps/protocol-frontend/src/components/ContributionsTable.tsx
+++ b/apps/protocol-frontend/src/components/ContributionsTable.tsx
@@ -429,7 +429,6 @@ const ContributionsTable = ({
           content={
             <BulkDaoAttributeModal
               contributions={selectedFlatRows.map(r => r.original)}
-              onFinish={toggleSelected}
             />
           }
         />

--- a/apps/protocol-frontend/src/components/ContributionsTable.tsx
+++ b/apps/protocol-frontend/src/components/ContributionsTable.tsx
@@ -34,6 +34,8 @@ import { Link } from 'react-router-dom';
 import { IoArrowDown, IoArrowUp } from 'react-icons/io5';
 import { FiEdit2, FiTrash2 } from 'react-icons/fi';
 import ModalWrapper from './ModalWrapper';
+import MintModal from './MintModal';
+import BulkDaoAttributeModal from './BulkDaoAttributeModal';
 import { useOverlay } from '../contexts/OverlayContext';
 import IndeterminateCheckbox from './IndeterminateCheckbox';
 import GlobalFilter from './GlobalFilter';
@@ -46,7 +48,6 @@ import InfiniteScroll from 'react-infinite-scroll-component';
 import { ContributionTableType } from '../types/table';
 import { mergePages } from '../utils/arrays';
 import { formatDate } from '../utils/date';
-import BulkDaoAttributeModal from './BulkDaoAttributeModal';
 
 export type DialogProps = {
   isOpen: boolean;
@@ -85,6 +86,14 @@ const ContributionsTable = ({
   const handleEditContributionFormModal = (id: number) => {
     setSelectedContribution(id);
     setModals({ editContributionFormModal: true });
+  };
+
+  const mintModalHandler = () => {
+    setModals({ mintModal: true });
+  };
+
+  const bulkDaoAttributeHandler = () => {
+    setModals({ bulkDaoAttributeModal: true });
   };
 
   const [dialog, setDialog] = useState<DialogProps>({
@@ -323,6 +332,7 @@ const ContributionsTable = ({
     setGlobalFilter,
     selectedFlatRows,
     prepareRow,
+    toggleAllRowsSelected,
   } = useTable(
     { columns, data, autoResetSelectedRows: false },
     useFilters,
@@ -335,6 +345,10 @@ const ContributionsTable = ({
   useEffect(() => {
     setSelectedContributions(selectedFlatRows);
   }, [selectedFlatRows, selectedRowIds]);
+
+  const toggleSelected = () => {
+    toggleAllRowsSelected(false);
+  };
 
   return (
     <Stack>
@@ -427,6 +441,29 @@ const ContributionsTable = ({
           }
         />
         <DeleteContributionDialog dialog={dialog} setDialog={setDialog} />
+        <ModalWrapper
+          name="mintModal"
+          title="Mint Your DAO Contributions"
+          localOverlay={localOverlay}
+          size="3xl"
+          content={
+            <MintModal
+              contributions={selectedFlatRows}
+              onFinish={toggleSelected}
+            />
+          }
+        />
+        <ModalWrapper
+          name="bulkDaoAttributeModal"
+          title="Attribute Contributions to a DAO"
+          localOverlay={localOverlay}
+          size="3xl"
+          content={
+            <BulkDaoAttributeModal
+              contributions={selectedFlatRows.map(r => r.original)}
+            />
+          }
+        />
       </Box>
     </Stack>
   );

--- a/apps/protocol-frontend/src/components/ContributionsTableShell.tsx
+++ b/apps/protocol-frontend/src/components/ContributionsTableShell.tsx
@@ -14,10 +14,7 @@ import {
   Text,
 } from '@chakra-ui/react';
 import { useOverlay } from '../contexts/OverlayContext';
-import ModalWrapper from './ModalWrapper';
 import { GovrnSpinner } from '@govrn/protocol-ui';
-import MintModal from './MintModal';
-import BulkDaoAttributeModal from './BulkDaoAttributeModal';
 import PageHeading from './PageHeading';
 import ContributionsTable from './ContributionsTable';
 import ContributionTypesTable from './ContributionTypesTable';
@@ -54,164 +51,144 @@ const ContributionsTableShell = () => {
   };
 
   return (
-    <>
-      <Container
-        paddingY={{ base: '4', md: '8' }}
-        paddingX={{ base: '0', md: '8' }}
-        color="gray.700"
-        maxWidth="1200px"
-      >
-        <PageHeading>Contributions</PageHeading>
-        {isFetching && contributions && contributions.pages.length === 0 ? (
-          <GovrnSpinner />
-        ) : contributions && contributions.pages.length > 0 ? (
-          <Tabs
-            variant="soft-rounded"
-            colorScheme="gray"
-            width="100%"
-            maxWidth="100vw"
-            paddingX={{ base: 4, lg: 0 }}
-          >
-            <TabList>
-              <Tab>Contributions</Tab>
-              <Tab>Contribution Types</Tab>
-            </TabList>
-            <TabPanels>
-              <TabPanel paddingX="0">
-                <Box
-                  background="white"
-                  boxShadow="sm"
-                  borderRadius={{ base: 'none', md: 'lg' }}
-                >
-                  <Stack spacing="5">
-                    <Box paddingX={{ base: '4', md: '6' }} paddingTop={4}>
-                      <Stack
-                        direction={{ base: 'column', md: 'row' }}
-                        justifyContent={{ base: 'center', lg: 'space-between' }}
-                        alignItems={{ base: 'flex-start', lg: 'center' }}
-                        width={{ base: '100%' }}
-                        maxWidth="100vw"
-                      >
-                        <Text fontSize="lg" fontWeight="medium">
-                          My Contributions
-                        </Text>
-                        {selectedContributions?.length === 0 ? (
-                          <Alert
-                            status="info"
-                            width={{ base: '100%', lg: '60%' }}
-                            borderRadius="md"
-                          >
-                            <AlertDescription>
-                              <span
-                                role="img"
-                                aria-labelledby="Sun emoji for alert to select at least one Contribution to mint."
-                              >
-                                🌞
-                              </span>{' '}
-                              Please select at least one Contribution to
-                              attribute to a DAO or mint.
-                            </AlertDescription>
-                          </Alert>
-                        ) : (
-                          <Stack direction="row" spacing={5}>
-                            <Button
-                              size="md"
-                              bgColor="brand.primary.50"
-                              color="brand.primary.600"
-                              transition="all 100ms ease-in-out"
-                              _hover={{ bgColor: 'brand.primary.100' }}
-                              colorScheme="brand.primary"
-                              onClick={bulkDaoAttributeHandler}
-                              disabled={selectedContributions?.length === 0}
+    <Container
+      paddingY={{ base: '4', md: '8' }}
+      paddingX={{ base: '0', md: '8' }}
+      color="gray.700"
+      maxWidth="1200px"
+    >
+      <PageHeading>Contributions</PageHeading>
+      {isFetching && contributions && contributions.pages.length === 0 ? (
+        <GovrnSpinner />
+      ) : contributions && contributions.pages.length > 0 ? (
+        <Tabs
+          variant="soft-rounded"
+          colorScheme="gray"
+          width="100%"
+          maxWidth="100vw"
+          paddingX={{ base: 4, lg: 0 }}
+        >
+          <TabList>
+            <Tab>Contributions</Tab>
+            <Tab>Contribution Types</Tab>
+          </TabList>
+          <TabPanels>
+            <TabPanel paddingX="0">
+              <Box
+                background="white"
+                boxShadow="sm"
+                borderRadius={{ base: 'none', md: 'lg' }}
+              >
+                <Stack spacing="5">
+                  <Box paddingX={{ base: '4', md: '6' }} paddingTop={4}>
+                    <Stack
+                      direction={{ base: 'column', md: 'row' }}
+                      justifyContent={{ base: 'center', lg: 'space-between' }}
+                      alignItems={{ base: 'flex-start', lg: 'center' }}
+                      width={{ base: '100%' }}
+                      maxWidth="100vw"
+                    >
+                      <Text fontSize="lg" fontWeight="medium">
+                        My Contributions
+                      </Text>
+                      {selectedContributions?.length === 0 ? (
+                        <Alert
+                          status="info"
+                          width={{ base: '100%', lg: '60%' }}
+                          borderRadius="md"
+                        >
+                          <AlertDescription>
+                            <span
+                              role="img"
+                              aria-labelledby="Sun emoji for alert to select at least one Contribution to mint."
                             >
-                              Attribute to DAO
-                            </Button>
-                            <Button
-                              size="md"
-                              bgColor="white"
-                              color="brand.primary.600"
-                              border="1px solid"
-                              borderColor="brand.primary.500"
-                              transition="all 100ms ease-in-out"
-                              _hover={{ bgColor: 'brand.primary.50' }}
-                              colorScheme="brand.primary"
-                              onClick={mintModalHandler}
-                              disabled={selectedContributions?.length === 0}
-                              data-testid="mint-btn-test"
-                            >
-                              {selectedContributions?.length > 1
-                                ? 'Bulk Mint'
-                                : 'Mint'}
-                            </Button>
-                          </Stack>
-                        )}
-                      </Stack>
-                    </Box>
-                    <Box width="100%" maxWidth="100vw" overflowX="auto">
-                      <ContributionsTable
-                        contributionsData={contributions.pages}
-                        setSelectedContributions={setSelectedContributions}
-                        nextPage={fetchNextPage}
-                        hasMoreItems={hasNextPage || false}
-                      />
-                    </Box>
-                  </Stack>
-                </Box>
-              </TabPanel>
-              <TabPanel paddingX="0">
-                <Box
-                  background="white"
-                  boxShadow="sm"
-                  borderRadius={{ base: 'none', md: 'lg' }}
-                >
-                  <Stack spacing="5">
-                    <Box paddingX={{ base: '4', md: '6' }} paddingTop={4}>
-                      <Stack
-                        direction={{ base: 'column', md: 'row' }}
-                        justify="space-between"
-                      >
-                        <Text fontSize="lg" fontWeight="medium">
-                          Contribution Types
-                        </Text>
-                      </Stack>
-                    </Box>
-                    <Box width="100%" maxWidth="100vw" overflowX="auto">
-                      {contributions.pages.length > 0 ? (
-                        <ContributionTypesTable
-                          contributionTypesData={contributions.pages}
-                        />
+                              🌞
+                            </span>{' '}
+                            Please select at least one Contribution to attribute
+                            to a DAO or mint.
+                          </AlertDescription>
+                        </Alert>
                       ) : (
-                        <EmptyContributions />
+                        <Stack direction="row" spacing={5}>
+                          <Button
+                            size="md"
+                            bgColor="brand.primary.50"
+                            color="brand.primary.600"
+                            transition="all 100ms ease-in-out"
+                            _hover={{ bgColor: 'brand.primary.100' }}
+                            colorScheme="brand.primary"
+                            onClick={bulkDaoAttributeHandler}
+                            disabled={selectedContributions?.length === 0}
+                          >
+                            Attribute to DAO
+                          </Button>
+                          <Button
+                            size="md"
+                            bgColor="white"
+                            color="brand.primary.600"
+                            border="1px solid"
+                            borderColor="brand.primary.500"
+                            transition="all 100ms ease-in-out"
+                            _hover={{ bgColor: 'brand.primary.50' }}
+                            colorScheme="brand.primary"
+                            onClick={mintModalHandler}
+                            disabled={selectedContributions?.length === 0}
+                            data-testid="mint-btn-test"
+                          >
+                            {selectedContributions?.length > 1
+                              ? 'Bulk Mint'
+                              : 'Mint'}
+                          </Button>
+                        </Stack>
                       )}
-                    </Box>
-                  </Stack>
-                </Box>
-              </TabPanel>
-            </TabPanels>
-          </Tabs>
-        ) : (
-          <EmptyContributions />
-        )}
-      </Container>
-      <ModalWrapper
-        name="mintModal"
-        title="Mint Your DAO Contributions"
-        localOverlay={localOverlay}
-        size="3xl"
-        content={<MintModal contributions={selectedContributions} />}
-      />
-      <ModalWrapper
-        name="bulkDaoAttributeModal"
-        title="Attribute Contributions to a DAO"
-        localOverlay={localOverlay}
-        size="3xl"
-        content={
-          <BulkDaoAttributeModal
-            contributions={selectedContributions.map(r => r.original)}
-          />
-        }
-      />
-    </>
+                    </Stack>
+                  </Box>
+                  <Box width="100%" maxWidth="100vw" overflowX="auto">
+                    <ContributionsTable
+                      contributionsData={contributions.pages}
+                      setSelectedContributions={setSelectedContributions}
+                      nextPage={fetchNextPage}
+                      hasMoreItems={hasNextPage || false}
+                    />
+                  </Box>
+                </Stack>
+              </Box>
+            </TabPanel>
+            <TabPanel paddingX="0">
+              <Box
+                background="white"
+                boxShadow="sm"
+                borderRadius={{ base: 'none', md: 'lg' }}
+              >
+                <Stack spacing="5">
+                  <Box paddingX={{ base: '4', md: '6' }} paddingTop={4}>
+                    <Stack
+                      direction={{ base: 'column', md: 'row' }}
+                      justify="space-between"
+                    >
+                      <Text fontSize="lg" fontWeight="medium">
+                        Contribution Types
+                      </Text>
+                    </Stack>
+                  </Box>
+                  <Box width="100%" maxWidth="100vw" overflowX="auto">
+                    {contributions.pages.length > 0 ? (
+                      <ContributionTypesTable
+                        contributionTypesData={contributions.pages}
+                      />
+                    ) : (
+                      <EmptyContributions />
+                    )}
+                  </Box>
+                </Stack>
+              </Box>
+            </TabPanel>
+          </TabPanels>
+        </Tabs>
+      ) : (
+        <EmptyContributions />
+      )}
+    </Container>
   );
 };
 

--- a/apps/protocol-frontend/src/components/ContributionsTableShell.tsx
+++ b/apps/protocol-frontend/src/components/ContributionsTableShell.tsx
@@ -36,7 +36,6 @@ const ContributionsTableShell = () => {
       user_id: { equals: userData?.id },
     },
   });
-  const localOverlay = useOverlay();
   const { setModals } = useOverlay();
   const [selectedContributions, setSelectedContributions] = useState<
     Row<ContributionTableType>[]

--- a/apps/protocol-frontend/src/components/MintModal.tsx
+++ b/apps/protocol-frontend/src/components/MintModal.tsx
@@ -22,7 +22,7 @@ import useContributionBulkMint from '../hooks/useContributionBulkMint';
 import { TextList } from './TextList';
 import pluralize from 'pluralize';
 
-const MintModal = ({ contributions }: MintModalProps) => {
+const MintModal = ({ contributions, onFinish }: MintModalProps) => {
   const { setModals } = useOverlay();
   const { mutateAsync: bulkMintContributions } = useContributionBulkMint();
   const { mutateAsync: mintContribution } = useContributionMint();
@@ -79,6 +79,7 @@ const MintModal = ({ contributions }: MintModalProps) => {
         await mintContribution({ ...originalClean });
       }
       setModals({}); // Closes mint modal
+      if (onFinish) onFinish();
       setMinting(false);
     } catch {
       setModals({}); // Closes mint modal

--- a/apps/protocol-frontend/src/hooks/useAttestationBulkMint.ts
+++ b/apps/protocol-frontend/src/hooks/useAttestationBulkMint.ts
@@ -50,11 +50,9 @@ const useAttestationBulkMint = () => {
         if (results.length > 0) {
           toast.success({
             title: 'Attestation successfully minted',
-            description: `${pluralize(
-              'Attestation',
-              results.length,
-              true,
-            )} has been minted.`,
+            description: `${pluralize('Attestation', results.length, true)} ${
+              results.length === 1 ? 'has' : 'have'
+            } been minted.`,
           });
         }
 

--- a/apps/protocol-frontend/src/hooks/useAttestationBulkMint.ts
+++ b/apps/protocol-frontend/src/hooks/useAttestationBulkMint.ts
@@ -4,10 +4,8 @@ import useGovrnToast from '../components/toast';
 import { useNetwork, useSigner } from 'wagmi';
 import { useUser } from '../contexts/UserContext';
 import pluralize from 'pluralize';
-import { useOverlay } from '../contexts/OverlayContext';
 
-const useAttestationBulkMint = (onFinish?: (() => void) | undefined) => {
-  const { setModals } = useOverlay();
+const useAttestationBulkMint = () => {
   const toast = useGovrnToast();
   const queryClient = useQueryClient();
   const { data: signer } = useSigner();
@@ -58,8 +56,6 @@ const useAttestationBulkMint = (onFinish?: (() => void) | undefined) => {
               true,
             )} has been minted.`,
           });
-          setModals({ bulkAttestationModal: false });
-          if (onFinish) onFinish();
         }
 
         if (errors.length > 0) {

--- a/apps/protocol-frontend/src/hooks/useAttestationBulkMint.ts
+++ b/apps/protocol-frontend/src/hooks/useAttestationBulkMint.ts
@@ -4,8 +4,10 @@ import useGovrnToast from '../components/toast';
 import { useNetwork, useSigner } from 'wagmi';
 import { useUser } from '../contexts/UserContext';
 import pluralize from 'pluralize';
+import { useOverlay } from '../contexts/OverlayContext';
 
-const useAttestationBulkMint = () => {
+const useAttestationBulkMint = (onFinish?: (() => void) | undefined) => {
+  const { setModals } = useOverlay();
   const toast = useGovrnToast();
   const queryClient = useQueryClient();
   const { data: signer } = useSigner();
@@ -56,6 +58,8 @@ const useAttestationBulkMint = () => {
               true,
             )} has been minted.`,
           });
+          setModals({ bulkAttestationModal: false });
+          if (onFinish) onFinish();
         }
 
         if (errors.length > 0) {

--- a/apps/protocol-frontend/src/hooks/useAttestationMint.ts
+++ b/apps/protocol-frontend/src/hooks/useAttestationMint.ts
@@ -1,13 +1,10 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { networks } from '../utils/networks';
-
 import useGovrnToast from '../components/toast';
 import { useNetwork, useSigner } from 'wagmi';
 import { useUser } from '../contexts/UserContext';
-import { useOverlay } from '../contexts/OverlayContext';
 
-const useAttestationMint = (onFinish?: (() => void) | undefined) => {
-  const { setModals } = useOverlay();
+const useAttestationMint = () => {
   const toast = useGovrnToast();
   const queryClient = useQueryClient();
   const { data: signer } = useSigner();
@@ -48,8 +45,6 @@ const useAttestationMint = (onFinish?: (() => void) | undefined) => {
           title: 'Attestation Successfully Minted',
           description: 'Your Attestation has been minted.',
         });
-        setModals({ bulkAttestationModal: false });
-        if (onFinish) onFinish();
       },
       onError: error => {
         console.error(error);

--- a/apps/protocol-frontend/src/hooks/useAttestationMint.ts
+++ b/apps/protocol-frontend/src/hooks/useAttestationMint.ts
@@ -1,10 +1,13 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { networks } from '../utils/networks';
+
 import useGovrnToast from '../components/toast';
 import { useNetwork, useSigner } from 'wagmi';
 import { useUser } from '../contexts/UserContext';
+import { useOverlay } from '../contexts/OverlayContext';
 
-const useAttestationMint = () => {
+const useAttestationMint = (onFinish?: (() => void) | undefined) => {
+  const { setModals } = useOverlay();
   const toast = useGovrnToast();
   const queryClient = useQueryClient();
   const { data: signer } = useSigner();
@@ -41,15 +44,15 @@ const useAttestationMint = () => {
     {
       onSuccess: () => {
         queryClient.invalidateQueries(['contributionInfiniteList']);
-
         toast.success({
           title: 'Attestation Successfully Minted',
           description: 'Your Attestation has been minted.',
         });
+        setModals({ bulkAttestationModal: false });
+        if (onFinish) onFinish();
       },
       onError: error => {
         console.error(error);
-
         toast.error({
           title: 'Unable to Mint Attestation',
           description: `Something went wrong. Please try again: ${error}`,

--- a/apps/protocol-frontend/src/hooks/useContributionBulkMint.ts
+++ b/apps/protocol-frontend/src/hooks/useContributionBulkMint.ts
@@ -71,11 +71,9 @@ const useContributionBulkMint = () => {
 
           toast.success({
             title: 'Contribution Successfully Minted',
-            description: `${pluralize(
-              'Contribution',
-              minted.length,
-              true,
-            )} has been minted.`,
+            description: `${pluralize('Contribution', minted.length, true)} ${
+              minted.length === 1 ? 'has' : 'have'
+            } been minted.`,
           });
         }
 

--- a/apps/protocol-frontend/src/types/mint.ts
+++ b/apps/protocol-frontend/src/types/mint.ts
@@ -17,6 +17,7 @@ export type MintContributionType = UIContribution & {
 
 export interface MintModalProps {
   contributions: UIContribution[] | Row<ContributionTableType>[];
+  onFinish?: (() => void) | undefined;
 }
 
 export type MintAttestationType = UIAttestations[1] & {


### PR DESCRIPTION
## Linear Ticket

- [PRO-655](https://linear.app/govrn/issue/PRO-655/close-modal-and-reset-checkboxes-on-attest)

## Description

- Resets the table checkboxes and closes the modals during the mint / attestation flows
- This adds an `onFinish` prop to the modals and resets the open modals and unchecks the checkboxes in the tables
- Also removes the Progress bar from the BulkAttestationModal since we weren't having it progress beyond 1. We can revisit this when we do a deeper design pass on the modals

## Screencaptures


https://user-images.githubusercontent.com/9438776/203393685-13768757-7327-4792-a1e0-f885de8787b4.mp4


https://user-images.githubusercontent.com/9438776/203393697-7e058484-848c-41d2-9149-70e3b16d9b64.mp4


https://user-images.githubusercontent.com/9438776/203393709-ec08859a-4492-4d87-b878-4e8d9aa3e529.mp4


https://user-images.githubusercontent.com/9438776/203393717-81e39e58-3815-4fc1-bba8-d1d6f029644c.mp4

