### PR TITLE
feature/dao-membership-profile-page (PRO-616)

### DIFF
--- a/apps/protocol-frontend/src/components/DaoCard.tsx
+++ b/apps/protocol-frontend/src/components/DaoCard.tsx
@@ -1,0 +1,62 @@
+import { Flex, Heading, Text } from '@chakra-ui/react';
+
+type DaoRoles = 'admin' | 'contributor' | 'recruit';
+
+type Dao = {
+  id: number;
+  name: string;
+  role: DaoRoles;
+  isFavorited: boolean;
+};
+
+interface DaoCardProps {
+  dao: Dao;
+}
+
+const daoBgGradient = {
+  admin: 'linear-gradient(180deg, #5100E4 0%, #9766EF 100%)',
+  contributor: 'linear-gradient(180deg, #DCCCFA 0%, #F8F4FF 100%)',
+  recruit: 'linear-gradient(180deg, #E2E8F0 0%, #F7FAFC 100%)',
+};
+
+const daoNameColor = {
+  admin: 'white',
+  contributor: 'brand.purple',
+  recruit: 'gray.700',
+};
+
+const DaoCard = ({ dao }: DaoCardProps) => {
+  return (
+    <Flex
+      direction="column"
+      alignItems="center"
+      justifyContent="center"
+      bg={daoBgGradient[dao.role]}
+      borderWidth="1px"
+      borderStyle="solid"
+      borderColor={dao.role === 'recruit' ? 'gray.200' : 'brand.purple'}
+      minWidth="14rem"
+    >
+      <Flex
+        direction="column"
+        alignItems="center"
+        justifyContent="center"
+        minHeight="6rem"
+      >
+        <Heading
+          as="h4"
+          color={daoNameColor[dao.role]}
+          fontWeight="600"
+          fontSize="md"
+        >
+          {dao.name}
+        </Heading>
+      </Flex>
+      <Flex direction="column" alignItems="center" justifyContent="center">
+        <Text>{dao.role}</Text>
+      </Flex>
+    </Flex>
+  );
+};
+
+export default DaoCard;

