### PR TITLE
qa/batch-fixes

### DIFF
--- a/apps/protocol-frontend/src/components/AttestationsTable.tsx
+++ b/apps/protocol-frontend/src/components/AttestationsTable.tsx
@@ -84,10 +84,12 @@ const AttestationsTable = ({
           row: Row<UIContribution>;
         }) => {
           return (
-            <Flex direction="column" wrap="wrap">
+            <Flex direction="column" wrap="wrap" paddingRight={1}>
               <Link to={`/contributions/${row.original.id}`}>
                 <Text
                   whiteSpace="normal"
+                  flex="1 0 0"
+                  maxW="300px"
                   bgGradient="linear-gradient(100deg, #1a202c 0%, #1a202c 100%)"
                   bgClip="text"
                   transition="all 100ms ease-in-out"

--- a/apps/protocol-frontend/src/components/AttestationsTable.tsx
+++ b/apps/protocol-frontend/src/components/AttestationsTable.tsx
@@ -86,7 +86,19 @@ const AttestationsTable = ({
           return (
             <Flex direction="column" wrap="wrap">
               <Link to={`/contributions/${row.original.id}`}>
-                <Text whiteSpace="normal">{getValue()}</Text>
+                <Text
+                  whiteSpace="normal"
+                  bgGradient="linear-gradient(100deg, #1a202c 0%, #1a202c 100%)"
+                  bgClip="text"
+                  transition="all 100ms ease-in-out"
+                  _hover={{
+                    fontWeight: 'bolder',
+                    bgGradient: 'linear(to-l, #7928CA, #FF0080)',
+                  }}
+                >
+                  {' '}
+                  {getValue()}
+                </Text>
               </Link>
             </Flex>
           );

--- a/apps/protocol-frontend/src/components/ContributionsTable.tsx
+++ b/apps/protocol-frontend/src/components/ContributionsTable.tsx
@@ -38,7 +38,6 @@ import { GovrnSpinner } from '@govrn/protocol-ui';
 import InfiniteScroll from 'react-infinite-scroll-component';
 import { formatDate, toDate } from '../utils/date';
 import { RowSelectionState } from '@tanstack/table-core';
-import { statusEmojiSelect } from '../utils/statusEmojiSelect';
 import GovrnTable from './GovrnTable';
 
 export type DialogProps = {
@@ -140,6 +139,7 @@ const ContributionsTable = ({
                   whiteSpace="normal"
                   bgGradient="linear-gradient(100deg, #1a202c 0%, #1a202c 100%)"
                   bgClip="text"
+                  maxW="300px"
                   transition="all 100ms ease-in-out"
                   _hover={{
                     fontWeight: 'bolder',
@@ -150,23 +150,6 @@ const ContributionsTable = ({
                 </Text>
               </Link>
             </Flex>
-          );
-        },
-      },
-      {
-        header: 'Status',
-        accessorFn: contribution => contribution.status.name,
-        cell: ({ getValue }: { getValue: Getter<string> }) => {
-          return (
-            <Text textTransform="capitalize">
-              {getValue()}{' '}
-              <span
-                role="img"
-                aria-labelledby="Emoji indicating Contribution status: Eyes emoji for staging and Three O’Clock emoji for Pending"
-              >
-                {statusEmojiSelect(getValue())}
-              </span>{' '}
-            </Text>
           );
         },
       },

--- a/apps/protocol-frontend/src/components/ContributionsTable.tsx
+++ b/apps/protocol-frontend/src/components/ContributionsTable.tsx
@@ -4,13 +4,12 @@ import {
   Flex,
   Link as ChakraLink,
   HStack,
-  Icon,
   IconButton,
   Stack,
   Text,
   Tooltip,
 } from '@chakra-ui/react';
-import { HiOutlineLink, HiOutlineEye } from 'react-icons/hi';
+import { HiOutlineLink } from 'react-icons/hi';
 import { useUser } from '../contexts/UserContext';
 import {
   ColumnDef,

--- a/apps/protocol-frontend/src/components/ContributionsTable.tsx
+++ b/apps/protocol-frontend/src/components/ContributionsTable.tsx
@@ -139,11 +139,12 @@ const ContributionsTable = ({
                   whiteSpace="normal"
                   bgGradient="linear-gradient(100deg, #1a202c 0%, #1a202c 100%)"
                   bgClip="text"
-                  maxW="300px"
+                  flex="1 0 0"
                   transition="all 100ms ease-in-out"
                   _hover={{
                     fontWeight: 'bolder',
                     bgGradient: 'linear(to-l, #7928CA, #FF0080)',
+                    textShadow: '10px 10px 11px #fff',
                   }}
                 >
                   {getValue()}

--- a/apps/protocol-frontend/src/components/ContributionsTable.tsx
+++ b/apps/protocol-frontend/src/components/ContributionsTable.tsx
@@ -134,7 +134,7 @@ const ContributionsTable = ({
           getValue: Getter<string>;
         }) => {
           return (
-            <Flex direction="column" wrap="wrap">
+            <Flex direction="column" wrap="wrap" paddingRight={1}>
               <Link to={`/contributions/${row.original.id}`}>
                 <Text
                   whiteSpace="normal"
@@ -146,7 +146,6 @@ const ContributionsTable = ({
                     bgGradient: 'linear(to-l, #7928CA, #FF0080)',
                   }}
                 >
-                  {' '}
                   {getValue()}
                 </Text>
               </Link>

--- a/apps/protocol-frontend/src/components/ContributionsTable.tsx
+++ b/apps/protocol-frontend/src/components/ContributionsTable.tsx
@@ -4,12 +4,13 @@ import {
   Flex,
   Link as ChakraLink,
   HStack,
+  Icon,
   IconButton,
   Stack,
   Text,
   Tooltip,
 } from '@chakra-ui/react';
-import { HiOutlineLink } from 'react-icons/hi';
+import { HiOutlineLink, HiOutlineEye } from 'react-icons/hi';
 import { useUser } from '../contexts/UserContext';
 import {
   ColumnDef,
@@ -135,7 +136,19 @@ const ContributionsTable = ({
           return (
             <Flex direction="column" wrap="wrap">
               <Link to={`/contributions/${row.original.id}`}>
-                <Text whiteSpace="normal">{getValue()}</Text>
+                <Text
+                  whiteSpace="normal"
+                  bgGradient="linear-gradient(100deg, #1a202c 0%, #1a202c 100%)"
+                  bgClip="text"
+                  transition="all 100ms ease-in-out"
+                  _hover={{
+                    fontWeight: 'bolder',
+                    bgGradient: 'linear(to-l, #7928CA, #FF0080)',
+                  }}
+                >
+                  {' '}
+                  {getValue()}
+                </Text>
               </Link>
             </Flex>
           );

--- a/apps/protocol-frontend/src/components/GovrnTable.tsx
+++ b/apps/protocol-frontend/src/components/GovrnTable.tsx
@@ -1,5 +1,6 @@
 import {
   Box,
+  Flex,
   chakra,
   Table as ChakraTable,
   TableProps,
@@ -27,7 +28,10 @@ const GovrnTable = <T extends RowData>(props: GovrnTableProps<T>) => {
             {headerGroup.headers.map(header => (
               <Th key={header.id} borderColor="gray.100">
                 {header.isPlaceholder ? null : (
-                  <Box
+                  <Flex
+                    direction="row"
+                    alignItems="center"
+                    justifyContent="space-between"
                     {...{
                       onClick: header.column.getToggleSortingHandler(),
                       cursor: 'pointer',
@@ -38,13 +42,13 @@ const GovrnTable = <T extends RowData>(props: GovrnTableProps<T>) => {
                       header.getContext(),
                     )}
 
-                    <chakra.span paddingLeft="4">
+                    <chakra.span marginLeft="4">
                       {{
                         asc: <IoArrowUp aria-label="sorted-ascending" />,
                         desc: <IoArrowDown aria-label="sorted-descending" />,
                       }[header.column.getIsSorted() as string] ?? null}
                     </chakra.span>
-                  </Box>
+                  </Flex>
                 )}
               </Th>
             ))}

--- a/apps/protocol-frontend/src/components/GovrnTable.tsx
+++ b/apps/protocol-frontend/src/components/GovrnTable.tsx
@@ -1,5 +1,4 @@
 import {
-  Box,
   Flex,
   chakra,
   Table as ChakraTable,

--- a/apps/protocol-frontend/src/components/GovrnTable.tsx
+++ b/apps/protocol-frontend/src/components/GovrnTable.tsx
@@ -30,8 +30,10 @@ const GovrnTable = <T extends RowData>(props: GovrnTableProps<T>) => {
                 {header.isPlaceholder ? null : (
                   <Flex
                     direction="row"
-                    alignItems="center"
+                    alignItems="stretch"
                     justifyContent="space-between"
+                    paddingRight={header.column.getIsSorted() ? '1' : '4'}
+                    flex="1"
                     {...{
                       onClick: header.column.getToggleSortingHandler(),
                       cursor: 'pointer',
@@ -42,7 +44,7 @@ const GovrnTable = <T extends RowData>(props: GovrnTableProps<T>) => {
                       header.getContext(),
                     )}
 
-                    <chakra.span marginLeft="4">
+                    <chakra.span paddingLeft="4" flex="1 1 auto">
                       {{
                         asc: <IoArrowUp aria-label="sorted-ascending" />,
                         desc: <IoArrowDown aria-label="sorted-descending" />,

--- a/apps/protocol-frontend/src/components/MintedContributionsTable.tsx
+++ b/apps/protocol-frontend/src/components/MintedContributionsTable.tsx
@@ -74,12 +74,14 @@ const MintedContributionsTable = ({
           getValue: Getter<string>;
         }) => {
           return (
-            <Flex direction="column" wrap="wrap">
+            <Flex direction="column" wrap="wrap" paddingRight={1}>
               <Link to={`/contributions/${row.original.id}`}>
                 <Text
                   whiteSpace="normal"
                   bgGradient="linear-gradient(100deg, #1a202c 0%, #1a202c 100%)"
                   bgClip="text"
+                  maxW="300px"
+                  flex="1 0 0"
                   transition="all 100ms ease-in-out"
                   _hover={{
                     fontWeight: 'bolder',

--- a/apps/protocol-frontend/src/components/MintedContributionsTable.tsx
+++ b/apps/protocol-frontend/src/components/MintedContributionsTable.tsx
@@ -76,7 +76,19 @@ const MintedContributionsTable = ({
           return (
             <Flex direction="column" wrap="wrap">
               <Link to={`/contributions/${row.original.id}`}>
-                <Text whiteSpace="normal">{getValue()}</Text>
+                <Text
+                  whiteSpace="normal"
+                  bgGradient="linear-gradient(100deg, #1a202c 0%, #1a202c 100%)"
+                  bgClip="text"
+                  transition="all 100ms ease-in-out"
+                  _hover={{
+                    fontWeight: 'bolder',
+                    bgGradient: 'linear(to-l, #7928CA, #FF0080)',
+                  }}
+                >
+                  {' '}
+                  {getValue()}
+                </Text>
               </Link>
             </Flex>
           );

--- a/apps/protocol-frontend/src/components/MyAttestationsTable.tsx
+++ b/apps/protocol-frontend/src/components/MyAttestationsTable.tsx
@@ -49,7 +49,18 @@ const MyAttestationsTable = ({
           return (
             <Flex direction="column" wrap="wrap">
               <Link to={`/contributions/${row.original.id}`}>
-                <Text whiteSpace="normal">{getValue()}</Text>
+                <Text
+                  whiteSpace="normal"
+                  bgGradient="linear-gradient(100deg, #1a202c 0%, #1a202c 100%)"
+                  bgClip="text"
+                  transition="all 100ms ease-in-out"
+                  _hover={{
+                    fontWeight: 'bolder',
+                    bgGradient: 'linear(to-l, #7928CA, #FF0080)',
+                  }}
+                >
+                  {getValue()}
+                </Text>
               </Link>
             </Flex>
           );

--- a/apps/protocol-frontend/src/components/RecentContributionsTable.tsx
+++ b/apps/protocol-frontend/src/components/RecentContributionsTable.tsx
@@ -29,9 +29,12 @@ const columnsDef: ColumnDef<UIContribution>[] = [
       getValue: Getter<string>;
     }) => {
       return (
-        <Flex direction="column" wrap="wrap">
+        <Flex direction="column" wrap="wrap" paddingRight={1}>
           <Link to={`/contributions/${row.original.id}`}>
             <Text
+              paddingRight={8}
+              flex="1 0 0"
+              maxW="300px"
               whiteSpace="normal"
               bgGradient="linear-gradient(100deg, #1a202c 0%, #1a202c 100%)"
               bgClip="text"
@@ -52,7 +55,13 @@ const columnsDef: ColumnDef<UIContribution>[] = [
     header: 'Type',
     accessorFn: contribution => contribution.activity_type.name,
     cell: ({ getValue }: { getValue: Getter<string> }) => {
-      return <Text>{getValue()} </Text>;
+      return (
+        <Flex direction="column" wrap="wrap">
+          <Text whiteSpace="normal" flex="1 0 0">
+            {getValue()}
+          </Text>
+        </Flex>
+      );
     },
   },
   {

--- a/apps/protocol-frontend/src/components/RecentContributionsTable.tsx
+++ b/apps/protocol-frontend/src/components/RecentContributionsTable.tsx
@@ -34,7 +34,7 @@ const columnsDef: ColumnDef<UIContribution>[] = [
             <Text
               paddingRight={8}
               flex="1 0 0"
-              maxW="300px"
+              maxW="15rem"
               whiteSpace="normal"
               bgGradient="linear-gradient(100deg, #1a202c 0%, #1a202c 100%)"
               bgClip="text"

--- a/apps/protocol-frontend/src/components/RecentContributionsTable.tsx
+++ b/apps/protocol-frontend/src/components/RecentContributionsTable.tsx
@@ -36,6 +36,10 @@ const columnsDef: ColumnDef<UIContribution>[] = [
               bgGradient="linear-gradient(100deg, #1a202c 0%, #1a202c 100%)"
               bgClip="text"
               transition="all 100ms ease-in-out"
+              _hover={{
+                fontWeight: 'bolder',
+                bgGradient: 'linear(to-l, #7928CA, #FF0080)',
+              }}
             >
               {getValue()}
             </Text>

--- a/apps/protocol-frontend/src/components/RecentContributionsTable.tsx
+++ b/apps/protocol-frontend/src/components/RecentContributionsTable.tsx
@@ -7,8 +7,10 @@ import {
   SortingState,
   getSortedRowModel,
   Getter,
+  Row,
 } from '@tanstack/react-table';
 import InfiniteScroll from 'react-infinite-scroll-component';
+import { Link } from 'react-router-dom';
 import { GovrnSpinner } from '@govrn/protocol-ui';
 import { UIContribution } from '@govrn/ui-types';
 import { formatDate, toDate } from '../utils/date';
@@ -19,10 +21,25 @@ const columnsDef: ColumnDef<UIContribution>[] = [
   {
     header: 'Name',
     accessorKey: 'name',
-    cell: ({ getValue }: { getValue: Getter<string> }) => {
+    cell: ({
+      row,
+      getValue,
+    }: {
+      row: Row<UIContribution>;
+      getValue: Getter<string>;
+    }) => {
       return (
         <Flex direction="column" wrap="wrap">
-          <Text whiteSpace="normal">{getValue()}</Text>
+          <Link to={`/contributions/${row.original.id}`}>
+            <Text
+              whiteSpace="normal"
+              bgGradient="linear-gradient(100deg, #1a202c 0%, #1a202c 100%)"
+              bgClip="text"
+              transition="all 100ms ease-in-out"
+            >
+              {getValue()}
+            </Text>
+          </Link>
         </Flex>
       );
     },

--- a/apps/protocol-frontend/src/components/ReportForm.tsx
+++ b/apps/protocol-frontend/src/components/ReportForm.tsx
@@ -29,7 +29,6 @@ import { reportFormValidation } from '../utils/validations';
 import { ContributionFormValues } from '../types/forms';
 import { HiOutlinePaperClip } from 'react-icons/hi';
 import { useUserActivityTypesList } from '../hooks/useUserActivityTypesList';
-import { useDaosList } from '../hooks/useDaosList';
 import { useContributionCreate } from '../hooks/useContributionCreate';
 import useUserGet from '../hooks/useUserGet';
 import { useGovrnToast } from '@govrn/protocol-ui';

--- a/apps/protocol-frontend/src/hooks/useDaoUsersList.ts
+++ b/apps/protocol-frontend/src/hooks/useDaoUsersList.ts
@@ -30,7 +30,7 @@ export const useDaoUsersInfiniteList = (
   } = useInfiniteQuery(
     ['daoUsersInfiniteList', args],
     async ({ pageParam }): Promise<UIGuildUsers[]> => {
-      const data = await govrn.guild.user.list(
+      const data = await govrn.guild?.user.list(
         { ...args, first: pageSize, skip: pageParam } || {},
       );
       const results = [];

--- a/libs/protocol-client/src/lib/client/contribution.ts
+++ b/libs/protocol-client/src/lib/client/contribution.ts
@@ -296,6 +296,7 @@ export class Contribution extends BaseClient {
         chain: { is: { chain_id: { equals: `${chainId}` } } },
         on_chain_id: { in: contributionIds },
       },
+      first: contributionIds.length,
     });
     if (dbContributions.result.length !== contributionIds.length) {
       throw new Error(


### PR DESCRIPTION
## Linear Ticket

- [ENG-942](https://linear.app/govrn/issue/ENG-942/recent-contributions-table-layout-shift)
- [ENG-891](https://linear.app/govrn/issue/ENG-891/arrow-should-be-justified-right-in-cell-instead-of-below-text)
- [ENG-877](https://linear.app/govrn/issue/ENG-877/make-a-visual-indicator-that-contribution-details-are-clickable)
- [ENG-923](https://linear.app/govrn/issue/ENG-923/attestation-limit-is-10)

## Description

- Fixes for several QA items:
  - moved sort arrow to horizontal instead of vertical flex (891)
  - added limit based on contributions length for bulk attest and bulk attribute (923)
  - better handling for preventing layout shift in tables (942)
  - added signifiers for contribution detail click (877)
- Removes the _Status_ header from the Contributions table since we now have minted tab -- brief conversation in the Product channel around this

I didn't screen record the attestation/contributions/attribute limit fix, but can be tested by the following:
- Select 11 or more contributions to attribute / mint / attest to
- Run through the flow -- previously we ran into an error message about chain id that was due to a mismatch in the expected contributions and what's coming as a response from the db

## Screencaptures

![contribution-details-improved-hover](https://user-images.githubusercontent.com/9438776/219260182-4807809a-ae02-4816-beb1-515e81832933.gif)

![sort-arrow](https://user-images.githubusercontent.com/9438776/219260289-1ce74d93-ba38-4cc7-892c-d7d3e1dfa010.gif)
