### PR TITLE
Staging new reporting form

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,10 @@
 {
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "python.defaultInterpreterPath": "apps/kevin-malone/.venv/bin/python3",
+  "python.testing.cwd": "apps/kevin-malone",
+  "python.testing.pytestArgs": [
+    "tests"
+  ],
+  "python.testing.unittestEnabled": false,
+  "python.testing.pytestEnabled": true
 }

--- a/apps/kevin-malone/bot/common/threads/report.py
+++ b/apps/kevin-malone/bot/common/threads/report.py
@@ -33,7 +33,7 @@ class ReportStep(BaseStep):
 
     async def send(self, message, user_id, ctx=None):
         guild = await gql.get_guild_by_discord_id(self.guild_id)
-        link = REPORTING_FORM_FMT % guild["id"]
+        link = REPORTING_FORM_FMT
 
         msg = ReportStep.report_message % link
         sent_message = None

--- a/apps/kevin-malone/bot/config.py
+++ b/apps/kevin-malone/bot/config.py
@@ -25,7 +25,7 @@ BOMB_EMOJI = "\U0001F4A3"
 COLLISION_EMOJI = "\U0001F4A5"
 MECHANICAL_ARM_EMOJI = "\U0001F9BE"
 
-REPORTING_FORM_FMT = "https://report.govrn.app/#/contribution/%s"
+REPORTING_FORM_FMT = "https://govrn.app/#/report"
 
 REQUESTED_TWEET_FMT = "Kevin Malone told me to tweet this number %s"
 TWITTER_URL_REGEXP = r"^https://twitter.com/(.+)/status/([0-9]+)"

--- a/apps/kevin-malone/tests/common/threads/test_report.py
+++ b/apps/kevin-malone/tests/common/threads/test_report.py
@@ -22,7 +22,7 @@ async def test_reporting_step_happypath(mocker, thread_dependencies):
 
     user_id = 1234
     (sent_message, metadata) = await report.send(message, user_id)
-    link = REPORTING_FORM_FMT % guild["id"]
+    link = REPORTING_FORM_FMT
     expected_message = ReportStep.report_message % link
     expected_congrats = ReportStep.congrats_message % (
         user_id,
@@ -51,7 +51,7 @@ async def test_reporting_step_no_congrats(mocker, thread_dependencies):
 
     user_id = 1234
     (sent_message, metadata) = await report.send(message, user_id)
-    link = REPORTING_FORM_FMT % guild["id"]
+    link = REPORTING_FORM_FMT
     expected_message = ReportStep.report_message % link
 
     # assert
@@ -74,7 +74,7 @@ async def test_reporting_step_no_contibutions(mocker, thread_dependencies):
 
     user_id = 1234
     (sent_message, metadata) = await report.send(message, user_id)
-    link = REPORTING_FORM_FMT % guild["id"]
+    link = REPORTING_FORM_FMT
     expected_message = ReportStep.report_message % link
 
     # assert


### PR DESCRIPTION
## Linear Ticket

[Add the link to the Linear ticket here.
](https://linear.app/govrn/issue/PRO-801/send-v1-reporting-link-instead-of-deprecated-form)

## Description

Kevin now sends the link to the v1 reporting form

## Screencaptures

For frontend changes, considering adding a screenshot or screencapture of the changes.
Before/after screenshots may be helpful when relevant.