--- a/apps/protocol-frontend/src/components/DaoCard.tsx
+++ b/apps/protocol-frontend/src/components/DaoCard.tsx
@@ -80,31 +80,35 @@ const DaoCard = ({ dao }: DaoCardProps) => {
           >
             {dao.role.charAt(0).toUpperCase() + dao.role.slice(1)}
           </Text>
-          <IconButton
-            aria-label={
-              dao.role === 'admin'
-                ? "Click on the gear icon to open this DAO's settings."
-                : 'Click on the star to favorite this DAO.'
-            }
-            bg="transparent"
-            _hover={{ bg: 'transparent' }}
-            _active={{ bg: 'transparent' }}
-            icon={
-              dao.role === 'admin' ? (
-                <HiOutlineCog color="#5100E4" size={24} />
-              ) : dao.isFavorited === true ? (
-                <HiStar
-                  fill={dao.role === 'recruit' ? 'gray.700' : '#5100E4'}
-                  size={24}
-                />
-              ) : (
-                <HiOutlineStar
-                  color={dao.role === 'recruit' ? 'gray.700' : '#5100E4'}
-                  size={24}
-                />
-              )
-            }
-          />
+          {dao.role === 'admin' ? (
+            <IconButton
+              aria-label="Click on the gear icon to open this DAO's settings."
+              bg="transparent"
+              _hover={{ bg: 'transparent' }}
+              _active={{ bg: 'transparent' }}
+              icon={<HiOutlineCog color="#5100E4" size={24} />}
+            />
+          ) : (
+            <IconButton
+              aria-label="Click on the star to favorite this DAO."
+              bg="transparent"
+              _hover={{ bg: 'transparent' }}
+              _active={{ bg: 'transparent' }}
+              icon={
+                dao.isFavorited === true ? (
+                  <HiStar
+                    fill={dao.role === 'recruit' ? 'gray.700' : '#5100E4'}
+                    size={24}
+                  />
+                ) : (
+                  <HiOutlineStar
+                    color={dao.role === 'recruit' ? 'gray.700' : '#5100E4'}
+                    size={24}
+                  />
+                )
+              }
+            />
+          )}
         </Flex>
       </Flex>
     </Flex>

--- a/apps/protocol-frontend/src/components/DaoCard.tsx
+++ b/apps/protocol-frontend/src/components/DaoCard.tsx
@@ -40,6 +40,9 @@ const daoNameColor = {
 };
 
 const DaoCard = ({ dao }: DaoCardProps) => {
+  const daoIconColor = (daoRole: DaoRoles) =>
+    daoRole === 'recruit' ? 'gray.700' : '#5100E4';
+
   return (
     <LinkBox>
       <Flex
@@ -96,7 +99,7 @@ const DaoCard = ({ dao }: DaoCardProps) => {
             <Text
               fontWeight="semibold"
               fontSize="md"
-              color={dao.role === 'recruit' ? 'gray.700' : 'brand.purple'}
+              color={daoIconColor(dao.role)}
             >
               {dao.role.charAt(0).toUpperCase() + dao.role.slice(1)}
             </Text>
@@ -116,15 +119,9 @@ const DaoCard = ({ dao }: DaoCardProps) => {
                 _active={{ bg: 'transparent' }}
                 icon={
                   dao.favorite === true ? (
-                    <HiStar
-                      fill={dao.role === 'recruit' ? 'gray.700' : '#5100E4'}
-                      size={24}
-                    />
+                    <HiStar fill={daoIconColor(dao.role)} size={24} />
                   ) : (
-                    <HiOutlineStar
-                      color={dao.role === 'recruit' ? 'gray.700' : '#5100E4'}
-                      size={24}
-                    />
+                    <HiOutlineStar color={daoIconColor(dao.role)} size={24} />
                   )
                 }
               />

--- a/apps/protocol-frontend/src/components/DaoCard.tsx
+++ b/apps/protocol-frontend/src/components/DaoCard.tsx
@@ -68,7 +68,11 @@ const DaoCard = ({ dao }: DaoCardProps) => {
         paddingX={5}
         bg="white"
       >
-        <Flex direction="row" alignItems="center" justifyContent="space-around">
+        <Flex
+          direction="row"
+          alignItems="center"
+          justifyContent="space-between"
+        >
           <Text
             fontWeight="semibold"
             fontSize="md"
@@ -84,13 +88,20 @@ const DaoCard = ({ dao }: DaoCardProps) => {
             }
             bg="transparent"
             _hover={{ bg: 'transparent' }}
+            _active={{ bg: 'transparent' }}
             icon={
               dao.role === 'admin' ? (
-                <HiOutlineCog color="#5100E4" />
+                <HiOutlineCog color="#5100E4" size={24} />
               ) : dao.isFavorited === true ? (
-                <HiStar color="#5100E4" />
+                <HiStar
+                  fill={dao.role === 'recruit' ? 'gray.700' : '#5100E4'}
+                  size={24}
+                />
               ) : (
-                <HiOutlineStar color="#5100E4" />
+                <HiOutlineStar
+                  color={dao.role === 'recruit' ? 'gray.700' : '#5100E4'}
+                  size={24}
+                />
               )
             }
           />

--- a/apps/protocol-frontend/src/components/DaoCard.tsx
+++ b/apps/protocol-frontend/src/components/DaoCard.tsx
@@ -1,4 +1,13 @@
-import { Flex, Heading, IconButton, Text } from '@chakra-ui/react';
+import { Link } from 'react-router-dom';
+import {
+  Flex,
+  Heading,
+  IconButton,
+  Text,
+  LinkBox,
+  LinkOverlay,
+  Box,
+} from '@chakra-ui/react';
 import { HiOutlineCog, HiStar, HiOutlineStar } from 'react-icons/hi';
 
 type DaoRoles = 'admin' | 'contributor' | 'recruit';
@@ -28,90 +37,100 @@ const daoNameColor = {
 
 const DaoCard = ({ dao }: DaoCardProps) => {
   return (
-    <Flex
-      direction="column"
-      alignItems="center"
-      justifyContent="center"
-      bg={daoBgGradient[dao.role]}
-      borderWidth="1px"
-      borderStyle="solid"
-      borderColor={dao.role === 'recruit' ? 'gray.700' : 'brand.purple'}
-      minWidth="14rem"
-      borderRadius="md"
-    >
+    <LinkBox>
       <Flex
         direction="column"
-        alignItems="center"
-        justifyContent="center"
-        minHeight="6rem"
+        // alignItems="center"
+        // justifyContent="center"
+        bg={daoBgGradient[dao.role]}
+        borderWidth="1px"
+        borderStyle="solid"
+        borderColor={dao.role === 'recruit' ? 'gray.700' : 'brand.purple'}
+        minWidth="14rem"
+        borderRadius="md"
       >
-        <Heading
-          as="h4"
-          color={daoNameColor[dao.role]}
-          fontWeight="600"
-          fontSize="md"
-        >
-          {dao.name}
-        </Heading>
-      </Flex>
-      <Flex
-        direction="column"
-        alignItems="space-apart"
-        justifyContent="center"
-        width="100%"
-        borderTopRadius="none"
-        borderTopWidth="1px"
-        borderTopStyle="solid"
-        borderTopColor={dao.role === 'recruit' ? 'gray.700' : 'brand.purple'}
-        borderBottomRadius="inherit"
-        paddingY={3}
-        paddingX={5}
-        bg="white"
-      >
+        <Link to={`/dao/${dao.id}`}>
+          <LinkOverlay>
+            <Box height="100%" width="100%">
+              <Flex
+                direction="column"
+                alignItems="center"
+                justifyContent="center"
+                minHeight="6rem"
+                width="100%"
+                height="100%"
+              >
+                <Heading
+                  as="h4"
+                  color={daoNameColor[dao.role]}
+                  fontWeight="600"
+                  fontSize="md"
+                >
+                  {dao.name}
+                </Heading>
+              </Flex>
+            </Box>
+          </LinkOverlay>
+        </Link>
         <Flex
-          direction="row"
-          alignItems="center"
-          justifyContent="space-between"
+          direction="column"
+          alignItems="space-apart"
+          justifyContent="center"
+          width="100%"
+          borderTopRadius="none"
+          borderTopWidth="1px"
+          borderTopStyle="solid"
+          borderTopColor={dao.role === 'recruit' ? 'gray.700' : 'brand.purple'}
+          borderBottomRadius="inherit"
+          paddingY={3}
+          paddingX={5}
+          bg="white"
         >
-          <Text
-            fontWeight="semibold"
-            fontSize="md"
-            color={dao.role === 'recruit' ? 'gray.700' : 'brand.purple'}
+          <Flex
+            direction="row"
+            alignItems="center"
+            justifyContent="space-between"
           >
-            {dao.role.charAt(0).toUpperCase() + dao.role.slice(1)}
-          </Text>
-          {dao.role === 'admin' ? (
-            <IconButton
-              aria-label="Click on the gear icon to open this DAO's settings."
-              bg="transparent"
-              _hover={{ bg: 'transparent' }}
-              _active={{ bg: 'transparent' }}
-              icon={<HiOutlineCog color="#5100E4" size={24} />}
-            />
-          ) : (
-            <IconButton
-              aria-label="Click on the star to favorite this DAO."
-              bg="transparent"
-              _hover={{ bg: 'transparent' }}
-              _active={{ bg: 'transparent' }}
-              icon={
-                dao.isFavorited === true ? (
-                  <HiStar
-                    fill={dao.role === 'recruit' ? 'gray.700' : '#5100E4'}
-                    size={24}
-                  />
-                ) : (
-                  <HiOutlineStar
-                    color={dao.role === 'recruit' ? 'gray.700' : '#5100E4'}
-                    size={24}
-                  />
-                )
-              }
-            />
-          )}
+            <Text
+              fontWeight="semibold"
+              fontSize="md"
+              color={dao.role === 'recruit' ? 'gray.700' : 'brand.purple'}
+            >
+              {dao.role.charAt(0).toUpperCase() + dao.role.slice(1)}
+            </Text>
+            {dao.role === 'admin' ? (
+              <IconButton
+                aria-label="Click on the gear icon to open this DAO's settings."
+                bg="transparent"
+                _hover={{ bg: 'transparent' }}
+                _active={{ bg: 'transparent' }}
+                icon={<HiOutlineCog color="#5100E4" size={24} />}
+              />
+            ) : (
+              <IconButton
+                aria-label="Click on the star to favorite this DAO."
+                bg="transparent"
+                _hover={{ bg: 'transparent' }}
+                _active={{ bg: 'transparent' }}
+                icon={
+                  dao.isFavorited === true ? (
+                    <HiStar
+                      fill={dao.role === 'recruit' ? 'gray.700' : '#5100E4'}
+                      size={24}
+                    />
+                  ) : (
+                    <HiOutlineStar
+                      color={dao.role === 'recruit' ? 'gray.700' : '#5100E4'}
+                      size={24}
+                    />
+                  )
+                }
+              />
+            )}
+          </Flex>
         </Flex>
       </Flex>
-    </Flex>
+    </LinkBox>
   );
 };
 

--- a/apps/protocol-frontend/src/components/DaoCard.tsx
+++ b/apps/protocol-frontend/src/components/DaoCard.tsx
@@ -10,6 +10,9 @@ import {
 } from '@chakra-ui/react';
 import { HiOutlineCog, HiStar, HiOutlineStar } from 'react-icons/hi';
 
+// TODO: clicking on admin settings -> dao settings page (when ready)
+// TODO: clicking on favorite -> toggles favorite true/false via a guild update mutation
+
 // these are here for mocking, will be removed
 type DaoRoles = 'admin' | 'contributor' | 'recruit';
 

--- a/apps/protocol-frontend/src/components/DaoCard.tsx
+++ b/apps/protocol-frontend/src/components/DaoCard.tsx
@@ -1,4 +1,5 @@
-import { Flex, Heading, Text } from '@chakra-ui/react';
+import { Flex, Heading, IconButton, Text } from '@chakra-ui/react';
+import { HiOutlineCog, HiStar, HiOutlineStar } from 'react-icons/hi';
 
 type DaoRoles = 'admin' | 'contributor' | 'recruit';
 
@@ -34,7 +35,7 @@ const DaoCard = ({ dao }: DaoCardProps) => {
       bg={daoBgGradient[dao.role]}
       borderWidth="1px"
       borderStyle="solid"
-      borderColor={dao.role === 'recruit' ? 'gray.200' : 'brand.purple'}
+      borderColor={dao.role === 'recruit' ? 'gray.700' : 'brand.purple'}
       minWidth="14rem"
       borderRadius="md"
     >
@@ -55,25 +56,45 @@ const DaoCard = ({ dao }: DaoCardProps) => {
       </Flex>
       <Flex
         direction="column"
-        alignItems="center"
+        alignItems="space-apart"
         justifyContent="center"
         width="100%"
         borderTopRadius="none"
         borderTopWidth="1px"
         borderTopStyle="solid"
-        borderTopColor={dao.role === 'recruit' ? 'gray.200' : 'brand.purple'}
+        borderTopColor={dao.role === 'recruit' ? 'gray.700' : 'brand.purple'}
         borderBottomRadius="inherit"
         paddingY={3}
         paddingX={5}
         bg="white"
       >
-        <Text
-          fontWeight="semibold"
-          fontSize="md"
-          color={dao.role === 'recruit' ? 'gray.700' : 'brand.purple'}
-        >
-          {dao.role}
-        </Text>
+        <Flex direction="row" alignItems="center" justifyContent="space-around">
+          <Text
+            fontWeight="semibold"
+            fontSize="md"
+            color={dao.role === 'recruit' ? 'gray.700' : 'brand.purple'}
+          >
+            {dao.role.charAt(0).toUpperCase() + dao.role.slice(1)}
+          </Text>
+          <IconButton
+            aria-label={
+              dao.role === 'admin'
+                ? "Click on the gear icon to open this DAO's settings."
+                : 'Click on the star to favorite this DAO.'
+            }
+            bg="transparent"
+            _hover={{ bg: 'transparent' }}
+            icon={
+              dao.role === 'admin' ? (
+                <HiOutlineCog color="#5100E4" />
+              ) : dao.isFavorited === true ? (
+                <HiStar color="#5100E4" />
+              ) : (
+                <HiOutlineStar color="#5100E4" />
+              )
+            }
+          />
+        </Flex>
       </Flex>
     </Flex>
   );

--- a/apps/protocol-frontend/src/components/DaoCard.tsx
+++ b/apps/protocol-frontend/src/components/DaoCard.tsx
@@ -36,6 +36,7 @@ const DaoCard = ({ dao }: DaoCardProps) => {
       borderStyle="solid"
       borderColor={dao.role === 'recruit' ? 'gray.200' : 'brand.purple'}
       minWidth="14rem"
+      borderRadius="md"
     >
       <Flex
         direction="column"
@@ -52,8 +53,27 @@ const DaoCard = ({ dao }: DaoCardProps) => {
           {dao.name}
         </Heading>
       </Flex>
-      <Flex direction="column" alignItems="center" justifyContent="center">
-        <Text>{dao.role}</Text>
+      <Flex
+        direction="column"
+        alignItems="center"
+        justifyContent="center"
+        width="100%"
+        borderTopRadius="none"
+        borderTopWidth="1px"
+        borderTopStyle="solid"
+        borderTopColor={dao.role === 'recruit' ? 'gray.200' : 'brand.purple'}
+        borderBottomRadius="inherit"
+        paddingY={3}
+        paddingX={5}
+        bg="white"
+      >
+        <Text
+          fontWeight="semibold"
+          fontSize="md"
+          color={dao.role === 'recruit' ? 'gray.700' : 'brand.purple'}
+        >
+          {dao.role}
+        </Text>
       </Flex>
     </Flex>
   );

--- a/apps/protocol-frontend/src/components/DaoCard.tsx
+++ b/apps/protocol-frontend/src/components/DaoCard.tsx
@@ -10,13 +10,14 @@ import {
 } from '@chakra-ui/react';
 import { HiOutlineCog, HiStar, HiOutlineStar } from 'react-icons/hi';
 
+// these are here for mocking, will be removed
 type DaoRoles = 'admin' | 'contributor' | 'recruit';
 
 type Dao = {
   id: number;
   name: string;
   role: DaoRoles;
-  isFavorited: boolean;
+  favorite: boolean;
 };
 
 interface DaoCardProps {
@@ -40,8 +41,6 @@ const DaoCard = ({ dao }: DaoCardProps) => {
     <LinkBox>
       <Flex
         direction="column"
-        // alignItems="center"
-        // justifyContent="center"
         bg={daoBgGradient[dao.role]}
         borderWidth="1px"
         borderStyle="solid"
@@ -113,7 +112,7 @@ const DaoCard = ({ dao }: DaoCardProps) => {
                 _hover={{ bg: 'transparent' }}
                 _active={{ bg: 'transparent' }}
                 icon={
-                  dao.isFavorited === true ? (
+                  dao.favorite === true ? (
                     <HiStar
                       fill={dao.role === 'recruit' ? 'gray.700' : '#5100E4'}
                       size={24}

--- a/apps/protocol-frontend/src/components/FeatureFlagWrapper.tsx
+++ b/apps/protocol-frontend/src/components/FeatureFlagWrapper.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Box } from '@chakra-ui/react';
+
+interface FeatureFlagWrapperProps {
+  children: React.ReactNode;
+}
+
+const FeatureFlagWrapper = ({ children }: FeatureFlagWrapperProps) => {
+  const dev = import.meta.env.MODE || false;
+  return <Box display={dev ? 'block' : 'none'}>{children}</Box>;
+};
+
+export default FeatureFlagWrapper;

--- a/apps/protocol-frontend/src/components/ProfileDaos.tsx
+++ b/apps/protocol-frontend/src/components/ProfileDaos.tsx
@@ -9,7 +9,7 @@ type Dao = {
   id: number;
   name: string;
   role: DaoRoles;
-  isFavorited: boolean;
+  favorite: boolean;
 };
 
 interface ProfileDaoProps {

--- a/apps/protocol-frontend/src/components/ProfileDaos.tsx
+++ b/apps/protocol-frontend/src/components/ProfileDaos.tsx
@@ -1,4 +1,5 @@
-import { Flex, Heading, Divider, SimpleGrid } from '@chakra-ui/react';
+import { Button, Flex, Heading, Divider, SimpleGrid } from '@chakra-ui/react';
+import { ControlledSelect } from '@govrn/protocol-ui';
 import DaoCard from './DaoCard';
 
 // only here for mocking purposes, will replace
@@ -28,7 +29,7 @@ const ProfileDaos = ({ daos }: ProfileDaoProps) => {
       boxShadow="sm"
       marginBottom={4}
     >
-      <Flex justify="space-between" direction="column" wrap="wrap">
+      <Flex justifyContent="space-between" direction="column" wrap="wrap">
         <Heading as="h3" size="md" fontWeight="medium" color="gray.700">
           My DAOs
         </Heading>
@@ -39,6 +40,24 @@ const ProfileDaos = ({ daos }: ProfileDaoProps) => {
           gap={8}
           width="100%"
         >
+          <Flex
+            direction="row"
+            justifyContent="center"
+            alignItems="flex-end"
+            width="40%"
+            gap={4}
+          >
+            <ControlledSelect
+              label="Select a DAO to Join"
+              isSearchable={true}
+              onChange={value => console.log(value)}
+              options={[
+                { value: '1', label: 'DAO 1' },
+                { value: '2', label: 'DAO 2' },
+              ]}
+            />
+            <Button variant="primary">Join</Button>
+          </Flex>
           <SimpleGrid columns={{ base: 1, lg: 4 }} spacing={4}>
             {daos.map(dao => (
               <DaoCard dao={dao} key={dao.id} />

--- a/apps/protocol-frontend/src/components/ProfileDaos.tsx
+++ b/apps/protocol-frontend/src/components/ProfileDaos.tsx
@@ -16,7 +16,6 @@ type Dao = {
 };
 
 interface ProfileDaoProps {
-  daos: Dao[];
   userId: number | undefined;
 }
 
@@ -50,7 +49,7 @@ const mockDaos: Dao[] = [
   },
 ];
 
-const ProfileDaos = ({ daos, userId }: ProfileDaoProps) => {
+const ProfileDaos = ({ userId }: ProfileDaoProps) => {
   // data fetching within this component so the loading states dont block the entire profile's render -- we can show a spinner for this part of the UI only similar to how we handle the fetches on the DaoDashboard page
   const { isLoading: daosListIsLoading, data: joinableDaosListData } =
     useDaosList({

--- a/apps/protocol-frontend/src/components/ProfileDaos.tsx
+++ b/apps/protocol-frontend/src/components/ProfileDaos.tsx
@@ -3,6 +3,8 @@ import { ControlledSelect, GovrnSpinner } from '@govrn/protocol-ui';
 import { useDaosList } from '../hooks/useDaosList';
 import DaoCard from './DaoCard';
 
+//TODO: add the Join function
+
 // only here for mocking purposes, will replace
 type DaoRoles = 'admin' | 'contributor' | 'recruit';
 
@@ -18,7 +20,7 @@ interface ProfileDaoProps {
   userId: number | undefined;
 }
 
-// this is mock data for the user's DAOs with their role and whether or note it is favorited
+// this is mock data for the user's DAOs with their role and whether or not it is favorited
 // TODO: replace this with data coming from a guildUsers query that includes these fields
 
 const mockDaos: Dao[] = [
@@ -49,7 +51,7 @@ const mockDaos: Dao[] = [
 ];
 
 const ProfileDaos = ({ daos, userId }: ProfileDaoProps) => {
-  // data fetching within this component so the loading states dont block the entire profile's render -- we can show a spinner for this part of the UI only
+  // data fetching within this component so the loading states dont block the entire profile's render -- we can show a spinner for this part of the UI only similar to how we handle the fetches on the DaoDashboard page
   const { isLoading: daosListIsLoading, data: joinableDaosListData } =
     useDaosList({
       where: { users: { none: { user_id: { equals: userId } } } }, // show daos user isn't in and can join

--- a/apps/protocol-frontend/src/components/ProfileDaos.tsx
+++ b/apps/protocol-frontend/src/components/ProfileDaos.tsx
@@ -1,5 +1,6 @@
 import { Button, Flex, Heading, Divider, SimpleGrid } from '@chakra-ui/react';
-import { ControlledSelect } from '@govrn/protocol-ui';
+import { ControlledSelect, GovrnSpinner } from '@govrn/protocol-ui';
+import { useDaosList } from '../hooks/useDaosList';
 import DaoCard from './DaoCard';
 
 // only here for mocking purposes, will replace
@@ -14,9 +15,22 @@ type Dao = {
 
 interface ProfileDaoProps {
   daos: Dao[];
+  userId: number | undefined;
 }
 
-const ProfileDaos = ({ daos }: ProfileDaoProps) => {
+const ProfileDaos = ({ daos, userId }: ProfileDaoProps) => {
+  const { isLoading: daosListIsLoading, data: joinableDaosListData } =
+    useDaosList({
+      where: { users: { none: { user_id: { equals: userId } } } }, // show daos user isn't in
+    });
+
+  const daoListOptions =
+    joinableDaosListData?.map(dao => ({
+      value: dao.id,
+      label: dao.name ?? '',
+    })) || [];
+
+  if (daosListIsLoading) return <GovrnSpinner />;
   return (
     <Flex
       justify="space-between"
@@ -51,10 +65,7 @@ const ProfileDaos = ({ daos }: ProfileDaoProps) => {
               label="Select a DAO to Join"
               isSearchable={false}
               onChange={value => console.log(value)}
-              options={[
-                { value: '1', label: 'DAO 1' },
-                { value: '2', label: 'DAO 2' },
-              ]}
+              options={daoListOptions}
             />
             <Button variant="primary">Join</Button>
           </Flex>

--- a/apps/protocol-frontend/src/components/ProfileDaos.tsx
+++ b/apps/protocol-frontend/src/components/ProfileDaos.tsx
@@ -44,12 +44,12 @@ const ProfileDaos = ({ daos }: ProfileDaoProps) => {
             direction="row"
             justifyContent="center"
             alignItems="flex-end"
-            width="40%"
+            width={{ base: '100%', lg: '40%' }}
             gap={4}
           >
             <ControlledSelect
               label="Select a DAO to Join"
-              isSearchable={true}
+              isSearchable={false}
               onChange={value => console.log(value)}
               options={[
                 { value: '1', label: 'DAO 1' },

--- a/apps/protocol-frontend/src/components/ProfileDaos.tsx
+++ b/apps/protocol-frontend/src/components/ProfileDaos.tsx
@@ -18,10 +18,41 @@ interface ProfileDaoProps {
   userId: number | undefined;
 }
 
+// this is mock data for the user's DAOs with their role and whether or note it is favorited
+// TODO: replace this with data coming from a guildUsers query that includes these fields
+
+const mockDaos: Dao[] = [
+  {
+    id: 1,
+    name: 'Govrn',
+    role: 'admin',
+    favorite: true,
+  },
+  {
+    id: 2,
+    name: 'Boys Club',
+    role: 'contributor',
+    favorite: true,
+  },
+  {
+    id: 3,
+    name: 'Seed Club',
+    role: 'recruit',
+    favorite: false,
+  },
+  {
+    id: 3,
+    name: 'Raid Guild',
+    role: 'recruit',
+    favorite: false,
+  },
+];
+
 const ProfileDaos = ({ daos, userId }: ProfileDaoProps) => {
+  // data fetching within this component so the loading states dont block the entire profile's render -- we can show a spinner for this part of the UI only
   const { isLoading: daosListIsLoading, data: joinableDaosListData } =
     useDaosList({
-      where: { users: { none: { user_id: { equals: userId } } } }, // show daos user isn't in
+      where: { users: { none: { user_id: { equals: userId } } } }, // show daos user isn't in and can join
     });
 
   const daoListOptions =
@@ -31,6 +62,7 @@ const ProfileDaos = ({ daos, userId }: ProfileDaoProps) => {
     })) || [];
 
   if (daosListIsLoading) return <GovrnSpinner />;
+
   return (
     <Flex
       justify="space-between"
@@ -70,7 +102,7 @@ const ProfileDaos = ({ daos, userId }: ProfileDaoProps) => {
             <Button variant="primary">Join</Button>
           </Flex>
           <SimpleGrid columns={{ base: 1, lg: 4 }} spacing={4}>
-            {daos.map(dao => (
+            {mockDaos.map(dao => (
               <DaoCard dao={dao} key={dao.id} />
             ))}
           </SimpleGrid>

--- a/apps/protocol-frontend/src/components/ProfileDaos.tsx
+++ b/apps/protocol-frontend/src/components/ProfileDaos.tsx
@@ -1,0 +1,53 @@
+import { Flex, Heading, Divider, SimpleGrid } from '@chakra-ui/react';
+import DaoCard from './DaoCard';
+
+// only here for mocking purposes, will replace
+type DaoRoles = 'admin' | 'contributor' | 'recruit';
+
+type Dao = {
+  id: number;
+  name: string;
+  role: DaoRoles;
+  isFavorited: boolean;
+};
+
+interface ProfileDaoProps {
+  daos: Dao[];
+}
+
+const ProfileDaos = ({ daos }: ProfileDaoProps) => {
+  return (
+    <Flex
+      justify="space-between"
+      direction="column"
+      wrap="wrap"
+      width="100%"
+      paddingX={4}
+      paddingY={8}
+      background="white"
+      boxShadow="sm"
+      marginBottom={4}
+    >
+      <Flex justify="space-between" direction="column" wrap="wrap">
+        <Heading as="h3" size="md" fontWeight="medium" color="gray.700">
+          My DAOs
+        </Heading>
+        <Divider marginY={8} bgColor="gray.300" />
+        <Flex
+          direction="column"
+          justifyContent="space-apart"
+          gap={8}
+          width="100%"
+        >
+          <SimpleGrid columns={{ base: 1, lg: 4 }} spacing={4}>
+            {daos.map(dao => (
+              <DaoCard dao={dao} key={dao.id} />
+            ))}
+          </SimpleGrid>
+        </Flex>
+      </Flex>
+    </Flex>
+  );
+};
+
+export default ProfileDaos;

--- a/apps/protocol-frontend/src/components/ProfileDaos.tsx
+++ b/apps/protocol-frontend/src/components/ProfileDaos.tsx
@@ -1,4 +1,4 @@
-import { Button, Flex, Heading, Divider, SimpleGrid } from '@chakra-ui/react';
+import { Button, Flex, Heading, Divider, Grid } from '@chakra-ui/react';
 import { ControlledSelect, GovrnSpinner } from '@govrn/protocol-ui';
 import { useDaosList } from '../hooks/useDaosList';
 import DaoCard from './DaoCard';
@@ -102,11 +102,20 @@ const ProfileDaos = ({ userId }: ProfileDaoProps) => {
             />
             <Button variant="primary">Join</Button>
           </Flex>
-          <SimpleGrid columns={{ base: 1, lg: 4 }} spacing={4}>
+          <Grid
+            templateColumns={{
+              base: 'repeat(1, 1fr)',
+              md: 'repeat(2, 1fr)',
+              lg: 'repeat(3, 1fr)',
+              xl: 'repeat(4, 1fr)',
+            }}
+            gap={4}
+            justifyContent="space-between"
+          >
             {mockDaos.map(dao => (
               <DaoCard dao={dao} key={dao.id} />
             ))}
-          </SimpleGrid>
+          </Grid>
         </Flex>
       </Flex>
     </Flex>

--- a/apps/protocol-frontend/src/components/ProfileForm.tsx
+++ b/apps/protocol-frontend/src/components/ProfileForm.tsx
@@ -1,13 +1,5 @@
 import { useCallback, useEffect } from 'react';
-import { Link } from 'react-router-dom';
-import {
-  Flex,
-  Heading,
-  Button,
-  Divider,
-  SimpleGrid,
-  Text,
-} from '@chakra-ui/react';
+import { Flex, Heading, Button, Divider, Text } from '@chakra-ui/react';
 import { Input } from '@govrn/protocol-ui';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
@@ -16,7 +8,6 @@ import { profileFormValidation } from '../utils/validations';
 import { ProfileFormValues } from '../types/forms';
 import { BASE_URL } from '../utils/constants';
 import useDisplayName from '../hooks/useDisplayName';
-import { useDaosList } from '../hooks/useDaosList';
 import FeatureFlagWrapper from './FeatureFlagWrapper';
 import ProfileDaos from './ProfileDaos';
 
@@ -26,38 +17,40 @@ type Dao = {
   id: number;
   name: string;
   role: DaoRoles;
-  isFavorited: boolean;
+  favorite: boolean;
 };
 
 const LINEAR_CLIENT_ID = import.meta.env.VITE_LINEAR_CLIENT_ID;
 const LINEAR_REDIRECT_URI = import.meta.env.VITE_LINEAR_REDIRECT_URI;
 const BACKEND_ADDR = `${BASE_URL}`;
 
-// TODO: replace with updated useDaosList query that has the favorite and membershipStatus in it
+// this is mock data for the user's DAOs with their role and whether or note it is favorited
+// TODO: replace this with data coming from a guildUsers query that includes these fields
+
 const mockDaos: Dao[] = [
   {
     id: 1,
     name: 'Govrn',
     role: 'admin',
-    isFavorited: true,
+    favorite: true,
   },
   {
     id: 2,
     name: 'Boys Club',
     role: 'contributor',
-    isFavorited: true,
+    favorite: true,
   },
   {
     id: 3,
     name: 'Seed Club',
     role: 'recruit',
-    isFavorited: false,
+    favorite: false,
   },
   {
     id: 3,
     name: 'Raid Guild',
     role: 'recruit',
-    isFavorited: false,
+    favorite: false,
   },
 ];
 
@@ -65,11 +58,6 @@ const ProfileForm = () => {
   const { userData, updateProfile, disconnectLinear } = useUser();
   const { displayName } = useDisplayName();
 
-  const { isLoading: daosListIsLoading, data: daosListData } = useDaosList({
-    where: { users: { some: { user_id: { equals: userData?.id } } } }, // show only user's DAOs
-  });
-
-  console.log('daosListData', daosListData);
   const localForm = useForm<ProfileFormValues>({
     mode: 'all',
     resolver: yupResolver(profileFormValidation),

--- a/apps/protocol-frontend/src/components/ProfileForm.tsx
+++ b/apps/protocol-frontend/src/components/ProfileForm.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect } from 'react';
-import { Flex, Heading, Button, Divider } from '@chakra-ui/react';
+import { Flex, Heading, Button, Divider, Text } from '@chakra-ui/react';
 import { Input } from '@govrn/protocol-ui';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
@@ -7,6 +7,8 @@ import { useUser } from '../contexts/UserContext';
 import { profileFormValidation } from '../utils/validations';
 import { ProfileFormValues } from '../types/forms';
 import { BASE_URL } from '../utils/constants';
+import useDisplayName from '../hooks/useDisplayName';
+import FeatureFlagWrapper from './FeatureFlagWrapper';
 
 const LINEAR_CLIENT_ID = import.meta.env.VITE_LINEAR_CLIENT_ID;
 const LINEAR_REDIRECT_URI = import.meta.env.VITE_LINEAR_REDIRECT_URI;
@@ -14,6 +16,7 @@ const BACKEND_ADDR = `${BASE_URL}`;
 
 const ProfileForm = () => {
   const { userData, updateProfile, disconnectLinear } = useUser();
+  const { displayName } = useDisplayName();
 
   const localForm = useForm<ProfileFormValues>({
     mode: 'all',
@@ -75,9 +78,20 @@ const ProfileForm = () => {
           borderRadius={{ base: 'none', md: 'lg' }}
           marginBottom={4}
         >
-          <Heading as="h3" size="md" fontWeight="medium" color="gray.700">
-            Your Details
+          <Heading as="h3" size="md" color="gray.800" fontWeight="medium">
+            Hi,{' '}
+            <Text
+              as="span"
+              bgGradient="linear(to-l, #7928CA, #FF0080)"
+              bgClip="text"
+            >
+              {displayName}
+            </Text>
+            <span role="img" aria-labelledby="wave emoji next to user name">
+              {'!'} 👋
+            </span>
           </Heading>
+
           <Flex
             direction="column"
             alignItems="flex-start"
@@ -98,6 +112,34 @@ const ProfileForm = () => {
           </Flex>
         </Flex>
       </form>
+      <FeatureFlagWrapper>
+        <Flex
+          justify="space-between"
+          direction="column"
+          wrap="wrap"
+          width="100%"
+          paddingX={4}
+          paddingTop={4}
+          background="white"
+          boxShadow="sm"
+          marginBottom={4}
+        >
+          <Flex justify="space-between" direction="column" wrap="wrap">
+            <Heading as="h3" size="md" fontWeight="medium" color="gray.700">
+              My DAOs
+            </Heading>
+            <Divider marginY={8} />
+            <Flex
+              direction="column"
+              align="flex-start"
+              marginTop={4}
+              marginBottom={4}
+              gap="20px"
+              width={{ base: '100%', lg: '50%' }}
+            ></Flex>
+          </Flex>
+        </Flex>
+      </FeatureFlagWrapper>
       <form>
         <Flex
           justify="space-between"
@@ -114,6 +156,7 @@ const ProfileForm = () => {
             <Heading as="h3" size="md" fontWeight="medium" color="gray.700">
               Integrations
             </Heading>
+            <Divider marginY={8} />
             <Flex
               direction="column"
               align="flex-start"

--- a/apps/protocol-frontend/src/components/ProfileForm.tsx
+++ b/apps/protocol-frontend/src/components/ProfileForm.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import {
   Flex,
   Heading,

--- a/apps/protocol-frontend/src/components/ProfileForm.tsx
+++ b/apps/protocol-frontend/src/components/ProfileForm.tsx
@@ -15,8 +15,9 @@ import { profileFormValidation } from '../utils/validations';
 import { ProfileFormValues } from '../types/forms';
 import { BASE_URL } from '../utils/constants';
 import useDisplayName from '../hooks/useDisplayName';
+import { useDaosList } from '../hooks/useDaosList';
 import FeatureFlagWrapper from './FeatureFlagWrapper';
-import DaoCard from './DaoCard';
+import ProfileDaos from './ProfileDaos';
 
 type DaoRoles = 'admin' | 'contributor' | 'recruit';
 
@@ -31,6 +32,7 @@ const LINEAR_CLIENT_ID = import.meta.env.VITE_LINEAR_CLIENT_ID;
 const LINEAR_REDIRECT_URI = import.meta.env.VITE_LINEAR_REDIRECT_URI;
 const BACKEND_ADDR = `${BASE_URL}`;
 
+// TODO: replace with updated useDaosList query that has the favorite and membershipStatus in it
 const mockDaos: Dao[] = [
   {
     id: 1,
@@ -62,6 +64,11 @@ const ProfileForm = () => {
   const { userData, updateProfile, disconnectLinear } = useUser();
   const { displayName } = useDisplayName();
 
+  const { isLoading: daosListIsLoading, data: daosListData } = useDaosList({
+    where: { users: { some: { user_id: { equals: userData?.id } } } }, // show only user's DAOs
+  });
+
+  console.log('daosListData', daosListData);
   const localForm = useForm<ProfileFormValues>({
     mode: 'all',
     resolver: yupResolver(profileFormValidation),
@@ -157,36 +164,7 @@ const ProfileForm = () => {
         </Flex>
       </form>
       <FeatureFlagWrapper>
-        <Flex
-          justify="space-between"
-          direction="column"
-          wrap="wrap"
-          width="100%"
-          paddingX={4}
-          paddingY={8}
-          background="white"
-          boxShadow="sm"
-          marginBottom={4}
-        >
-          <Flex justify="space-between" direction="column" wrap="wrap">
-            <Heading as="h3" size="md" fontWeight="medium" color="gray.700">
-              My DAOs
-            </Heading>
-            <Divider marginY={8} bgColor="gray.300" />
-            <Flex
-              direction="column"
-              justifyContent="space-apart"
-              gap={8}
-              width="100%"
-            >
-              <SimpleGrid columns={4} spacing={4}>
-                {mockDaos.map(dao => (
-                  <DaoCard dao={dao} key={dao.id} />
-                ))}
-              </SimpleGrid>
-            </Flex>
-          </Flex>
-        </Flex>
+        <ProfileDaos daos={mockDaos} />
       </FeatureFlagWrapper>
       <form>
         <Flex

--- a/apps/protocol-frontend/src/components/ProfileForm.tsx
+++ b/apps/protocol-frontend/src/components/ProfileForm.tsx
@@ -1,5 +1,12 @@
 import { useCallback, useEffect } from 'react';
-import { Flex, Heading, Button, Divider, Text } from '@chakra-ui/react';
+import {
+  Flex,
+  Heading,
+  Button,
+  Divider,
+  SimpleGrid,
+  Text,
+} from '@chakra-ui/react';
 import { Input } from '@govrn/protocol-ui';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
@@ -156,7 +163,7 @@ const ProfileForm = () => {
           wrap="wrap"
           width="100%"
           paddingX={4}
-          paddingTop={4}
+          paddingY={8}
           background="white"
           boxShadow="sm"
           marginBottom={4}
@@ -168,15 +175,15 @@ const ProfileForm = () => {
             <Divider marginY={8} bgColor="gray.300" />
             <Flex
               direction="column"
-              align="flex-start"
-              marginTop={4}
-              marginBottom={4}
-              gap="20px"
-              width={{ base: '100%', lg: '50%' }}
+              justifyContent="space-apart"
+              gap={8}
+              width="100%"
             >
-              {mockDaos.map(dao => (
-                <DaoCard dao={dao} key={dao.id} />
-              ))}
+              <SimpleGrid columns={4} spacing={4}>
+                {mockDaos.map(dao => (
+                  <DaoCard dao={dao} key={dao.id} />
+                ))}
+              </SimpleGrid>
             </Flex>
           </Flex>
         </Flex>

--- a/apps/protocol-frontend/src/components/ProfileForm.tsx
+++ b/apps/protocol-frontend/src/components/ProfileForm.tsx
@@ -4,7 +4,6 @@ import { Input } from '@govrn/protocol-ui';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { useUser } from '../contexts/UserContext';
-import { useDaosList } from '../hooks/useDaosList';
 import { profileFormValidation } from '../utils/validations';
 import { ProfileFormValues } from '../types/forms';
 import { BASE_URL } from '../utils/constants';
@@ -12,48 +11,9 @@ import useDisplayName from '../hooks/useDisplayName';
 import FeatureFlagWrapper from './FeatureFlagWrapper';
 import ProfileDaos from './ProfileDaos';
 
-type DaoRoles = 'admin' | 'contributor' | 'recruit';
-
-type Dao = {
-  id: number;
-  name: string;
-  role: DaoRoles;
-  favorite: boolean;
-};
-
 const LINEAR_CLIENT_ID = import.meta.env.VITE_LINEAR_CLIENT_ID;
 const LINEAR_REDIRECT_URI = import.meta.env.VITE_LINEAR_REDIRECT_URI;
 const BACKEND_ADDR = `${BASE_URL}`;
-
-// this is mock data for the user's DAOs with their role and whether or note it is favorited
-// TODO: replace this with data coming from a guildUsers query that includes these fields
-
-const mockDaos: Dao[] = [
-  {
-    id: 1,
-    name: 'Govrn',
-    role: 'admin',
-    favorite: true,
-  },
-  {
-    id: 2,
-    name: 'Boys Club',
-    role: 'contributor',
-    favorite: true,
-  },
-  {
-    id: 3,
-    name: 'Seed Club',
-    role: 'recruit',
-    favorite: false,
-  },
-  {
-    id: 3,
-    name: 'Raid Guild',
-    role: 'recruit',
-    favorite: false,
-  },
-];
 
 const ProfileForm = () => {
   const { userData, updateProfile, disconnectLinear } = useUser();
@@ -154,7 +114,7 @@ const ProfileForm = () => {
         </Flex>
       </form>
       <FeatureFlagWrapper>
-        <ProfileDaos daos={mockDaos} userId={userData?.id} />
+        <ProfileDaos userId={userData?.id} />
       </FeatureFlagWrapper>
       <form>
         <Flex

--- a/apps/protocol-frontend/src/components/ProfileForm.tsx
+++ b/apps/protocol-frontend/src/components/ProfileForm.tsx
@@ -4,6 +4,7 @@ import { Input } from '@govrn/protocol-ui';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { useUser } from '../contexts/UserContext';
+import { useDaosList } from '../hooks/useDaosList';
 import { profileFormValidation } from '../utils/validations';
 import { ProfileFormValues } from '../types/forms';
 import { BASE_URL } from '../utils/constants';
@@ -153,7 +154,7 @@ const ProfileForm = () => {
         </Flex>
       </form>
       <FeatureFlagWrapper>
-        <ProfileDaos daos={mockDaos} />
+        <ProfileDaos daos={mockDaos} userId={userData?.id} />
       </FeatureFlagWrapper>
       <form>
         <Flex
@@ -201,7 +202,6 @@ const ProfileForm = () => {
                 </Button>
               )}
             </Flex>
-            {/* <Divider bgColor="gray.300" /> */}
           </Flex>
           <Flex justify="space-between" direction="column" wrap="wrap">
             <Flex

--- a/apps/protocol-frontend/src/components/ProfileForm.tsx
+++ b/apps/protocol-frontend/src/components/ProfileForm.tsx
@@ -9,10 +9,47 @@ import { ProfileFormValues } from '../types/forms';
 import { BASE_URL } from '../utils/constants';
 import useDisplayName from '../hooks/useDisplayName';
 import FeatureFlagWrapper from './FeatureFlagWrapper';
+import DaoCard from './DaoCard';
+
+type DaoRoles = 'admin' | 'contributor' | 'recruit';
+
+type Dao = {
+  id: number;
+  name: string;
+  role: DaoRoles;
+  isFavorited: boolean;
+};
 
 const LINEAR_CLIENT_ID = import.meta.env.VITE_LINEAR_CLIENT_ID;
 const LINEAR_REDIRECT_URI = import.meta.env.VITE_LINEAR_REDIRECT_URI;
 const BACKEND_ADDR = `${BASE_URL}`;
+
+const mockDaos: Dao[] = [
+  {
+    id: 1,
+    name: 'Govrn',
+    role: 'admin',
+    isFavorited: true,
+  },
+  {
+    id: 2,
+    name: 'Boys Club',
+    role: 'contributor',
+    isFavorited: true,
+  },
+  {
+    id: 3,
+    name: 'Seed Club',
+    role: 'recruit',
+    isFavorited: false,
+  },
+  {
+    id: 3,
+    name: 'Raid Guild',
+    role: 'recruit',
+    isFavorited: false,
+  },
+];
 
 const ProfileForm = () => {
   const { userData, updateProfile, disconnectLinear } = useUser();
@@ -87,7 +124,7 @@ const ProfileForm = () => {
             >
               {displayName}
             </Text>
-            <span role="img" aria-labelledby="wave emoji next to user name">
+            <span role="img" aria-labelledby="Wave emoji next to user name">
               {'!'} 👋
             </span>
           </Heading>
@@ -128,7 +165,7 @@ const ProfileForm = () => {
             <Heading as="h3" size="md" fontWeight="medium" color="gray.700">
               My DAOs
             </Heading>
-            <Divider marginY={8} />
+            <Divider marginY={8} bgColor="gray.300" />
             <Flex
               direction="column"
               align="flex-start"
@@ -136,7 +173,11 @@ const ProfileForm = () => {
               marginBottom={4}
               gap="20px"
               width={{ base: '100%', lg: '50%' }}
-            ></Flex>
+            >
+              {mockDaos.map(dao => (
+                <DaoCard dao={dao} key={dao.id} />
+              ))}
+            </Flex>
           </Flex>
         </Flex>
       </FeatureFlagWrapper>
@@ -156,7 +197,7 @@ const ProfileForm = () => {
             <Heading as="h3" size="md" fontWeight="medium" color="gray.700">
               Integrations
             </Heading>
-            <Divider marginY={8} />
+            <Divider marginY={8} bgColor="gray.300" />
             <Flex
               direction="column"
               align="flex-start"
@@ -166,7 +207,7 @@ const ProfileForm = () => {
               width={{ base: '100%', lg: '50%' }}
             >
               <Heading as="h4" size="sm" fontWeight="medium" color="gray.700">
-                Connect Linear
+                Linear
               </Heading>
               {userData?.linear_users && userData.linear_users.length > 0 ? (
                 <Button
@@ -186,7 +227,7 @@ const ProfileForm = () => {
                 </Button>
               )}
             </Flex>
-            <Divider bgColor="gray.300" />
+            {/* <Divider bgColor="gray.300" /> */}
           </Flex>
           <Flex justify="space-between" direction="column" wrap="wrap">
             <Flex
@@ -198,14 +239,13 @@ const ProfileForm = () => {
             >
               <Input
                 name="userTwitterHandle"
-                label="Twitter Handle (Coming Soon!)"
-                tip="Enter your Twitter handle for the upcoming Twitter integration."
+                label="Twitter Handle (Coming Soon)"
                 placeholder="govrn"
                 localForm={localForm}
                 isDisabled
               />
               <Button variant="primary" type="submit" isDisabled>
-                Link Twitter
+                Connect Twitter
               </Button>
             </Flex>
           </Flex>

--- a/libs/protocol-ui/src/components/molecules/ControlledSelect/ControlledSelect.tsx
+++ b/libs/protocol-ui/src/components/molecules/ControlledSelect/ControlledSelect.tsx
@@ -63,6 +63,8 @@ const ControlledSelect: React.FC<ControlledSelectProps> = ({
           onChange={onChange}
           value={value}
           isSearchable={isSearchable}
+          styles={{ menuPortal: base => ({ ...base, zIndex: 9999 }) }}
+          menuPortalTarget={document.querySelector('body')} // so dropdown menu doesnt interfere with clickable elements
           {...props}
         />
       </Box>

--- a/libs/protocol-ui/src/components/molecules/ControlledSelect/ControlledSelect.tsx
+++ b/libs/protocol-ui/src/components/molecules/ControlledSelect/ControlledSelect.tsx
@@ -45,7 +45,7 @@ const ControlledSelect: React.FC<ControlledSelectProps> = ({
   return (
     <Stack spacing={2} width="100%">
       {label && (
-        <Text fontSize="" color="gray.800">
+        <Text fontSize="md" fontWeight="500" color="gray.800">
           {label}
         </Text>
       )}

--- a/libs/protocol-ui/src/components/molecules/CreatableSelect/CreatableSelect.tsx
+++ b/libs/protocol-ui/src/components/molecules/CreatableSelect/CreatableSelect.tsx
@@ -42,6 +42,7 @@ export interface CreatableSelectProps {
   variant?: 'outline' | 'filled';
   value?: any;
   components?: SelectComponents;
+  // menuPortalBody?: boolean;
 }
 
 const CreatableSelect: React.FC<CreatableSelectProps> = ({
@@ -87,6 +88,8 @@ const CreatableSelect: React.FC<CreatableSelectProps> = ({
                 isDisabled={isDisabled}
                 value={value}
                 components={{ SelectContainer }}
+                styles={{ menuPortal: base => ({ ...base, zIndex: 9999 }) }}
+                menuPortalTarget={document.querySelector('body')} // so dropdown menu doesnt interfere with clickable elements
               />
             )}
           />

--- a/libs/protocol-ui/src/components/molecules/Select/Select.tsx
+++ b/libs/protocol-ui/src/components/molecules/Select/Select.tsx
@@ -85,6 +85,8 @@ const Select: React.FC<SelectProps> = ({
                 isDisabled={isDisabled}
                 value={value}
                 components={{ SelectContainer }}
+                styles={{ menuPortal: base => ({ ...base, zIndex: 9999 }) }}
+                menuPortalTarget={document.querySelector('body')} // so dropdown menu doesnt interfere with clickable elements
               />
             )}
           />


### PR DESCRIPTION
## Linear Ticket

- [PRO-616](https://linear.app/govrn/issue/PRO-616/dao-card-on-profile-page)
- [PRO-779](https://linear.app/govrn/issue/PRO-779/states)
- [PRO-617](https://linear.app/govrn/issue/PRO-617/show-daos-youve-joined)
- [PRO-817](https://linear.app/govrn/issue/PRO-817/create-feature-flag-component)

## Description

- Adds in the UI for the _My DAOs_ section of the Profile
- Modifies our Select components to support better portalling and respect to clickable elements behind the open menu
- Adds the `ProfileDaos` and `DaoCard` components
- Fetching is done at the `ProfileDaos` component so that we don't block any loading for the rest of the Profile (similar to how we did this for the DAO Dashboards)
- Uses mock data that'll be replaced:
  - Noted throughout the code but the mock data is for the user's DAOs that (mock data being used for the `favorite` and their `role`)  

## Screencaptures

![govrn-profile-daos-mobile](https://user-images.githubusercontent.com/9438776/212723367-59577178-d7d1-4d0e-9a48-d25227ef7315.gif)
![govrn-profile-daos](https://user-images.githubusercontent.com/9438776/212723372-a18c1c3b-2a34-421c-8ba3-838040bff66a.gif)


