### PR TITLE
fix/local-cypress-tests (PRO-705)

### DIFF
--- a/apps/protocol-frontend/src/utils/web3.ts
+++ b/apps/protocol-frontend/src/utils/web3.ts
@@ -25,7 +25,7 @@ const gnosisChain: Chain = {
   testnet: false,
 };
 
-const dev = import.meta.env.VITE_STAGING_MODE || false;
+const dev = import.meta.env.MODE || false;
 const defaultChains = dev
   ? [gnosisChain, chain.goerli, chain.rinkeby, chain.localhost]
   : [gnosisChain];


### PR DESCRIPTION
## Linear Ticket

- [PRO-705](https://linear.app/govrn/issue/PRO-705/cypress-cannot-run-locally)

## Description

- This fixes Cypress tests locally
- Changes the `env` var that detects if we're in local dev mode -- these chains are needed for our testing mock

## Screencaptures

n/a
