### PR TITLE
feature/empty-states-profile-dao

### DIFF
--- a/apps/protocol-frontend/src/Routes.tsx
+++ b/apps/protocol-frontend/src/Routes.tsx
@@ -124,7 +124,7 @@ const Routes = () => {
             userDaos && userDaos?.size > 0 ? (
               <Navigate
                 replace
-                to={`/dao/${userDaos?.values().next().value}`}
+                to={`/dao/${userDaos?.values().next().value?.guild_id}`}
               />
             ) : (
               <RequireActiveUser>

--- a/apps/protocol-frontend/src/components/ProfileDaos.tsx
+++ b/apps/protocol-frontend/src/components/ProfileDaos.tsx
@@ -1,6 +1,14 @@
 import { useState, useMemo } from 'react';
-import { Link } from 'react-router-dom';
-import { Button, Flex, Heading, Divider, Grid } from '@chakra-ui/react';
+import { Link as RouterLink } from 'react-router-dom';
+import {
+  Button,
+  Flex,
+  Heading,
+  Link,
+  Divider,
+  Grid,
+  Text,
+} from '@chakra-ui/react';
 import { ControlledSelect, GovrnSpinner } from '@govrn/protocol-ui';
 import { useDaoUserCreate } from '../hooks/useDaoUserCreate';
 import { useDaosList } from '../hooks/useDaosList';
@@ -97,15 +105,38 @@ const ProfileDaos = ({ userId, userAddress }: ProfileDaoProps) => {
         <Heading as="h3" size="md" fontWeight="medium" color="gray.700">
           My DAOs
         </Heading>
-        <Divider marginY={8} bgColor="gray.300" />
+        {data && data.length === 0 ? (
+          <Flex
+            direction="column"
+            maxWidth={{ base: '100%', xl: '50%' }}
+            fontSize="md"
+          >
+            <Text>
+              You'll need other collaborators to be part of a DAO!
+              <Text>
+                Select a DAO to join below or press create DAO and make your
+                own.
+              </Text>
+            </Text>
+          </Flex>
+        ) : null}
+        <Divider marginY={{ base: 4, lg: 0 }} bgColor="gray.300" />
         <Flex
           direction="column"
           justifyContent="space-apart"
           gap={8}
           width="100%"
         >
-          <Flex direction="row" alignItems="flex-end" gap={4}>
-            <Flex direction="column" width="40%" alignSelf="flex-start">
+          <Flex
+            direction={{ base: 'column', lg: 'row' }}
+            alignItems={{ base: 'flex-start', lg: 'flex-end' }}
+            gap={4}
+          >
+            <Flex
+              direction="column"
+              alignSelf="flex-start"
+              width={{ base: '100%', lg: '40%' }}
+            >
               <ControlledSelect
                 label="Select a DAO to Join"
                 onChange={dao => setSelectedDao(dao)}
@@ -119,11 +150,21 @@ const ProfileDaos = ({ userId, userAddress }: ProfileDaoProps) => {
               variant="primary"
               onClick={handleDaoJoin}
               disabled={createDaoUserLoading}
+              width={{ base: '100%', lg: 'auto' }}
             >
               Join
             </Button>
-            <Link to="/dao/create">
-              <Button variant="secondary" disabled={createDaoUserLoading}>
+
+            <Link
+              as={RouterLink}
+              to="/dao/create"
+              width={{ base: '100%', lg: 'auto' }}
+            >
+              <Button
+                variant="secondary"
+                disabled={createDaoUserLoading}
+                width={{ base: '100%', lg: 'auto' }}
+              >
                 Create DAO
               </Button>
             </Link>

--- a/apps/protocol-frontend/src/components/ProfileDaos.tsx
+++ b/apps/protocol-frontend/src/components/ProfileDaos.tsx
@@ -117,7 +117,7 @@ const ProfileDaos = ({ userId, userAddress }: ProfileDaoProps) => {
             </Text>
           </Flex>
         ) : null}
-        <Divider marginY={{ base: 4, lg: 0 }} bgColor="gray.300" />
+        <Divider marginY={{ base: 4, lg: 4 }} bgColor="gray.300" />
         <Flex
           direction="column"
           justifyContent="space-apart"

--- a/apps/protocol-frontend/src/components/ProfileDaos.tsx
+++ b/apps/protocol-frontend/src/components/ProfileDaos.tsx
@@ -111,12 +111,9 @@ const ProfileDaos = ({ userId, userAddress }: ProfileDaoProps) => {
             maxWidth={{ base: '100%', xl: '50%' }}
             fontSize="md"
           >
+            <Text>You'll need other collaborators to be part of a DAO!</Text>
             <Text>
-              You'll need other collaborators to be part of a DAO!
-              <Text>
-                Select a DAO to join below or press create DAO and make your
-                own.
-              </Text>
+              Select a DAO to join below or press create DAO and make your own.
             </Text>
           </Flex>
         ) : null}
@@ -159,6 +156,10 @@ const ProfileDaos = ({ userId, userAddress }: ProfileDaoProps) => {
               as={RouterLink}
               to="/dao/create"
               width={{ base: '100%', lg: 'auto' }}
+              textDecoration="none"
+              _hover={{
+                textDecoration: 'none',
+              }}
             >
               <Button
                 variant="secondary"

--- a/apps/protocol-frontend/src/components/ProfileDaos.tsx
+++ b/apps/protocol-frontend/src/components/ProfileDaos.tsx
@@ -1,5 +1,5 @@
-import { useState, useMemo } from 'react';
-import { Link as RouterLink } from 'react-router-dom';
+import { useState, useMemo, useEffect } from 'react';
+import { Link as RouterLink, useLocation } from 'react-router-dom';
 import {
   Button,
   Flex,
@@ -28,6 +28,16 @@ const ProfileDaos = ({ userId, userAddress }: ProfileDaoProps) => {
     value: number;
     label: string;
   } | null>(null);
+
+  const { state } = useLocation();
+  const { targetId } = state || {};
+
+  useEffect(() => {
+    const el = document.getElementById(targetId);
+    if (el) {
+      el.scrollIntoView();
+    }
+  }, [targetId]);
 
   const { isLoading: joinableDaosListLoading, data: joinableDaosListData } =
     useDaosList({
@@ -101,7 +111,12 @@ const ProfileDaos = ({ userId, userAddress }: ProfileDaoProps) => {
       boxShadow="sm"
       marginBottom={4}
     >
-      <Flex justifyContent="space-between" direction="column" wrap="wrap">
+      <Flex
+        justifyContent="space-between"
+        direction="column"
+        wrap="wrap"
+        id="myDaos"
+      >
         <Heading as="h3" size="md" fontWeight="medium" color="gray.700">
           My DAOs
         </Heading>

--- a/apps/protocol-frontend/src/pages/DaoLandingPage.tsx
+++ b/apps/protocol-frontend/src/pages/DaoLandingPage.tsx
@@ -96,6 +96,7 @@ const DaoLandingPage = () => {
       <Container
         paddingY={{ base: '4', md: '8' }}
         paddingX={{ base: '0', md: '8' }}
+        marginY={{ base: 8, lg: 0 }}
         color="gray.700"
         maxWidth="1200px"
       >

--- a/apps/protocol-frontend/src/pages/DaoLandingPage.tsx
+++ b/apps/protocol-frontend/src/pages/DaoLandingPage.tsx
@@ -60,6 +60,7 @@ const DaoLandingPage = () => {
       <Link
         as={RouterLink}
         to="/profile"
+        state={{ targetId: 'myDaos' }}
         _hover={{
           textDecoration: 'none',
         }}

--- a/apps/protocol-frontend/src/pages/DaoLandingPage.tsx
+++ b/apps/protocol-frontend/src/pages/DaoLandingPage.tsx
@@ -1,9 +1,20 @@
 import { useAccount } from 'wagmi';
+import { Link as RouterLink } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import { useUser } from '../contexts/UserContext';
-import { Box, Container, Stack, Text } from '@chakra-ui/react';
+import {
+  Box,
+  Button,
+  Container,
+  Flex,
+  Link,
+  Stack,
+  Text,
+} from '@chakra-ui/react';
+import { GovrnCta } from '@govrn/protocol-ui';
 import SiteLayout from '../components/SiteLayout';
 import NewUserView from '../components/NewUserView';
+import { HiOutlineExternalLink } from 'react-icons/hi';
 import { GOVRN_MOTTO } from '../utils/constants';
 
 const UserView = () => {
@@ -25,6 +36,57 @@ const DaoLandingPage = () => {
   const { isAuthenticated } = useAuth();
   const { userData } = useUser();
 
+  const CopyChildren = () => (
+    <Flex direction="column" alignItems="center" justifyContent="center">
+      <Text as="span">
+        {' '}
+        <span role="img" aria-labelledby="person emoji">
+          👤
+        </span>{' '}
+        Head to your profile to join or create a DAO
+      </Text>
+      <Text as="span">
+        {' '}
+        <span role="img" aria-labelledby="robot emoji">
+          🤖
+        </span>{' '}
+        Learn more about Kevin Malone, our friendly Discord bot for DAOs
+      </Text>
+    </Flex>
+  );
+
+  const ButtonChildren = () => (
+    <>
+      <Link
+        as={RouterLink}
+        to="/profile"
+        _hover={{
+          textDecoration: 'none',
+        }}
+      >
+        <Button variant="primary" size="md">
+          Join a DAO From Your Profile
+        </Button>
+      </Link>
+      <Link
+        href="https://govrn.gitbook.io/govrn-docs/lets-party/kevin-malone"
+        isExternal
+        textDecoration="none"
+        _hover={{
+          textDecoration: 'none',
+        }}
+      >
+        <Button
+          variant="secondary"
+          size="md"
+          leftIcon={<HiOutlineExternalLink />}
+        >
+          Learn More About Kevin Malone
+        </Button>
+      </Link>
+    </>
+  );
+
   return (
     <SiteLayout>
       <Container
@@ -39,23 +101,12 @@ const DaoLandingPage = () => {
             boxShadow="sm"
             borderRadius={{ base: 'none', md: 'lg' }}
           >
-            <Stack spacing="4" justify="center" align="center" minHeight="50vh">
-              <Text fontSize="lg" fontWeight="medium">
-                <span
-                  role="img"
-                  aria-labelledby="Sun emoji for callout indicating user is not in any DAOs yet."
-                >
-                  🌞
-                </span>{' '}
-                You're not in any DAOs yet!{' '}
-                <span
-                  role="img"
-                  aria-labelledby="Sun emoji for callout indicating user is not in any DAOs yet."
-                >
-                  🌞
-                </span>{' '}
-              </Text>
-            </Stack>
+            <GovrnCta
+              heading={`You aren't in any DAOs yet`}
+              emoji="👀"
+              copy={<CopyChildren />}
+              children={<ButtonChildren />}
+            />
           </Box>
         ) : (
           <Box>

--- a/apps/protocol-frontend/src/pages/DaoLandingPage.tsx
+++ b/apps/protocol-frontend/src/pages/DaoLandingPage.tsx
@@ -64,7 +64,11 @@ const DaoLandingPage = () => {
           textDecoration: 'none',
         }}
       >
-        <Button variant="primary" size="md">
+        <Button
+          variant="primary"
+          size="md"
+          width={{ base: '100%', lg: 'auto' }}
+        >
           Join a DAO From Your Profile
         </Button>
       </Link>
@@ -100,6 +104,8 @@ const DaoLandingPage = () => {
             background="white"
             boxShadow="sm"
             borderRadius={{ base: 'none', md: 'lg' }}
+            marginX={{ base: 4, lg: 0 }}
+            marginTop={{ base: 8, lg: 0 }}
           >
             <GovrnCta
               heading={`You aren't in any DAOs yet`}

--- a/libs/protocol-ui/src/components/molecules/GovrnCta/GovrnCta.tsx
+++ b/libs/protocol-ui/src/components/molecules/GovrnCta/GovrnCta.tsx
@@ -20,8 +20,8 @@ const GovrnCta = ({ heading, emoji, copy, children }: GovrnCtaProps) => (
       direction="row"
       alignItems="baseline"
       fontSize={{ base: 'xl', lg: '3xl' }}
-      paddingY={8}
-      paddingX={{ base: 2 }}
+      paddingY="8"
+      paddingX={{ base: 8, lg: 0 }}
     >
       {emoji ? (
         <Text

--- a/libs/protocol-ui/src/components/molecules/GovrnCta/GovrnCta.tsx
+++ b/libs/protocol-ui/src/components/molecules/GovrnCta/GovrnCta.tsx
@@ -3,7 +3,7 @@ import { Heading, Divider, Flex, Text } from '@chakra-ui/react';
 export interface GovrnCtaProps {
   heading: string;
   emoji?: string;
-  copy?: string;
+  copy?: string | React.ReactNode;
   children?: React.ReactNode;
 }
 

--- a/libs/protocol-ui/src/components/molecules/GovrnCta/GovrnCta.tsx
+++ b/libs/protocol-ui/src/components/molecules/GovrnCta/GovrnCta.tsx
@@ -16,7 +16,13 @@ const GovrnCta = ({ heading, emoji, copy, children }: GovrnCtaProps) => (
     boxShadow="sm"
     borderRadius={{ base: 'none', md: 'lg' }}
   >
-    <Flex direction="row" alignItems="baseline" fontSize="3xl" paddingY={8}>
+    <Flex
+      direction="row"
+      alignItems="baseline"
+      fontSize={{ base: 'xl', lg: '3xl' }}
+      paddingY={8}
+      paddingX={{ base: 2 }}
+    >
       {emoji ? (
         <Text
           as="span"
@@ -24,14 +30,14 @@ const GovrnCta = ({ heading, emoji, copy, children }: GovrnCtaProps) => (
           aria-labelledby="eye emoji for the CTA"
           fontSize="inherit"
         >
-          {emoji}
+          {emoji}&nbsp;
         </Text>
       ) : null}
-      <Heading as="h3" fontSize="3xl" fontWeight="600">
+      <Heading as="h3" fontSize={{ base: '2xl', lg: '3xl' }} fontWeight="600">
         {heading}
       </Heading>
     </Flex>
-    <Text paddingBottom={8} fontSize="md">
+    <Text paddingBottom={8} fontSize="md" paddingX={{ base: 8, lg: 0 }}>
       {copy}
     </Text>
     {children ? (
@@ -44,7 +50,8 @@ const GovrnCta = ({ heading, emoji, copy, children }: GovrnCtaProps) => (
       >
         <Divider color="gray.200" />
         <Flex
-          direction="row"
+          direction={{ base: 'column', lg: 'row' }}
+          gap={{ base: 4, lg: 0 }}
           alignItems="center"
           justifyContent="space-around"
           paddingY={8}

--- a/libs/protocol-ui/src/components/molecules/GovrnShowcase/GovrnShowcase.tsx
+++ b/libs/protocol-ui/src/components/molecules/GovrnShowcase/GovrnShowcase.tsx
@@ -47,7 +47,7 @@ const GovrnShowcase = ({ copy, emoji, children }: GovrnShowcaseProps) => (
             aria-labelledby="emoji for the showcase"
             fontSize="3xl"
           >
-            {emoji}
+            {emoji}&nbsp;
           </Text>
         </Flex>
       )}


### PR DESCRIPTION
## Linear Ticket

- [ENG-945](https://linear.app/govrn/issue/ENG-945/empty-state-profile)
- [ENG-943](https://linear.app/govrn/issue/ENG-943/empty-state-dao)

## Description

- Slightly adjusts the GovrnCta component to also take children for the copy
- Added the empty states to the /dao route and the Profile

## Screencaptures

DAO route:
![empty-states-dao-mobile](https://user-images.githubusercontent.com/9438776/221250802-31958d1a-b7a3-4048-af07-2bf48466ae90.jpg)
![empty-states-dao](https://user-images.githubusercontent.com/9438776/221250803-33f7f7ee-7b9b-4ece-8479-ec6459aeb822.jpg)


Profile:

![empty-states-profile-mobile](https://user-images.githubusercontent.com/9438776/221250821-da34ae2e-5ac9-4cd3-8e08-1a0a1b5e9210.jpg)
![empty-states-profile](https://user-images.githubusercontent.com/9438776/221250824-25eb468c-e79c-42c0-a99e-6d904bd01e99.jpg)

