### PR TITLE
qa/remove-profile-daos-limit (ENG-886)

### DIFF
--- a/apps/protocol-frontend/src/components/ProfileDaos.tsx
+++ b/apps/protocol-frontend/src/components/ProfileDaos.tsx
@@ -4,10 +4,7 @@ import { Button, Flex, Heading, Divider, Grid } from '@chakra-ui/react';
 import { ControlledSelect, GovrnSpinner } from '@govrn/protocol-ui';
 import { useDaoUserCreate } from '../hooks/useDaoUserCreate';
 import { useDaosList } from '../hooks/useDaosList';
-import {
-  useDaoUsersList,
-  useDaoUsersInfiniteList,
-} from '../hooks/useDaoUsersList';
+import { useDaoUsersInfiniteList } from '../hooks/useDaoUsersList';
 import DaoCard from './DaoCard';
 import { SortOrder } from '@govrn/protocol-client';
 import { mergeMemberPages } from '../utils/arrays';
@@ -23,17 +20,11 @@ const ProfileDaos = ({ userId, userAddress }: ProfileDaoProps) => {
     value: number;
     label: string;
   } | null>(null);
-  // data fetching within this component so the loading states dont block the entire profile's render -- we can show a spinner for this part of the UI only similar to how we handle the fetches on the DaoDashboard page
-  const { isLoading: daosListLoading, data: joinableDaosListData } =
+
+  const { isLoading: joinableDaosListLoading, data: joinableDaosListData } =
     useDaosList({
       where: { users: { none: { user_id: { equals: userId || 0 } } } },
     });
-
-  // const { isLoading: daoUsersListLoading, data: daosUsersListData } =
-  //   useDaoUsersList({
-  //     where: { user_id: { equals: userId } },
-  //     orderBy: [{ membershipStatus: { name: 'asc' } }, { favorite: 'desc' }],
-  //   });
 
   const {
     data: daoUsersData,
@@ -48,7 +39,7 @@ const ProfileDaos = ({ userId, userAddress }: ProfileDaoProps) => {
         { favorite: SortOrder.Desc },
       ],
     },
-    4,
+    8, // page size
   );
 
   const daoListOptions =
@@ -81,8 +72,7 @@ const ProfileDaos = ({ userId, userAddress }: ProfileDaoProps) => {
     );
   }, [daoUsersData]);
 
