### PR TITLE
Add in staging vars (ENG-857)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,6 +108,7 @@ jobs:
           echo VITE_LINEAR_CLIENT_ID=9131c342273502268438468f08337b29 >> .env
           echo VITE_INFURA_SUBDOMAIN=https://govrn.infura-ipfs.io >> .env
           echo VITE_PUBLIC_ALCHEMY_KEY=${{ secrets.PUBLIC_ALCHEMY_KEY }} >> .env
+          echo VITE_BUILD_ENV=production >> .env
           echo CLOUDFLARE_ACCOUNT_ID=${{ secrets.CLOUDFLARE_ACCOUNT_ID }} >> .env
           echo CLOUDFLARE_API_TOKEN=${{ secrets.CLOUDFLARE_API_TOKEN }} >> .env
       - name: Build

--- a/.github/workflows/ci_staging.yaml
+++ b/.github/workflows/ci_staging.yaml
@@ -189,6 +189,7 @@ jobs:
           echo VITE_LINEAR_CLIENT_ID=0cc73e0a21f8cd7087d78634a9e4e0ce >> .env
           echo VITE_INFURA_SUBDOMAIN=https://govrn-staging.infura-ipfs.io >> .env
           echo VITE_STAGING_MODE=true >> .env
+          echo VITE_BUILD_ENV=staging >> .env
           echo VITE_PUBLIC_ALCHEMY_KEY=${{ secrets.PUBLIC_ALCHEMY_KEY }} >> .env
       - name: Create Database
         run: yarn nx run protocol-api:migrate

--- a/apps/protocol-frontend/src/components/FeatureFlagWrapper.tsx
+++ b/apps/protocol-frontend/src/components/FeatureFlagWrapper.tsx
@@ -6,8 +6,11 @@ interface FeatureFlagWrapperProps {
 }
 
 const FeatureFlagWrapper = ({ children }: FeatureFlagWrapperProps) => {
-  const dev = import.meta.env.DEV === true;
-  return <Box display={dev ? 'block' : 'none'}>{children}</Box>;
+  const buildEnv = import.meta.env.VITE_BUILD_ENV;
+
+  return (
+    <Box display={buildEnv !== 'production' ? 'block' : 'none'}>{children}</Box>
+  );
 };
 
 export default FeatureFlagWrapper;

--- a/apps/protocol-frontend/src/utils/web3.ts
+++ b/apps/protocol-frontend/src/utils/web3.ts
@@ -25,10 +25,12 @@ const gnosisChain: Chain = {
   testnet: false,
 };
 
-const dev = import.meta.env.DEV === true;
-const defaultChains = dev
-  ? [gnosisChain, chain.goerli, chain.rinkeby, chain.localhost]
-  : [gnosisChain];
+const buildEnv = import.meta.env.VITE_BUILD_ENV;
+
+const defaultChains =
+  buildEnv !== 'production'
+    ? [gnosisChain, chain.goerli, chain.rinkeby, chain.localhost]
+    : [gnosisChain];
 export const { chains, provider } = configureChains(defaultChains, [
   alchemyProvider({ apiKey: ALCHEMY_KEY }),
   publicProvider(),


### PR DESCRIPTION
## Linear Ticket

- [ENG-857](https://linear.app/govrn/issue/ENG-857/add-goerli-back-to-supported-networks-on-staging)

## Description

- Adds in the `VITE_BUILD_MODE` to the CI yaml and adjusts the logic for determining what we should show in dev, staging, and prod
- In staging:
  - UI wrapped in `FeatureFlagWrapper` will show 
  - Testnets will show
- In prod:
  -  No UI in wrapper will show
  - Testnets are hidden
- In dev:
  - Effectively similar to staging -- all will show

Key distinction is that this allows us to set staging deploys to not be a prod environment. If we use the built-in Vite modes we were building staging in prod, so we didn't have the testnets.

I modified our yaml files to set the env. I tested by setting the env locally and the logic worked, but would appreciate more eyes on the yaml builds.
