### PR TITLE
fix/dao-dashboard-data (PRO-790)

### DIFF
--- a/apps/protocol-frontend/src/components/ContributionsByDateChart.tsx
+++ b/apps/protocol-frontend/src/components/ContributionsByDateChart.tsx
@@ -152,7 +152,12 @@ const ContributionsByDateChart = ({
   }
 
   return (
-    <Flex direction="column" paddingX={{ base: 4, lg: 0 }} paddingBottom="0">
+    <Flex
+      direction="column"
+      paddingX={{ base: 4, lg: 0 }}
+      paddingBottom="0"
+      width="100%"
+    >
       <Flex
         direction="column"
         paddingY={{ base: '4', lg: '4' }}
@@ -176,7 +181,7 @@ const ContributionsByDateChart = ({
           contributionsCountMap?.length !== 0 && (
             <Box
               alignSelf="flex-start"
-              height={{ base: '5rem', lg: '10rem' }}
+              height={{ base: '5rem', lg: '8.5rem' }}
               width="100%"
               paddingX={{ base: 2, lg: 0 }}
             >

--- a/apps/protocol-frontend/src/components/ContributionsByDateChart.tsx
+++ b/apps/protocol-frontend/src/components/ContributionsByDateChart.tsx
@@ -43,6 +43,9 @@ const ContributionsByDateChart = ({
     };
   });
 
+  console.log('original data', contributionsCount);
+  console.log('mapped data', contributionsCountMap);
+
   if (isError) {
     return (
       <Text>An error occurred fetching the DAO's recent Contributions.</Text>

--- a/apps/protocol-frontend/src/components/ContributionsByDateChart.tsx
+++ b/apps/protocol-frontend/src/components/ContributionsByDateChart.tsx
@@ -38,7 +38,7 @@ const ContributionsByDateChart = ({
   const isMobile = useBreakpointValue({ base: true, lg: false });
   const contributionsCountMap = contributionsCount?.map(contribution => {
     return {
-      day: formatDate(contribution.date, 'yyyy-MM-dd'),
+      day: formatDate(contribution.date, 'yyyy-MM-dd', true),
       value: contribution.count,
     };
   });

--- a/apps/protocol-frontend/src/components/ContributionsHeatMap.tsx
+++ b/apps/protocol-frontend/src/components/ContributionsHeatMap.tsx
@@ -21,10 +21,13 @@ const ContributionsHeatMap = ({
   const isMobile = useBreakpointValue({ base: true, lg: false });
   const contributionsCountMap = contributionsCount.map(contribution => {
     return {
-      day: formatDate(contribution.date, 'yyyy-MM-dd'),
+      day: formatDate(contribution.date, 'yyyy-MM-dd', true),
       value: contribution.count,
     };
   });
+
+  console.log('contributions count', contributionsCount);
+  console.log('contributionsCountMap', contributionsCountMap);
 
   return (
     <Flex direction="column" paddingBottom={4} paddingX={{ base: 4, lg: 0 }}>

--- a/apps/protocol-frontend/src/components/DaoDashboardShell.tsx
+++ b/apps/protocol-frontend/src/components/DaoDashboardShell.tsx
@@ -122,6 +122,7 @@ const DaoDashboardShell = ({ daoName, daoId }: DaoDashboardShellProps) => {
               gap={2}
               flexBasis="20%"
               justifyContent="space-between"
+              alignItems="flex-end"
               marginY={{ base: 4, lg: 0 }}
             >
               <Flex direction="column" gap={2}>

--- a/apps/protocol-frontend/src/utils/date.ts
+++ b/apps/protocol-frontend/src/utils/date.ts
@@ -1,5 +1,16 @@
 import { format } from 'date-fns';
 
-export const formatDate = (date: string | Date, formatting?: string) => {
-  return format(new Date(date), formatting ?? 'P');
+export const formatDate = (
+  date: string | Date,
+  formatting?: string,
+  ignoreTimezone?: true,
+) => {
+  const dateOriginal = new Date(date);
+  const dateWithoutTimezone = new Date(
+    dateOriginal.valueOf() + dateOriginal.getTimezoneOffset() * 60 * 1000,
+  );
+  return format(
+    new Date(ignoreTimezone === true ? dateWithoutTimezone : dateOriginal),
+    formatting ?? 'P',
+  );
 };


### PR DESCRIPTION
## Linear Ticket

- https://linear.app/govrn/issue/PRO-790/data-is-wrong-for-dao-dashboards-on-dao-dashboards
- https://linear.app/govrn/issue/PRO-771/custom-date-sort-is-getting-weird-filters-earlier-in-the-year

## Description

- Fixes the data display issue on the heatmaps due to inclusion of tz data since Prisma v4 upgrade
- Adds an 'ignore timezone' to our `formatDay` utility function
- Adjusts some of the spacing to account for the last month of the year in the DAO heatmap
- This seems to resolve the custom filter issue, but we should continue testing. It worked for me locally, but we should specifically test that again in staging upon merge

## Screencaptures

https://user-images.githubusercontent.com/9438776/208321241-99b62985-ed1d-4663-9016-932d3fd9dccc.mp4
