### PR TITLE
fix/dao-missing-attestation-feed (PRO-624)

### DIFF
--- a/apps/protocol-frontend/src/components/AttestationsTable.tsx
+++ b/apps/protocol-frontend/src/components/AttestationsTable.tsx
@@ -55,8 +55,6 @@ const AttestationsTable = ({
         date_of_submission: contribution.date_of_submission,
         date_of_engagement: contribution.date_of_submission,
         guilds: contribution.guilds,
-        guildName:
-          contribution.guilds.map(guildObj => guildObj.guild.name)[0] ?? '---',
         status: contribution.status.name,
         action: '',
         name: contribution.name,

--- a/apps/protocol-frontend/src/components/AttestationsTable.tsx
+++ b/apps/protocol-frontend/src/components/AttestationsTable.tsx
@@ -54,6 +54,7 @@ const AttestationsTable = ({
         id: contribution.id,
         date_of_submission: contribution.date_of_submission,
         date_of_engagement: contribution.date_of_submission,
+        guilds: contribution.guilds,
         guildName:
           contribution.guilds.map(guildObj => guildObj.guild.name)[0] ?? '---',
         status: contribution.status.name,
@@ -111,8 +112,15 @@ const AttestationsTable = ({
         accessor: 'contributor',
       },
       {
-        Header: 'DAOs',
+        Header: 'DAO',
         accessor: 'guilds',
+        Cell: ({ value }) => {
+          let guildName;
+          if (value && value.length > 0) {
+            guildName = value[0].guild.name ?? '---';
+          }
+          return <Text>{guildName}</Text>;
+        },
       },
     ],
     [],


### PR DESCRIPTION
## Linear Ticket

- [PRO-624](https://linear.app/govrn/issue/PRO-624/dao-missing-from-attestation-feed)

## Description

- Adds in the DAO's name for each Contribution in the Attestation feed
- Switches the header name to be singular 'DAO' instead of 'DAOs' until we support attributing to multiple DAOs
- Uses the `guilds` object that is already on the `AttestationTableTypes` as the accessor instead of using/adding the `guildName` accessor

## Screencaptures

![govrn-attestation-dao-name](https://user-images.githubusercontent.com/9438776/203401454-1a3b6539-4ecf-4680-9db3-17c647cfe324.jpg)
