### PR TITLE
fix/app-landing-page-tweaks (PRO-747)

### DIFF
--- a/apps/protocol-frontend/src/components/HomeShell.tsx
+++ b/apps/protocol-frontend/src/components/HomeShell.tsx
@@ -135,9 +135,11 @@ const HomeShell = () => {
           fontWeight="400"
           marginBottom={{ base: 40, lg: 0 }}
           gap={1}
+          maxW="60%"
         >
-          <Text>Track and record your DAO</Text>
-          <Text>Contributions</Text>
+          <Text textAlign="center">
+            Track and record your DAO Contributions
+          </Text>
           <span role="img" aria-labelledby="Govrn motto handshake emoji">
             🤝
           </span>
@@ -152,10 +154,10 @@ const HomeShell = () => {
             color="white"
             fontSize={{ base: 'lg', lg: 'xl' }}
             fontWeight="400"
+            maxW={{ base: '80%', lg: '70%' }}
           >
-            <Text>To get started, connect</Text>
-            <Text marginBottom={{ base: 10, lg: 16 }}>
-              your wallet to Gnosis Chain.
+            <Text marginBottom={{ base: 10, lg: 16 }} textAlign="center">
+              To get started, connect your wallet to Gnosis Chain.
             </Text>
             <ConnectWallet />
           </Flex>

--- a/apps/protocol-frontend/src/components/HomeShell.tsx
+++ b/apps/protocol-frontend/src/components/HomeShell.tsx
@@ -135,7 +135,7 @@ const HomeShell = () => {
           fontWeight="400"
           marginBottom={{ base: 40, lg: 0 }}
           gap={1}
-          maxW="60%"
+          maxW={{ base: '70%', lg: '60%' }}
         >
           <Text textAlign="center">
             Track and record your DAO Contributions
@@ -154,7 +154,7 @@ const HomeShell = () => {
             color="white"
             fontSize={{ base: 'lg', lg: 'xl' }}
             fontWeight="400"
-            maxW={{ base: '80%', lg: '70%' }}
+            maxW={{ base: '60%', lg: '70%' }}
           >
             <Text marginBottom={{ base: 10, lg: 16 }} textAlign="center">
               To get started, connect your wallet to Gnosis Chain.

--- a/apps/protocol-frontend/src/components/HomeShell.tsx
+++ b/apps/protocol-frontend/src/components/HomeShell.tsx
@@ -111,7 +111,7 @@ const HomeShell = () => {
       paddingX={{ base: 8, lg: 0 }}
       minHeight="100vh"
       minWidth="100vw"
-      bgGradient="linear(to-r, #DF1F97 0%, #5100E4 100%)"
+      bgGradient="linear-gradient(49deg, rgba(223,31,151,1) 0%, rgba(81,0,228,1) 100%)"
     >
       <Flex
         direction="column"

--- a/libs/protocol-ui/src/theme/colors.ts
+++ b/libs/protocol-ui/src/theme/colors.ts
@@ -33,5 +33,7 @@ export default {
       'linear-gradient(100deg, rgba(81, 0, 228, 0.7) 0%, rgba(223, 31, 151, 0.7) 100%)',
     gradientHover: 'linear-gradient(100deg, #5100E4 0%, #5100E4 100%)', // purple
     gradientFocused: 'linear-gradient(100deg, #9766EF 0%,#9766EF 100%)', // purple.400
+    gradientBackground:
+      'linear-gradient(49deg, rgba(223,31,151,1) 0%, rgba(81,0,228,1) 100%)',
   },
 };


### PR DESCRIPTION
## Linear Ticket

- [PRO-747](https://linear.app/govrn/issue/PRO-747/app-landing-page-tweaks)

## Description

Adjusts the max width and adds the starting degrees to the app landing page background gradient

## Screencaptures

![desktop-landing-page](https://user-images.githubusercontent.com/9438776/207126984-93303d5e-e965-4c62-af01-17e711e73f6a.jpg)

Matched mobile very closely to the Figma. Can get it more accurate by forcing the line break but would prefer to not add another element if unnecessary.

