### PR TITLE
feature/dao-manual-create-functionality (ENG-843)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,14 @@
 {
+    "[typescript]": {
+      "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[typescriptreact]": {
+      "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[javascript]": {
+      "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+  "editor.formatOnSave": true,
   "typescript.tsdk": "node_modules/typescript/lib",
   "python.defaultInterpreterPath": "apps/kevin-malone/.venv/bin/python3",
   "python.testing.cwd": "apps/kevin-malone",
@@ -6,5 +16,8 @@
     "tests"
   ],
   "python.testing.unittestEnabled": false,
-  "python.testing.pytestEnabled": true
+  "python.testing.pytestEnabled": true,
+  "[prisma]": {
+    "editor.defaultFormatter": "Prisma.prisma"
+  },
 }

--- a/apps/protocol-api/src/prisma/resolvers/UserGuild.ts
+++ b/apps/protocol-api/src/prisma/resolvers/UserGuild.ts
@@ -67,6 +67,8 @@ export class GuildUserCustomResolver {
   ) {
     const address = req.session.siwe.data.address;
 
+    console.log('args', args);
+
     const user = await prisma.user.findFirst({
       where: { address: { equals: address } },
     });

--- a/apps/protocol-api/src/prisma/resolvers/UserGuild.ts
+++ b/apps/protocol-api/src/prisma/resolvers/UserGuild.ts
@@ -114,10 +114,6 @@ export class GuildUserCustomResolver {
       throw new Error('Signature address does not equal requested address');
     }
 
-    // modify to fetch the guild and if the guild doesnt exist then skip this check
-    // create the guild in separate query and use this guild id
-    // name would be required in the create guild query
-
     if (args.data.guildId !== undefined) {
       return await prisma.guildUser.create({
         data: {

--- a/apps/protocol-api/src/prisma/resolvers/UserGuild.ts
+++ b/apps/protocol-api/src/prisma/resolvers/UserGuild.ts
@@ -70,6 +70,10 @@ export class GuildUserCustomResolver {
       throw new Error('Signature address does not equal requested address');
     }
 
+    // modify to fetch the guild and if the guild doesnt exist then skip this check
+    // create the guild in separate query and use this guild id
+    // name would be required in the create guild query
+
     return await prisma.guildUser.create({
       data: {
         user: {
@@ -77,13 +81,8 @@ export class GuildUserCustomResolver {
             create: {
               address: args.data.userAddress,
               chain_type: {
-                connectOrCreate: {
-                  create: {
-                    name: 'ethereum_mainnet',
-                  },
-                  where: {
-                    name: 'ethereum_mainnet',
-                  },
+                connect: {
+                  name: 'ethereum_mainnet',
                 },
               },
             },
@@ -94,13 +93,8 @@ export class GuildUserCustomResolver {
           },
         },
         guild: {
-          connectOrCreate: {
-            create: {
-              id: args.data.guildId,
-            },
-            where: {
-              id: args.data.guildId,
-            },
+          connect: {
+            id: args.data.guildId,
           },
         },
         membershipStatus: {

--- a/apps/protocol-api/src/prisma/resolvers/UserGuild.ts
+++ b/apps/protocol-api/src/prisma/resolvers/UserGuild.ts
@@ -6,11 +6,19 @@ import { Context } from './types';
   isAbstract: true,
 })
 export class GuildUserCreateCustomInput {
-  @TypeGraphQL.Field(_type => TypeGraphQL.Int)
-  userId: number;
+  @TypeGraphQL.Field(_type => TypeGraphQL.Int, {
+    nullable: true,
+  })
+  userId?: number;
 
   @TypeGraphQL.Field(_type => TypeGraphQL.Int)
   guildId: number;
+
+  @TypeGraphQL.Field(_type => String, { nullable: true })
+  userAddress?: string;
+
+  @TypeGraphQL.Field(_type => String, { nullable: true })
+  membershipStatus?: string;
 }
 
 @TypeGraphQL.ArgsType()
@@ -65,8 +73,24 @@ export class GuildUserCustomResolver {
     return await prisma.guildUser.create({
       data: {
         user: {
-          connect: {
-            id: args.data.userId,
+          connectOrCreate: {
+            create: {
+              address: args.data.userAddress,
+              chain_type: {
+                connectOrCreate: {
+                  create: {
+                    name: 'ethereum_mainnet',
+                  },
+                  where: {
+                    name: 'ethereum_mainnet',
+                  },
+                },
+              },
+            },
+            where: {
+              id: args.data.userId,
+              address: args.data.userAddress,
+            },
           },
         },
         guild: {
@@ -76,7 +100,7 @@ export class GuildUserCustomResolver {
         },
         membershipStatus: {
           connect: {
-            name: 'Recruit',
+            name: args.data.membershipStatus ?? 'Recruit',
           },
         },
       },

--- a/apps/protocol-api/src/prisma/resolvers/UserGuild.ts
+++ b/apps/protocol-api/src/prisma/resolvers/UserGuild.ts
@@ -112,7 +112,7 @@ export class GuildUserCustomResolver {
       });
     }
 
-    if (args.data.guildId !== undefined && user?.id !== args.data.userId) {
+    if (args.data.guildId === undefined && user?.id !== args.data.userId) {
       throw new Error('Signature address does not equal requested address');
     }
 

--- a/apps/protocol-api/src/prisma/resolvers/UserGuild.ts
+++ b/apps/protocol-api/src/prisma/resolvers/UserGuild.ts
@@ -71,10 +71,6 @@ export class GuildUserCustomResolver {
       where: { address: { equals: address } },
     });
 
-    console.log('address', address);
-    console.log('args.data.userId', args.data.userId);
-    console.log('guild id', args.data.guildId);
-
     if (args.data.guildId === undefined && user?.id !== args.data.userId) {
       throw new Error('Signature address does not equal requested address');
     }
@@ -130,7 +126,6 @@ export class GuildUserCustomResolver {
               },
             },
             where: {
-              // id: args.data.userId,
               address: args.data.userAddress,
             },
           },

--- a/apps/protocol-api/src/prisma/resolvers/UserGuild.ts
+++ b/apps/protocol-api/src/prisma/resolvers/UserGuild.ts
@@ -115,7 +115,7 @@ export class GuildUserCustomResolver {
     }
 
     if (args.data.guildId !== undefined) {
-      return await prisma.guildUser.create({
+      await prisma.guildUser.create({
         data: {
           user: {
             connectOrCreate: {

--- a/apps/protocol-api/src/prisma/resolvers/UserGuild.ts
+++ b/apps/protocol-api/src/prisma/resolvers/UserGuild.ts
@@ -71,7 +71,7 @@ export class GuildUserCustomResolver {
       where: { address: { equals: address } },
     });
 
-    if (args.data.guildId === undefined && user?.id !== args.data.userId) {
+    if (args.data.guildId !== undefined && user?.id !== args.data.userId) {
       throw new Error('Signature address does not equal requested address');
     }
 

--- a/apps/protocol-api/src/prisma/resolvers/UserGuild.ts
+++ b/apps/protocol-api/src/prisma/resolvers/UserGuild.ts
@@ -77,6 +77,7 @@ export class GuildUserCustomResolver {
           name: args.data.guildName,
         },
       });
+
       return await prisma.guildUser.create({
         data: {
           user: {
@@ -97,17 +98,14 @@ export class GuildUserCustomResolver {
           },
           guild: {
             connect: {
-              id:
-                args.data.guildId !== undefined
-                  ? args.data.guildId
-                  : guildCreate.id,
+              id: guildCreate.id,
             },
           },
-          // membershipStatus: {
-          //   connect: {
-          //     name: args.data.membershipStatus ?? 'Recruit',
-          //   },
-          // },
+          membershipStatus: {
+            connect: {
+              name: args.data.membershipStatus ?? 'Recruit',
+            },
+          },
         },
       });
     }
@@ -144,11 +142,11 @@ export class GuildUserCustomResolver {
               id: args.data.guildId,
             },
           },
-          // membershipStatus: {
-          //   connect: {
-          //     name: args.data.membershipStatus ?? 'Recruit',
-          //   },
-          // },
+          membershipStatus: {
+            connect: {
+              name: args.data.membershipStatus ?? 'Recruit',
+            },
+          },
         },
       });
     }

--- a/apps/protocol-api/src/prisma/resolvers/UserGuild.ts
+++ b/apps/protocol-api/src/prisma/resolvers/UserGuild.ts
@@ -11,8 +11,8 @@ export class GuildUserCreateCustomInput {
   })
   userId?: number;
 
-  @TypeGraphQL.Field(_type => TypeGraphQL.Int)
-  guildId: number;
+  @TypeGraphQL.Field(_type => TypeGraphQL.Int, { nullable: true })
+  guildId?: number;
 
   @TypeGraphQL.Field(_type => String, { nullable: true })
   userAddress?: string;
@@ -94,8 +94,13 @@ export class GuildUserCustomResolver {
           },
         },
         guild: {
-          connect: {
-            id: args.data.guildId,
+          connectOrCreate: {
+            create: {
+              id: args.data.guildId,
+            },
+            where: {
+              id: args.data.guildId,
+            },
           },
         },
         membershipStatus: {

--- a/apps/protocol-api/src/prisma/resolvers/UserGuild.ts
+++ b/apps/protocol-api/src/prisma/resolvers/UserGuild.ts
@@ -67,8 +67,6 @@ export class GuildUserCustomResolver {
   ) {
     const address = req.session.siwe.data.address;
 
-    console.log('args', args);
-
     const user = await prisma.user.findFirst({
       where: { address: { equals: address } },
     });

--- a/apps/protocol-frontend/src/components/CreateDaoLayout.tsx
+++ b/apps/protocol-frontend/src/components/CreateDaoLayout.tsx
@@ -89,7 +89,7 @@ const CreateDaoLayout = () => {
       />
       <ModalWrapper
         name="createDaoModal"
-        title="Add DAO Members"
+        title="Create a DAO"
         localOverlay={localOverlay}
         size="3xl"
         content={<DaoTextareaForm />}

--- a/apps/protocol-frontend/src/components/DaoTextareaForm.tsx
+++ b/apps/protocol-frontend/src/components/DaoTextareaForm.tsx
@@ -103,7 +103,7 @@ const DaoTextareaForm = () => {
           <Button
             variant="primary"
             type="submit"
-            disabled={errors['daoMemberAddresses'] !== undefined}
+            disabled={importing || errors['daoMemberAddresses'] !== undefined}
           >
             Import
           </Button>

--- a/apps/protocol-frontend/src/components/DaoTextareaForm.tsx
+++ b/apps/protocol-frontend/src/components/DaoTextareaForm.tsx
@@ -32,7 +32,7 @@ const DaoTextareaForm = () => {
     DaoTextareaFormValues
   > = async values => {
     const { daoMemberAddresses } = values;
-    // setImporting(true);
+    setImporting(true);
     if (daoMemberAddresses !== undefined) {
       const parsedDaoMemberAddresses = splitEntriesByComma(daoMemberAddresses);
       const uniqueParsedDaoMemberAddresses = [
@@ -40,6 +40,7 @@ const DaoTextareaForm = () => {
       ];
 
       await createDaoUser({
+        userId: userData?.id,
         guildName: values.guildName,
         userAddress: userData?.address,
         membershipStatus: 'Admin',
@@ -53,7 +54,7 @@ const DaoTextareaForm = () => {
           return true;
         }),
       );
-      // setImporting(false);
+      setImporting(false);
       setModals({ createDaoModal: false });
     }
   };

--- a/apps/protocol-frontend/src/components/DaoTextareaForm.tsx
+++ b/apps/protocol-frontend/src/components/DaoTextareaForm.tsx
@@ -34,7 +34,9 @@ const DaoTextareaForm = () => {
     const { daoMemberAddresses } = values;
     setImporting(true);
     if (daoMemberAddresses !== undefined) {
-      const parsedDaoMemberAddresses = splitEntriesByComma(daoMemberAddresses);
+      const parsedDaoMemberAddresses = splitEntriesByComma(
+        daoMemberAddresses,
+      ).filter(address => address !== userData?.address);
       const uniqueParsedDaoMemberAddresses = [
         ...new Set(parsedDaoMemberAddresses),
       ];

--- a/apps/protocol-frontend/src/components/DaoTextareaForm.tsx
+++ b/apps/protocol-frontend/src/components/DaoTextareaForm.tsx
@@ -4,7 +4,7 @@ import { useForm, SubmitHandler } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { DaoTextareaFormValues } from '../types/forms';
 import { AiFillCheckCircle } from 'react-icons/ai';
-import { Textarea } from '@govrn/protocol-ui';
+import { Input, Textarea } from '@govrn/protocol-ui';
 import { splitEntriesByComma } from '../utils/arrays';
 import { daoTextareaFormValidation } from '../utils/validations';
 import { useOverlay } from '../contexts/OverlayContext';
@@ -45,8 +45,15 @@ const DaoTextareaForm = () => {
   return (
     <Flex direction="column" width="100%" color="gray.800">
       <form onSubmit={handleSubmit(daoTextareaImportHandler)}>
+        <Input
+          name="guildName"
+          label="DAO Name"
+          placeholder="govrn-user"
+          localForm={localForm}
+        />
         <Textarea
           name="daoMemberAddresses"
+          label="DAO Member Addresses"
           tip='Enter a comma-separated list of Ethereum addresses. For example: "0x..., 0x...'
           placeholder="0x..., 0x..."
           onChange={addresses => setValue('daoMemberAddresses', addresses)}

--- a/apps/protocol-frontend/src/components/DaoTextareaForm.tsx
+++ b/apps/protocol-frontend/src/components/DaoTextareaForm.tsx
@@ -53,6 +53,7 @@ const DaoTextareaForm = () => {
         uniqueParsedDaoMemberAddresses.map(address => {
           createDaoUser({
             newDaoUser: {
+              userId: userData?.id, // summoner's userId still needed for the resolver -- it still creates new users with a unique ID
               guildName: values.guildName,
               userAddress: address,
               guildId: data.mutationData.createGuildUserCustom.guild_id,

--- a/apps/protocol-frontend/src/components/DaoTextareaForm.tsx
+++ b/apps/protocol-frontend/src/components/DaoTextareaForm.tsx
@@ -42,16 +42,21 @@ const DaoTextareaForm = () => {
       ];
 
       await createDaoUser({
-        userId: userData?.id,
-        guildName: values.guildName,
-        userAddress: userData?.address,
-        membershipStatus: 'Admin',
+        newDaoUser: {
+          userId: userData?.id,
+          guildName: values.guildName,
+          userAddress: userData?.address,
+          membershipStatus: 'Admin',
+        },
+        creatingNewDao: true,
       }).then(data =>
         uniqueParsedDaoMemberAddresses.map(address => {
           createDaoUser({
-            guildName: values.guildName,
-            userAddress: address,
-            guildId: data.createGuildUserCustom.guild_id,
+            newDaoUser: {
+              guildName: values.guildName,
+              userAddress: address,
+              guildId: data.mutationData.createGuildUserCustom.guild_id,
+            },
           });
           return true;
         }),

--- a/apps/protocol-frontend/src/components/ProfileDaos.tsx
+++ b/apps/protocol-frontend/src/components/ProfileDaos.tsx
@@ -40,9 +40,12 @@ const ProfileDaos = ({ userId, userAddress }: ProfileDaoProps) => {
   const handleDaoJoin = async () => {
     if (!selectedDao || userId === undefined) return;
     const result = await createDaoUser({
-      userId: userId,
-      userAddress: userAddress,
-      guildId: selectedDao?.value,
+      newDaoUser: {
+        userId: userId,
+        userAddress: userAddress,
+        guildId: selectedDao?.value,
+      },
+      creatingNewDao: false,
     });
     if (result) {
       setSelectedDao(null);

--- a/apps/protocol-frontend/src/components/ProfileDaos.tsx
+++ b/apps/protocol-frontend/src/components/ProfileDaos.tsx
@@ -8,9 +8,10 @@ import DaoCard from './DaoCard';
 
 interface ProfileDaoProps {
   userId: number | undefined;
+  userAddress: string | undefined;
 }
 
-const ProfileDaos = ({ userId }: ProfileDaoProps) => {
+const ProfileDaos = ({ userId, userAddress }: ProfileDaoProps) => {
   const [selectedDao, setSelectedDao] = useState<{
     value: number;
     label: string;
@@ -40,6 +41,7 @@ const ProfileDaos = ({ userId }: ProfileDaoProps) => {
     if (!selectedDao || userId === undefined) return;
     const result = await createDaoUser({
       userId: userId,
+      userAddress: userAddress,
       guildId: selectedDao?.value,
     });
     if (result) {

--- a/apps/protocol-frontend/src/components/ProfileForm.tsx
+++ b/apps/protocol-frontend/src/components/ProfileForm.tsx
@@ -116,7 +116,7 @@ const ProfileForm = () => {
         </Flex>
       </form>
       <FeatureFlagWrapper>
-        <ProfileDaos userId={userData?.id} />
+        <ProfileDaos userId={userData?.id} userAddress={userData?.address} />
       </FeatureFlagWrapper>
       <form>
         <Flex

--- a/apps/protocol-frontend/src/contexts/UserContext.tsx
+++ b/apps/protocol-frontend/src/contexts/UserContext.tsx
@@ -227,14 +227,15 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
   useEffect(() => {
     if (userDataByAddress && isAuthenticated) {
       getUser();
+      console.log('firing user effect');
     }
   }, [userDataByAddress, isAuthenticated]);
 
-  // useEffect(() => {
-  //   if (userDataByAddress && isAuthenticated) {
-  //     getUser();
-  //   }
-  // }, [userData?.guild_users, isAuthenticated, userDataByAddress]);
+  useEffect(() => {
+    if (userDataByAddress && isAuthenticated) {
+      getUser();
+    }
+  }, [userData?.guild_users]);
 
   return (
     <UserContext.Provider

--- a/apps/protocol-frontend/src/contexts/UserContext.tsx
+++ b/apps/protocol-frontend/src/contexts/UserContext.tsx
@@ -227,7 +227,6 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
   useEffect(() => {
     if (userDataByAddress && isAuthenticated) {
       getUser();
-      console.log('firing user effect');
     }
   }, [userDataByAddress, isAuthenticated]);
 

--- a/apps/protocol-frontend/src/contexts/UserContext.tsx
+++ b/apps/protocol-frontend/src/contexts/UserContext.tsx
@@ -228,7 +228,13 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
     if (userDataByAddress && isAuthenticated) {
       getUser();
     }
-  }, [userDataByAddress, userData, isAuthenticated]);
+  }, [userDataByAddress, isAuthenticated]);
+
+  // useEffect(() => {
+  //   if (userDataByAddress && isAuthenticated) {
+  //     getUser();
+  //   }
+  // }, [userData?.guild_users, isAuthenticated, userDataByAddress]);
 
   return (
     <UserContext.Provider

--- a/apps/protocol-frontend/src/contexts/UserContext.tsx
+++ b/apps/protocol-frontend/src/contexts/UserContext.tsx
@@ -230,12 +230,6 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
     }
   }, [userDataByAddress, isAuthenticated]);
 
-  useEffect(() => {
-    if (userDataByAddress && isAuthenticated) {
-      getUser();
-    }
-  }, [userData?.guild_users]);
-
   return (
     <UserContext.Provider
       value={{

--- a/apps/protocol-frontend/src/contexts/UserContext.tsx
+++ b/apps/protocol-frontend/src/contexts/UserContext.tsx
@@ -228,14 +228,7 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
     if (userDataByAddress && isAuthenticated) {
       getUser();
     }
-  }, [userDataByAddress, isAuthenticated]);
-
-  useEffect(() => {
-    if (userData) {
-      console.log('change in user data', userData);
-      getUser();
-    }
-  }, [userData]);
+  }, [userDataByAddress, userData, isAuthenticated]);
 
   return (
     <UserContext.Provider

--- a/apps/protocol-frontend/src/contexts/UserContext.tsx
+++ b/apps/protocol-frontend/src/contexts/UserContext.tsx
@@ -230,6 +230,13 @@ export const UserContextProvider: React.FC<UserContextProps> = ({
     }
   }, [userDataByAddress, isAuthenticated]);
 
+  useEffect(() => {
+    if (userData) {
+      console.log('change in user data', userData);
+      getUser();
+    }
+  }, [userData]);
+
   return (
     <UserContext.Provider
       value={{

--- a/apps/protocol-frontend/src/hooks/useDaoUserCreate.ts
+++ b/apps/protocol-frontend/src/hooks/useDaoUserCreate.ts
@@ -22,9 +22,11 @@ export const useDaoUserCreate = () => {
       return mutationData;
     },
     {
-      onSuccess: () => {
+      onSuccess: data => {
         queryClient.invalidateQueries(['userDaos']);
         queryClient.invalidateQueries(['daoUsersList']);
+
+        console.log('data', data);
 
         const toastSuccessId = 'dao-user-create-success';
         if (!toast.isActive(toastSuccessId)) {

--- a/apps/protocol-frontend/src/hooks/useDaoUserCreate.ts
+++ b/apps/protocol-frontend/src/hooks/useDaoUserCreate.ts
@@ -23,16 +23,71 @@ export const useDaoUserCreate = () => {
         queryClient.invalidateQueries(['userDaos']);
         queryClient.invalidateQueries(['daoUsersList']);
 
-        toast.success({
-          title: 'Successfully joined DAO',
-          description: 'You have successfully joined as a recruit.',
-        });
+        const toastSuccessId = 'dao-user-create-success';
+        if (!toast.isActive(toastSuccessId)) {
+          toast.success({
+            id: toastSuccessId,
+            title: 'Successfully joined DAO',
+            description: 'You have successfully joined as a recruit.',
+          });
+        }
       },
       onError: error => {
-        toast.error({
-          title: 'Unable to Join DAO',
-          description: `Something went wrong. Please try again: ${error}`,
-        });
+        const toastErrorId = 'dao-user-create-error';
+        if (!toast.isActive(toastErrorId)) {
+          toast.error({
+            id: toastErrorId,
+            title: 'Unable to Join DAO',
+            description: `Something went wrong. Please try again: ${error}`,
+          });
+        }
+      },
+    },
+  );
+  return { mutateAsync, isLoading, isError, isSuccess };
+};
+
+export const useDaoCreateUserCreate = () => {
+  const toast = useGovrnToast();
+  const { govrnProtocol: govrn } = useUser();
+  const queryClient = useQueryClient();
+
+  const { mutateAsync, isLoading, isError, isSuccess } = useMutation(
+    async (newDaoUser: DaoUserCreateValues) => {
+      const mutationData = await govrn.guild.user.create({
+        data: {
+          userId: newDaoUser.userId,
+          guildId: newDaoUser.guildId,
+          guildName: newDaoUser.guildName,
+          userAddress: newDaoUser.userAddress,
+          membershipStatus: newDaoUser.membershipStatus,
+        },
+      });
+      return mutationData;
+    },
+    {
+      onSuccess: mutationData => {
+        queryClient.invalidateQueries(['userDaos']);
+        queryClient.invalidateQueries(['daoUsersList']);
+
+        const toastSuccessId = 'dao-user-create-success';
+        if (!toast.isActive(toastSuccessId)) {
+          toast.success({
+            id: toastSuccessId,
+            title: 'Successfully created DAO',
+            description: 'You have successfully created the DAO.',
+          });
+        }
+      },
+      onError: error => {
+        const toastErrorId = 'dao-user-create-error';
+        if (!toast.isActive(toastErrorId)) {
+          toast.error({
+            id: toastErrorId,
+            title: 'Unable to Join DAO',
+            description: `Something went wrong. Please try again: ${error}`,
+          });
+        }
       },
     },
   );

--- a/apps/protocol-frontend/src/hooks/useDaoUserCreate.ts
+++ b/apps/protocol-frontend/src/hooks/useDaoUserCreate.ts
@@ -12,9 +12,9 @@ export const useDaoUserCreate = () => {
   const toast = useGovrnToast();
   const { govrnProtocol: govrn } = useUser();
   const queryClient = useQueryClient();
-
   const { mutateAsync, isLoading, isError, isSuccess } = useMutation(
     async ({ newDaoUser, creatingNewDao = false }: DaoUserCreateProps) => {
+      console.log('newDaoUser', newDaoUser);
       const mutationData = await govrn.guild.user.create({
         data: {
           userId: newDaoUser.userId,

--- a/apps/protocol-frontend/src/hooks/useDaoUserCreate.ts
+++ b/apps/protocol-frontend/src/hooks/useDaoUserCreate.ts
@@ -14,6 +14,9 @@ export const useDaoUserCreate = () => {
         data: {
           userId: newDaoUser.userId,
           guildId: newDaoUser.guildId,
+          guildName: newDaoUser.guildName,
+          userAddress: newDaoUser.userAddress,
+          membershipStatus: newDaoUser.membershipStatus,
         },
       });
       return mutationData;

--- a/apps/protocol-frontend/src/hooks/useDaoUserCreate.ts
+++ b/apps/protocol-frontend/src/hooks/useDaoUserCreate.ts
@@ -14,7 +14,6 @@ export const useDaoUserCreate = () => {
   const queryClient = useQueryClient();
   const { mutateAsync, isLoading, isError, isSuccess } = useMutation(
     async ({ newDaoUser, creatingNewDao = false }: DaoUserCreateProps) => {
-      console.log('newDaoUser', newDaoUser);
       const mutationData = await govrn.guild.user.create({
         data: {
           userId: newDaoUser.userId,

--- a/apps/protocol-frontend/src/hooks/useDaoUserCreate.ts
+++ b/apps/protocol-frontend/src/hooks/useDaoUserCreate.ts
@@ -19,13 +19,13 @@ export const useDaoUserCreate = () => {
           membershipStatus: newDaoUser.membershipStatus,
         },
       });
+      console.log('mutationData', mutationData);
       return mutationData;
     },
     {
       onSuccess: data => {
         queryClient.invalidateQueries(['userDaos']);
         queryClient.invalidateQueries(['daoUsersList']);
-
         console.log('data', data);
 
         const toastSuccessId = 'dao-user-create-success';
@@ -34,53 +34,6 @@ export const useDaoUserCreate = () => {
             id: toastSuccessId,
             title: 'Successfully joined DAO',
             description: 'You have successfully joined as a recruit.',
-          });
-        }
-      },
-      onError: error => {
-        const toastErrorId = 'dao-user-create-error';
-        if (!toast.isActive(toastErrorId)) {
-          toast.error({
-            id: toastErrorId,
-            title: 'Unable to Join DAO',
-            description: `Something went wrong. Please try again: ${error}`,
-          });
-        }
-      },
-    },
-  );
-  return { mutateAsync, isLoading, isError, isSuccess };
-};
-
-export const useDaoCreateUserCreate = () => {
-  const toast = useGovrnToast();
-  const { govrnProtocol: govrn } = useUser();
-  const queryClient = useQueryClient();
-
-  const { mutateAsync, isLoading, isError, isSuccess } = useMutation(
-    async (newDaoUser: DaoUserCreateValues) => {
-      const mutationData = await govrn.guild.user.create({
-        data: {
-          userId: newDaoUser.userId,
-          guildId: newDaoUser.guildId,
-          guildName: newDaoUser.guildName,
-          userAddress: newDaoUser.userAddress,
-          membershipStatus: newDaoUser.membershipStatus,
-        },
-      });
-      return mutationData;
-    },
-    {
-      onSuccess: mutationData => {
-        queryClient.invalidateQueries(['userDaos']);
-        queryClient.invalidateQueries(['daoUsersList']);
-
-        const toastSuccessId = 'dao-user-create-success';
-        if (!toast.isActive(toastSuccessId)) {
-          toast.success({
-            id: toastSuccessId,
-            title: 'Successfully created DAO',
-            description: 'You have successfully created the DAO.',
           });
         }
       },

--- a/apps/protocol-frontend/src/types/forms.ts
+++ b/apps/protocol-frontend/src/types/forms.ts
@@ -32,6 +32,7 @@ export type ProfileFormValues = Partial<
 
 export type DaoTextareaFormValues = {
   daoMemberAddresses?: string;
+  guildName?: string;
 };
 
 export type DaoCsvImportFormValues = {
@@ -39,6 +40,9 @@ export type DaoCsvImportFormValues = {
 };
 
 export type DaoUserCreateValues = {
-  userId: number;
-  guildId: number;
+  userId?: number;
+  guildId?: number;
+  guildName?: string;
+  userAddress?: string;
+  membershipStatus?: string;
 };

--- a/apps/protocol-frontend/src/utils/validations.ts
+++ b/apps/protocol-frontend/src/utils/validations.ts
@@ -17,6 +17,7 @@ yup.addMethod(yup.string, 'ethAddress', function format(formats, parseStrict) {
 });
 
 export const daoTextareaFormValidation = yup.object({
+  guildName: yup.string().required('This field is required.'),
   daoMemberAddresses: yup
     .string()
     .min(1, 'Need to include at least one address.')

--- a/libs/protocol-client/src/lib/graphql/queries.graphql
+++ b/libs/protocol-client/src/lib/graphql/queries.graphql
@@ -229,6 +229,7 @@ fragment GuildUserFragment on GuildUser {
 mutation createGuildUserCustom($data: GuildUserCreateCustomInput!) {
   createGuildUserCustom(data: $data) {
     id
+    guild_id
   }
 }
 

--- a/libs/protocol-client/src/lib/protocol-types.ts
+++ b/libs/protocol-client/src/lib/protocol-types.ts
@@ -7094,7 +7094,7 @@ export type GuildUserCountOrderByAggregateInput = {
 };
 
 export type GuildUserCreateCustomInput = {
-  guildId: Scalars['Int'];
+  guildId?: InputMaybe<Scalars['Int']>;
   membershipStatus?: InputMaybe<Scalars['String']>;
   userAddress?: InputMaybe<Scalars['String']>;
   userId?: InputMaybe<Scalars['Int']>;

--- a/libs/protocol-client/src/lib/protocol-types.ts
+++ b/libs/protocol-client/src/lib/protocol-types.ts
@@ -7095,7 +7095,9 @@ export type GuildUserCountOrderByAggregateInput = {
 
 export type GuildUserCreateCustomInput = {
   guildId: Scalars['Int'];
-  userId: Scalars['Int'];
+  membershipStatus?: InputMaybe<Scalars['String']>;
+  userAddress?: InputMaybe<Scalars['String']>;
+  userId?: InputMaybe<Scalars['Int']>;
 };
 
 export type GuildUserCreateInput = {

--- a/libs/protocol-client/src/lib/protocol-types.ts
+++ b/libs/protocol-client/src/lib/protocol-types.ts
@@ -11109,7 +11109,7 @@ export type Mutation = {
 
 
 export type MutationCreateGuildUserCustomArgs = {
-  data?: InputMaybe<GuildUserCreateCustomInput>;
+  data: GuildUserCreateCustomInput;
 };
 
 

--- a/libs/protocol-client/src/lib/protocol-types.ts
+++ b/libs/protocol-client/src/lib/protocol-types.ts
@@ -7095,7 +7095,7 @@ export type GuildUserCountOrderByAggregateInput = {
 
 export type GuildUserCreateCustomInput = {
   guildId?: InputMaybe<Scalars['Int']>;
-  guildName?: InputMaybe<Scalars['Int']>;
+  guildName?: InputMaybe<Scalars['String']>;
   membershipStatus?: InputMaybe<Scalars['String']>;
   userAddress?: InputMaybe<Scalars['String']>;
   userId?: InputMaybe<Scalars['Int']>;

--- a/libs/protocol-client/src/lib/protocol-types.ts
+++ b/libs/protocol-client/src/lib/protocol-types.ts
@@ -7095,6 +7095,7 @@ export type GuildUserCountOrderByAggregateInput = {
 
 export type GuildUserCreateCustomInput = {
   guildId?: InputMaybe<Scalars['Int']>;
+  guildName?: InputMaybe<Scalars['Int']>;
   membershipStatus?: InputMaybe<Scalars['String']>;
   userAddress?: InputMaybe<Scalars['String']>;
   userId?: InputMaybe<Scalars['Int']>;

--- a/libs/protocol-client/src/lib/protocol-types.ts
+++ b/libs/protocol-client/src/lib/protocol-types.ts
@@ -11109,7 +11109,7 @@ export type Mutation = {
 
 
 export type MutationCreateGuildUserCustomArgs = {
-  data: GuildUserCreateCustomInput;
+  data?: InputMaybe<GuildUserCreateCustomInput>;
 };
 
 
@@ -18212,7 +18212,7 @@ export type CreateGuildUserCustomMutationVariables = Exact<{
 }>;
 
 
-export type CreateGuildUserCustomMutation = { createGuildUserCustom: { id: number } };
+export type CreateGuildUserCustomMutation = { createGuildUserCustom: { id: number, guild_id: number } };
 
 export type DeleteGuildUserMutationVariables = Exact<{
   where: GuildUserWhereUniqueInput;
@@ -19075,6 +19075,7 @@ export const CreateGuildUserCustomDocument = gql`
     mutation createGuildUserCustom($data: GuildUserCreateCustomInput!) {
   createGuildUserCustom(data: $data) {
     id
+    guild_id
   }
 }
     `;


### PR DESCRIPTION
## Linear Ticket

- [ENG-843](https://linear.app/govrn/issue/ENG-843/manual-dao-create-functionality)
- [ENG-866](https://linear.app/govrn/issue/ENG-866/add-name-to-the-create-a-dao-manual-text-input-modal)

## Description

- Updates our guild user create resolver to allow for creating DAOs in addition to setting status
- When a user joins the DAO via the Create Manual DAO and enters comma separated list of addresses the DAO is created and then each person is added as a recruit. The Summoner is set as an admin (these will be updatable in the Settings page)

## Screencaptures

https://user-images.githubusercontent.com/9438776/215204315-d50b9cef-b129-4f6c-88ab-cc8535a14139.mp4

