### PR TITLE
feature/improve-member-table-address-ux (ENG-917)

### DIFF
--- a/apps/protocol-frontend/src/components/DaoSettingsMembersTable.tsx
+++ b/apps/protocol-frontend/src/components/DaoSettingsMembersTable.tsx
@@ -28,6 +28,7 @@ import { useDaoUsersInfiniteList } from '../hooks/useDaoUsersList';
 import { RowSelectionState } from '@tanstack/table-core';
 import { SortOrder } from '@govrn/protocol-client';
 import GovrnTable from './GovrnTable';
+import { displayAddress } from '../utils/web3';
 
 interface DaoSettingsMembersTableProps {
   daoId: number;
@@ -111,6 +112,7 @@ const DaoSettingsMembersTable = ({ daoId }: DaoSettingsMembersTableProps) => {
         accessorKey: 'user',
         cell: ({ getValue }: { getValue: Getter<UIGuildUsers['user']> }) => {
           const value = getValue();
+          const displayMemberName = value.name || displayAddress(value.address);
           return value.address === userData?.address ? (
             <Tooltip
               variant="primary"
@@ -124,17 +126,21 @@ const DaoSettingsMembersTable = ({ daoId }: DaoSettingsMembersTableProps) => {
                 bgGradient="linear(to-l, #7928CA, #FF0080)"
                 bgClip="text"
               >
-                {value.address}
+                {displayAddress(value.address)}
               </Text>
             </Tooltip>
           ) : (
             <Tooltip
               variant="primary"
-              label={value.name}
+              label={value.address}
               fontSize="sm"
               placement="right"
             >
-              <Text whiteSpace="normal">{value.address}</Text>
+              <Text whiteSpace="normal">
+                {value.name === null || value.name === undefined
+                  ? displayAddress(value.address)
+                  : value.name}
+              </Text>
             </Tooltip>
           );
         },

--- a/apps/protocol-frontend/src/components/DaoSettingsMembersTable.tsx
+++ b/apps/protocol-frontend/src/components/DaoSettingsMembersTable.tsx
@@ -112,58 +112,31 @@ const DaoSettingsMembersTable = ({ daoId }: DaoSettingsMembersTableProps) => {
         accessorKey: 'user',
         cell: ({ getValue }: { getValue: Getter<UIGuildUsers['user']> }) => {
           const value = getValue();
-          const displayMemberName = value.name || displayAddress(value.address);
+          const displayMemberName =
+            value.name || value.display_name || displayAddress(value.address);
           return value.address === userData?.address ? (
+            <Text
+              whiteSpace="normal"
+              fontWeight="bold"
+              bgGradient="linear(to-l, #7928CA, #FF0080)"
+              bgClip="text"
+            >
+              {displayMemberName}
+            </Text>
+          ) : value.name || value.display_name ? (
             <Tooltip
               variant="primary"
-              label={value.name}
+              label={displayAddress(value.address)}
               fontSize="sm"
               placement="right"
             >
-              <Text
-                whiteSpace="normal"
-                fontWeight="bold"
-                bgGradient="linear(to-l, #7928CA, #FF0080)"
-                bgClip="text"
-              >
-                {displayAddress(value.address)}
-              </Text>
+              <Text whiteSpace="normal">{displayMemberName}</Text>
             </Tooltip>
           ) : (
-            <Tooltip
-              variant="primary"
-              label={value.address}
-              fontSize="sm"
-              placement="right"
-            >
-              <Text whiteSpace="normal">
-                {value.name === null || value.name === undefined
-                  ? displayAddress(value.address)
-                  : value.name}
-              </Text>
-            </Tooltip>
+            <Text whiteSpace="normal">{displayMemberName}</Text>
           );
         },
       },
-      // {
-      //   header: 'Member Name',
-      //   accessorKey: 'user',
-      //   cell: ({ getValue }: { getValue: Getter<UIGuildUsers['user']> }) => {
-      //     const value = getValue();
-      //     return value.name === userData?.name ? (
-      //       <Text
-      //         whiteSpace="normal"
-      //         fontWeight="bold"
-      //         bgGradient="linear(to-l, #7928CA, #FF0080)"
-      //         bgClip="text"
-      //       >
-      //         {value.name}
-      //       </Text>
-      //     ) : (
-      //       <Text whiteSpace="normal">{value.name}</Text>
-      //     );
-      //   },
-      // },
       {
         header: 'Role',
         accessorKey: 'membershipStatus',

--- a/apps/protocol-frontend/src/components/DaoSettingsMembersTable.tsx
+++ b/apps/protocol-frontend/src/components/DaoSettingsMembersTable.tsx
@@ -1,5 +1,13 @@
 import { useMemo, useState, useEffect } from 'react';
-import { Badge, Button, Box, Flex, Stack, Text } from '@chakra-ui/react';
+import {
+  Badge,
+  Button,
+  Box,
+  Flex,
+  Stack,
+  Text,
+  Tooltip,
+} from '@chakra-ui/react';
 import {
   ColumnDef,
   getCoreRowModel,
@@ -47,6 +55,8 @@ const DaoSettingsMembersTable = ({ daoId }: DaoSettingsMembersTableProps) => {
       daoUsersData && daoUsersData.pages.length > 0 ? daoUsersData.pages : [],
     );
   }, [daoUsersData]);
+
+  console.log('data', data);
 
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const [selectedRows, setSelectedRows] = useState<UIGuildUsers[]>([]);
@@ -97,24 +107,57 @@ const DaoSettingsMembersTable = ({ daoId }: DaoSettingsMembersTableProps) => {
         ),
       },
       {
-        header: 'Member Address',
+        header: 'Member',
         accessorKey: 'user',
         cell: ({ getValue }: { getValue: Getter<UIGuildUsers['user']> }) => {
           const value = getValue();
           return value.address === userData?.address ? (
-            <Text
-              whiteSpace="normal"
-              fontWeight="bold"
-              bgGradient="linear(to-l, #7928CA, #FF0080)"
-              bgClip="text"
+            <Tooltip
+              variant="primary"
+              label={value.name}
+              fontSize="sm"
+              placement="right"
             >
-              {value.address}
-            </Text>
+              <Text
+                whiteSpace="normal"
+                fontWeight="bold"
+                bgGradient="linear(to-l, #7928CA, #FF0080)"
+                bgClip="text"
+              >
+                {value.address}
+              </Text>
+            </Tooltip>
           ) : (
-            <Text whiteSpace="normal">{value.address}</Text>
+            <Tooltip
+              variant="primary"
+              label={value.name}
+              fontSize="sm"
+              placement="right"
+            >
+              <Text whiteSpace="normal">{value.address}</Text>
+            </Tooltip>
           );
         },
       },
+      // {
+      //   header: 'Member Name',
+      //   accessorKey: 'user',
+      //   cell: ({ getValue }: { getValue: Getter<UIGuildUsers['user']> }) => {
+      //     const value = getValue();
+      //     return value.name === userData?.name ? (
+      //       <Text
+      //         whiteSpace="normal"
+      //         fontWeight="bold"
+      //         bgGradient="linear(to-l, #7928CA, #FF0080)"
+      //         bgClip="text"
+      //       >
+      //         {value.name}
+      //       </Text>
+      //     ) : (
+      //       <Text whiteSpace="normal">{value.name}</Text>
+      //     );
+      //   },
+      // },
       {
         header: 'Role',
         accessorKey: 'membershipStatus',

--- a/apps/protocol-frontend/src/components/DaoSettingsMembersTable.tsx
+++ b/apps/protocol-frontend/src/components/DaoSettingsMembersTable.tsx
@@ -57,8 +57,6 @@ const DaoSettingsMembersTable = ({ daoId }: DaoSettingsMembersTableProps) => {
     );
   }, [daoUsersData]);
 
-  console.log('data', data);
-
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const [selectedRows, setSelectedRows] = useState<UIGuildUsers[]>([]);
   const [sorting, setSorting] = useState<SortingState>([]);
@@ -112,6 +110,7 @@ const DaoSettingsMembersTable = ({ daoId }: DaoSettingsMembersTableProps) => {
         accessorKey: 'user',
         cell: ({ getValue }: { getValue: Getter<UIGuildUsers['user']> }) => {
           const value = getValue();
+          const hasMemberName = value.name || value.display_name;
           const displayMemberName =
             value.name || value.display_name || displayAddress(value.address);
           return value.address === userData?.address ? (
@@ -123,10 +122,10 @@ const DaoSettingsMembersTable = ({ daoId }: DaoSettingsMembersTableProps) => {
             >
               {displayMemberName}
             </Text>
-          ) : value.name || value.display_name ? (
+          ) : hasMemberName ? (
             <Tooltip
               variant="primary"
-              label={displayAddress(value.address)}
+              label={value.address}
               fontSize="sm"
               placement="right"
             >

--- a/apps/protocol-frontend/src/utils/web3.ts
+++ b/apps/protocol-frontend/src/utils/web3.ts
@@ -48,4 +48,4 @@ export const wagmiClient = createClient({
 });
 
 export const displayAddress = (address: string | undefined | null) =>
-  address ? `${address.slice(0, 5)}...${address.slice(-4)}` : '0x';
+  address ? `${address.slice(0, 5)}...${address.slice(-5)}` : '0x';

--- a/libs/protocol-client/src/lib/graphql/queries.graphql
+++ b/libs/protocol-client/src/lib/graphql/queries.graphql
@@ -216,6 +216,7 @@ fragment GuildUserFragment on GuildUser {
   user_id
   user {
     name
+    display_name
     address
   }
   guild {

--- a/libs/protocol-client/src/lib/protocol-types.ts
+++ b/libs/protocol-client/src/lib/protocol-types.ts
@@ -18209,7 +18209,7 @@ export type GetActiveGuildUsersAverageQueryVariables = Exact<{
 
 export type GetActiveGuildUsersAverageQuery = { result: number };
 
-export type GuildUserFragmentFragment = { id: number, createdAt: string | Date, updatedAt: string | Date, favorite: boolean, user_id: number, user: { name?: string | null, address: string }, guild: { id: number, name?: string | null }, membershipStatus?: { id: number, createdAt: string | Date, updatedAt: string | Date, name: string } | null };
+export type GuildUserFragmentFragment = { id: number, createdAt: string | Date, updatedAt: string | Date, favorite: boolean, user_id: number, user: { name?: string | null, display_name?: string | null, address: string }, guild: { id: number, name?: string | null }, membershipStatus?: { id: number, createdAt: string | Date, updatedAt: string | Date, name: string } | null };
 
 export type CreateGuildUserCustomMutationVariables = Exact<{
   data: GuildUserCreateCustomInput;
@@ -18233,14 +18233,14 @@ export type ListGuildUsersQueryVariables = Exact<{
 }>;
 
 
-export type ListGuildUsersQuery = { result: Array<{ id: number, createdAt: string | Date, updatedAt: string | Date, favorite: boolean, user_id: number, user: { name?: string | null, address: string }, guild: { id: number, name?: string | null }, membershipStatus?: { id: number, createdAt: string | Date, updatedAt: string | Date, name: string } | null }> };
+export type ListGuildUsersQuery = { result: Array<{ id: number, createdAt: string | Date, updatedAt: string | Date, favorite: boolean, user_id: number, user: { name?: string | null, display_name?: string | null, address: string }, guild: { id: number, name?: string | null }, membershipStatus?: { id: number, createdAt: string | Date, updatedAt: string | Date, name: string } | null }> };
 
 export type UpdateGuildUserCustomMutationVariables = Exact<{
   data: GuildUserUpdateCustomInput;
 }>;
 
 
-export type UpdateGuildUserCustomMutation = { updateGuildUserCustom: { id: number, createdAt: string | Date, updatedAt: string | Date, favorite: boolean, user_id: number, user: { name?: string | null, address: string }, guild: { id: number, name?: string | null }, membershipStatus?: { id: number, createdAt: string | Date, updatedAt: string | Date, name: string } | null } };
+export type UpdateGuildUserCustomMutation = { updateGuildUserCustom: { id: number, createdAt: string | Date, updatedAt: string | Date, favorite: boolean, user_id: number, user: { name?: string | null, display_name?: string | null, address: string }, guild: { id: number, name?: string | null }, membershipStatus?: { id: number, createdAt: string | Date, updatedAt: string | Date, name: string } | null } };
 
 export type GuildImportFragmentFragment = { id: number, createdAt: string | Date, updatedAt: string | Date, guild_id: number, integration_type_id: number, authentication_token: string, guild: { id: number, name?: string | null }, integration_type: { id: number, name: string }, import_status: { id: number, createdAt: string | Date, updatedAt: string | Date, name: string }, users: Array<{ user_id: number }> };
 
@@ -18675,6 +18675,7 @@ export const GuildUserFragmentFragmentDoc = gql`
   user_id
   user {
     name
+    display_name
     address
   }
   guild {


### PR DESCRIPTION
## Linear Ticket

https://linear.app/govrn/issue/ENG-917/improve-member-table-address-ux

## Description

This is the _option 2_ from our discussion. We can adjust the logic for this further if we'd like, but here's how it displays:

- Uses `name` or `display_name` if they exist (added `display_name` to our GuildUser fragment)
- If they don't exist, use the `address`
- If showing the name or display name, show the address on tooltip
- Only show the address tooltip if _not_ the connected user (figure they'd know their own address, but open to feedback there)
- I also made it so that we only show the tooltip on addresses that aren't the connected user. I don't necessarily think they'd need to see a tooltip for their own address.

Additionally, only showing the tooltip if the user's address isn't showing (so if we're showing the name/display name, then the address shows on hover)

## Screencaptures

https://user-images.githubusercontent.com/9438776/217836658-a1253f03-ae69-4e60-a44e-b09c8ef1a8e3.mp4