-  // if (daosListLoading || daoUsersListLoading) return <GovrnSpinner />;
-  // if (daosListLoading || daoUsersListLoading) return <GovrnSpinner />;
+  if (joinableDaosListLoading) return <GovrnSpinner />;
 
   return (
     <Flex

--- a/apps/protocol-frontend/src/components/ProfileDaos.tsx
+++ b/apps/protocol-frontend/src/components/ProfileDaos.tsx
@@ -40,13 +40,16 @@ const ProfileDaos = ({ userId, userAddress }: ProfileDaoProps) => {
     hasNextPage,
     fetchNextPage,
     isFetchingNextPage,
-  } = useDaoUsersInfiniteList({
-    where: { user_id: { equals: userId } },
-    orderBy: [
-      { membershipStatus: { name: SortOrder.Asc } },
-      { favorite: SortOrder.Desc },
-    ],
-  });
+  } = useDaoUsersInfiniteList(
+    {
+      where: { user_id: { equals: userId } },
+      orderBy: [
+        { membershipStatus: { name: SortOrder.Asc } },
+        { favorite: SortOrder.Desc },
+      ],
+    },
+    4,
+  );
 
   const daoListOptions =
     joinableDaosListData?.map(dao => ({
@@ -141,18 +144,22 @@ const ProfileDaos = ({ userId, userAddress }: ProfileDaoProps) => {
             {data?.map(daoUser => (
               <DaoCard userId={userId} daoUser={daoUser} key={daoUser.id} />
             ))}
-            <Button
-              variant="secondary"
-              onClick={() => fetchNextPage()}
-              disabled={!hasNextPage || isFetchingNextPage}
-            >
-              {isFetchingNextPage
-                ? 'Loading more...'
-                : hasNextPage
-                ? 'Load More'
-                : 'Nothing more to load'}
-            </Button>
           </Grid>
+          {hasNextPage && (
+            <Flex direction="column" alignItems="flex-start">
+              <Button
+                variant="secondary"
+                onClick={() => fetchNextPage()}
+                disabled={!hasNextPage || isFetchingNextPage}
+              >
+                {isFetchingNextPage
+                  ? 'Loading more...'
+                  : hasNextPage
+                  ? 'Load More'
+                  : 'Nothing more to load'}
+              </Button>
+            </Flex>
+          )}
         </Flex>
       </Flex>
     </Flex>

--- a/apps/protocol-frontend/src/components/Sidebar.tsx
+++ b/apps/protocol-frontend/src/components/Sidebar.tsx
@@ -28,6 +28,7 @@ import { FaDiscord } from 'react-icons/fa';
 import { useAccount } from 'wagmi';
 import { useUser } from '../contexts/UserContext';
 import { useAuth } from '../contexts/AuthContext';
+import { useDaoUsersList } from '../hooks/useDaoUsersList';
 import ConnectWallet from './ConnectWallet';
 import Logo from './Logo';
 import NavButton from './NavButton';
@@ -37,6 +38,11 @@ const Sidebar = () => {
   const { userData } = useUser();
   const { isConnected } = useAccount();
   const { isAuthenticated } = useAuth();
+
+  const { data: daosUsersListData } = useDaoUsersList({
+    where: { user_id: { equals: userData?.id } },
+    orderBy: [{ membershipStatus: { name: 'asc' } }, { favorite: 'desc' }],
+  });
 
   return (
     <Flex
@@ -110,7 +116,8 @@ const Sidebar = () => {
             </Link>
             {isConnected && isAuthenticated && (
               <Stack>
-                {userData?.guild_users && userData?.guild_users.length > 0 ? (
+                {daosUsersListData !== undefined &&
+                daosUsersListData.length > 0 ? (
                   <Accordion allowToggle width="100%">
                     <AccordionItem border="none">
                       <AccordionButton
@@ -138,7 +145,7 @@ const Sidebar = () => {
                       </AccordionButton>
                       <AccordionPanel paddingTop={0}>
                         <Flex direction="column">
-                          {userData?.guild_users.map(dao => (
+                          {daosUsersListData.map(dao => (
                             <Stack paddingLeft={8} paddingY={1} key={dao.id}>
                               <Link to={`/dao/${dao.guild.id}`}>
                                 <Text

--- a/apps/protocol-frontend/src/hooks/useDaoUsersList.ts
+++ b/apps/protocol-frontend/src/hooks/useDaoUsersList.ts
@@ -17,7 +17,7 @@ export const useDaoUsersList = ({ ...args }) => {
 
 export const useDaoUsersInfiniteList = (
   args?: ListGuildUsersQueryVariables,
-  pageSize = 4,
+  pageSize = 20,
 ) => {
   const { govrnProtocol: govrn } = useUser();
   const {

--- a/apps/protocol-frontend/src/hooks/useDaoUsersList.ts
+++ b/apps/protocol-frontend/src/hooks/useDaoUsersList.ts
@@ -17,7 +17,7 @@ export const useDaoUsersList = ({ ...args }) => {
 
 export const useDaoUsersInfiniteList = (
   args?: ListGuildUsersQueryVariables,
-  pageSize = 20,
+  pageSize = 4,
 ) => {
   const { govrnProtocol: govrn } = useUser();
   const {


### PR DESCRIPTION
## Linear Ticket

- [ENG-886](https://linear.app/govrn/issue/ENG-886/remove-limit-on-daos-displaying-in-profile-but-keep-limit-for-sidebar)

## Description

- Adds in a 'Load More' to the Profile DAOs DAO Card grid with an initial load of 8 (2 rows of 4)
- Load More loads DAOs until the user has no more to display
- Sidebar now has the same sort order as the profile (admin -> member w/ favorite -> member w/o favorite -> recruit w/ favorite -> recruit w/o favorite) and a cap of 10

## Screencaptures

https://user-images.githubusercontent.com/9438776/216516555-f034d90e-faf8-466d-99c7-8890bceb29db.mp4


