### PR TITLE
fix/feature-flag-wrapper

### DIFF
--- a/apps/protocol-frontend/src/components/FeatureFlagWrapper.tsx
+++ b/apps/protocol-frontend/src/components/FeatureFlagWrapper.tsx
@@ -6,7 +6,7 @@ interface FeatureFlagWrapperProps {
 }
 
 const FeatureFlagWrapper = ({ children }: FeatureFlagWrapperProps) => {
-  const dev = import.meta.env.MODE || false;
+  const dev = import.meta.env.DEV === true;
   return <Box display={dev ? 'block' : 'none'}>{children}</Box>;
 };
 

--- a/apps/protocol-frontend/src/utils/web3.ts
+++ b/apps/protocol-frontend/src/utils/web3.ts
@@ -25,7 +25,7 @@ const gnosisChain: Chain = {
   testnet: false,
 };
 
-const dev = import.meta.env.MODE || false;
+const dev = import.meta.env.DEV === true;
 const defaultChains = dev
   ? [gnosisChain, chain.goerli, chain.rinkeby, chain.localhost]
   : [gnosisChain];


### PR DESCRIPTION
## Linear Ticket

n/a

## Description

- Fixes the logic used in the feature flag wrapper (and in `chains` to determine which networks we show)
- Using `import.meta.env.DEV` for the check instead of `.MODE` 

## Screencaptures

Dev (running localhost):

![govrn-dev-mode](https://user-images.githubusercontent.com/9438776/213529658-d574f241-2b51-40bf-8a34-d0b7b9b17231.gif)

Prod (built locally and served):

![govrn-prod-mode](https://user-images.githubusercontent.com/9438776/213529696-eb4c7aad-dc21-4502-97fa-2ad43e29e2ae.gif)



