### PR TITLE
feature/custom-tooltip-variants (PRO-710)

### DIFF
--- a/apps/protocol-frontend/src/components/MintModal.tsx
+++ b/apps/protocol-frontend/src/components/MintModal.tsx
@@ -94,11 +94,9 @@ const MintModal = ({ contributions, onFinish }: MintModalProps) => {
           Minting {pluralize('Contribution', contributions.length, true)}
         </Text>
         <Tooltip
-          variant="primary"
-          hasArrow
-          label={`Why Mint?
-        Minting a Contribution makes it immutable and creates a historical record of what's been done that can't be changed.`}
-          fontSize="md"
+          variant="mint"
+          label={`Minting a contribution makes it immutable and creates a historical record of what's been done that can't be changed.`}
+          fontSize="sm"
           placement="right"
         >
           <HStack width="fit-content">

--- a/apps/protocol-frontend/src/components/MintModal.tsx
+++ b/apps/protocol-frontend/src/components/MintModal.tsx
@@ -94,6 +94,7 @@ const MintModal = ({ contributions, onFinish }: MintModalProps) => {
           Minting {pluralize('Contribution', contributions.length, true)}
         </Text>
         <Tooltip
+          variant="primary"
           hasArrow
           label={`Why Mint?
         Minting a Contribution makes it immutable and creates a historical record of what's been done that can't be changed.`}

--- a/libs/protocol-ui/src/theme/components/tooltip.tsx
+++ b/libs/protocol-ui/src/theme/components/tooltip.tsx
@@ -1,9 +1,25 @@
 export default {
   baseStyle: {
     borderRadius: '8px',
-    backgroundColor: 'green.300',
+    paddingY: '8px',
+    paddingX: '16px',
   },
   variants: {
-    primary: {},
+    primary: {
+      backgroundColor: 'brand.secondary.100',
+      color: 'brand.purple',
+    },
+    secondary: {
+      backgroundColor: 'brand.primary.100',
+      color: 'brand.magenta',
+    },
+    tertiary: {
+      backgroundColor: 'gray.100',
+      color: 'gray.600',
+    },
+    mint: {
+      backgroundColor: 'gray.900',
+      color: 'gray.50',
+    },
   },
 };

--- a/libs/protocol-ui/src/theme/components/tooltip.tsx
+++ b/libs/protocol-ui/src/theme/components/tooltip.tsx
@@ -1,0 +1,9 @@
+export default {
+  baseStyle: {
+    borderRadius: '8px',
+    backgroundColor: 'green.300',
+  },
+  variants: {
+    primary: {},
+  },
+};

--- a/libs/protocol-ui/src/theme/index.ts
+++ b/libs/protocol-ui/src/theme/index.ts
@@ -6,6 +6,7 @@ import Switch from './components/switch';
 import Table from './components/table';
 import Tabs from './components/tabs';
 import Textarea from './components/textarea';
+import Tooltip from './components/tooltip';
 import { extendTheme } from '@chakra-ui/react';
 import '@fontsource/inter/variable-full.css';
 
@@ -22,7 +23,16 @@ export const GovrnTheme = extendTheme({
     heading: 'InterVariable, -apple-system, system-ui, sans-serif',
     body: 'InterVariable, -apple-system, system-ui, sans-serif',
   },
-  components: { Button, Input, Checkbox, Switch, Table, Tabs, Textarea },
+  components: {
+    Button,
+    Input,
+    Checkbox,
+    Switch,
+    Table,
+    Tabs,
+    Textarea,
+    Tooltip,
+  },
   config: {
     initialColorMode: 'light',
     useSystemColorMode: false,


### PR DESCRIPTION
## Linear Ticket

- [PRO-710](https://linear.app/govrn/issue/PRO-710/tooltips-variants)
- [PRO-763](https://linear.app/govrn/issue/PRO-763/primary)
- [PRO-764](https://linear.app/govrn/issue/PRO-764/secondary)
- [PRO-765](https://linear.app/govrn/issue/PRO-765/tertiary)
- [PRO-781](https://linear.app/govrn/issue/PRO-781/mint)

## Description

- Adds `tooltip` to component variants / customizations in the `protocol-ui` theme
- Base styles apply to all, then each variant (mint, primary, secondary, tertiary) has the appropriate styles applied
- Applies the `mint` variant to the Mint modal

We're not using Tooltips throughout the UI too much yet, so I used variants only for this. We can create a full custom component once we use more since we'll find what is helpful to generalize.

## Screencaptures

All examples applied to the same Tooltip:

![tooltip-tertiary](https://user-images.githubusercontent.com/9438776/207659526-e3c672a1-8539-4665-b8a4-f2182ccd86c9.jpg)
![tooltip-secondary](https://user-images.githubusercontent.com/9438776/207659530-45f8762c-f7b8-424a-93de-b88e43b237b9.jpg)
![tooltip-primary](https://user-images.githubusercontent.com/9438776/207659534-bebe775c-cb93-4209-bc6f-bd653c3a807d.jpg)
![tooltip-mint](https://user-images.githubusercontent.com/9438776/207659537-48b9d7ea-befd-41fe-a6be-4c5ea125acf3.jpg)


