### PR TITLE
contribution-table-enhancements

### DIFF
--- a/apps/protocol-frontend/src/components/AttestationsTable.tsx
+++ b/apps/protocol-frontend/src/components/AttestationsTable.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Box, Flex, Stack, Button, Text, Tooltip } from '@chakra-ui/react';
+import { Box, Flex, Stack, Button, Text } from '@chakra-ui/react';
 import { Link } from 'react-router-dom';
 import {
   ColumnDef,
@@ -20,11 +20,11 @@ import { useOverlay } from '../contexts/OverlayContext';
 import ModalWrapper from './ModalWrapper';
 import { BulkAttestationModal, AttestationModal } from './BulkAttestationModal';
 import { useUser } from '../contexts/UserContext';
-import { displayAddress } from '../utils/web3';
 import { RowSelectionState } from '@tanstack/table-core';
 import { statusEmojiSelect } from '../utils/statusEmojiSelect';
 import { formatDate, toDate } from '../utils/date';
 import GovrnTable from './GovrnTable';
+import MemberDisplayName from './MemberDisplayName';
 
 const AttestationsTable = ({
   data,
@@ -142,22 +142,7 @@ const AttestationsTable = ({
 
         cell: ({ getValue }: { getValue: Getter<UIContribution['user']> }) => {
           const value = getValue();
-
-          const hasMemberName = value.name || value.display_name;
-          const displayMemberName =
-            value.name || value.display_name || displayAddress(value.address);
-          return hasMemberName ? (
-            <Tooltip
-              variant="primary"
-              label={value.address}
-              fontSize="sm"
-              placement="right"
-            >
-              <Text whiteSpace="normal">{displayMemberName}</Text>
-            </Tooltip>
-          ) : (
-            <Text whiteSpace="normal">{displayMemberName}</Text>
-          );
+          return <MemberDisplayName memberValue={value} />;
         },
       },
       {

--- a/apps/protocol-frontend/src/components/AttestationsTable.tsx
+++ b/apps/protocol-frontend/src/components/AttestationsTable.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Box, Flex, Stack, Button, Text } from '@chakra-ui/react';
+import { Box, Flex, Stack, Button, Text, Tooltip } from '@chakra-ui/react';
 import { Link } from 'react-router-dom';
 import {
   ColumnDef,
@@ -138,8 +138,28 @@ const AttestationsTable = ({
       },
       {
         header: 'Contributor',
-        accessorFn: contribution =>
-          contribution.user.name || displayAddress(contribution.user.address),
+        accessorKey: 'user',
+        // accessorFn: contribution =>
+        //   contribution.user.name || displayAddress(contribution.user.address),
+        cell: ({ getValue }: { getValue: Getter<UIContribution['user']> }) => {
+          const value = getValue();
+
+          const hasMemberName = value.name || value.display_name;
+          const displayMemberName =
+            value.name || value.display_name || displayAddress(value.address);
+          return hasMemberName ? (
+            <Tooltip
+              variant="primary"
+              label={value.address}
+              fontSize="sm"
+              placement="right"
+            >
+              <Text whiteSpace="normal">{displayMemberName}</Text>
+            </Tooltip>
+          ) : (
+            <Text whiteSpace="normal">{displayMemberName}</Text>
+          );
+        },
       },
       {
         header: 'DAO',
@@ -165,6 +185,7 @@ const AttestationsTable = ({
     getSortedRowModel: getSortedRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
   });
+  console.log('table data', data);
 
   useEffect(() => {
     const selectedContributions: UIContribution[] = [];

--- a/apps/protocol-frontend/src/components/AttestationsTable.tsx
+++ b/apps/protocol-frontend/src/components/AttestationsTable.tsx
@@ -184,7 +184,6 @@ const AttestationsTable = ({
     getSortedRowModel: getSortedRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
   });
-  console.log('table data', data);
 
   useEffect(() => {
     const selectedContributions: UIContribution[] = [];

--- a/apps/protocol-frontend/src/components/AttestationsTable.tsx
+++ b/apps/protocol-frontend/src/components/AttestationsTable.tsx
@@ -139,8 +139,7 @@ const AttestationsTable = ({
       {
         header: 'Contributor',
         accessorKey: 'user',
-        // accessorFn: contribution =>
-        //   contribution.user.name || displayAddress(contribution.user.address),
+
         cell: ({ getValue }: { getValue: Getter<UIContribution['user']> }) => {
           const value = getValue();
 

--- a/apps/protocol-frontend/src/components/ContributionTypesTable.tsx
+++ b/apps/protocol-frontend/src/components/ContributionTypesTable.tsx
@@ -55,7 +55,7 @@ const ContributionTypesTable = ({
         cell: ({ getValue }: { getValue: Getter<string> }) => {
           return (
             <Box
-              bgColor="blue.50"
+              bgColor="brand.secondary.50"
               width="fit-content"
               padding={2}
               borderRadius="md"
@@ -74,7 +74,7 @@ const ContributionTypesTable = ({
         cell: ({ getValue }: { getValue: Getter<number> }) => {
           return (
             <Box
-              bgColor="blue.50"
+              bgColor="brand.secondary.50"
               width="fit-content"
               padding={2}
               borderRadius="md"

--- a/apps/protocol-frontend/src/components/ContributionTypesTable.tsx
+++ b/apps/protocol-frontend/src/components/ContributionTypesTable.tsx
@@ -1,6 +1,8 @@
 import { useMemo, useState } from 'react';
 import { isAfter } from 'date-fns';
-import { Box, Text } from '@chakra-ui/react';
+import { Link } from 'react-router-dom';
+import { Box, Flex, HStack, Text } from '@chakra-ui/react';
+
 import {
   ColumnDef,
   getCoreRowModel,
@@ -9,6 +11,7 @@ import {
   SortingState,
   getSortedRowModel,
   Getter,
+  Row,
 } from '@tanstack/react-table';
 import { UIContribution } from '@govrn/ui-types';
 import { formatDate, toDate } from '../utils/date';
@@ -84,20 +87,41 @@ const ContributionTypesTable = ({
       {
         header: 'Last Occurrence',
         accessorFn: contribution => toDate(contribution.date_of_engagement),
-        cell: ({ getValue }: { getValue: Getter<Date> }) => {
-          return <Text>{formatDate(getValue())}</Text>;
+        cell: ({
+          row,
+          getValue,
+        }: {
+          row: Row<UIContribution>;
+          getValue: Getter<Date>;
+        }) => {
+          return (
+            <Flex direction="column" wrap="wrap" paddingRight={1}>
+              <Link to={`/contributions/${row.original.id}`}>
+                <HStack justifyContent="baseline" alignItems="center">
+                  <Text
+                    as="span"
+                    paddingRight={8}
+                    flex="1 0 0"
+                    maxW="15rem"
+                    minW="15rem"
+                    whiteSpace="normal"
+                    bgGradient="linear-gradient(100deg, #1a202c 0%, #1a202c 100%)"
+                    bgClip="text"
+                    transition="all 100ms ease-in-out"
+                    _hover={{
+                      fontWeight: 'bolder',
+                      bgGradient: 'linear(to-l, #7928CA, #FF0080)',
+                    }}
+                  >
+                    {formatDate(getValue())}
+                  </Text>
+                </HStack>
+              </Link>
+            </Flex>
+          );
         },
         sortingFn: 'datetime',
         invertSorting: true,
-      },
-      {
-        header: 'Name',
-        accessorKey: 'name',
-      },
-      {
-        header: 'DAOs',
-        accessorFn: contribution =>
-          contribution.guilds.map(g => g.guild.name).join(','),
       },
     ],
     [sortedContributions],

--- a/apps/protocol-frontend/src/components/MemberDisplayName.tsx
+++ b/apps/protocol-frontend/src/components/MemberDisplayName.tsx
@@ -1,0 +1,29 @@
+import { Text, Tooltip } from '@chakra-ui/react';
+import { UIContribution } from '@govrn/ui-types';
+import { displayAddress } from '../utils/web3';
+
+interface MemberDisplayNameProps {
+  memberValue: UIContribution['user'];
+}
+
+const MemberDisplayName = ({ memberValue }: MemberDisplayNameProps) => {
+  const hasMemberName = memberValue.name || memberValue.display_name;
+  const displayMemberName =
+    memberValue.name ||
+    memberValue.display_name ||
+    displayAddress(memberValue.address);
+  return hasMemberName ? (
+    <Tooltip
+      variant="primary"
+      label={memberValue.address}
+      fontSize="sm"
+      placement="right"
+    >
+      <Text whiteSpace="normal">{displayMemberName}</Text>
+    </Tooltip>
+  ) : (
+    <Text whiteSpace="normal">{displayMemberName}</Text>
+  );
+};
+
+export default MemberDisplayName;

--- a/apps/protocol-frontend/src/components/MyAttestationsTable.tsx
+++ b/apps/protocol-frontend/src/components/MyAttestationsTable.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
-import { Box, Flex, Stack, Text } from '@chakra-ui/react';
+
+import { Box, Flex, Stack, Text, Tooltip } from '@chakra-ui/react';
 import {
   ColumnDef,
   getCoreRowModel,
@@ -18,6 +19,7 @@ import { GovrnSpinner } from '@govrn/protocol-ui';
 import { Link } from 'react-router-dom';
 import { useUser } from '../contexts/UserContext';
 import { statusEmojiSelect } from '../utils/statusEmojiSelect';
+import { displayAddress } from '../utils/web3';
 import GovrnTable from './GovrnTable';
 
 const MyAttestationsTable = ({
@@ -98,7 +100,27 @@ const MyAttestationsTable = ({
       },
       {
         header: 'Contributor',
-        accessorFn: contribution => contribution.user.name,
+        accessorKey: 'user',
+
+        cell: ({ getValue }: { getValue: Getter<UIContribution['user']> }) => {
+          const value = getValue();
+
+          const hasMemberName = value.name || value.display_name;
+          const displayMemberName =
+            value.name || value.display_name || displayAddress(value.address);
+          return hasMemberName ? (
+            <Tooltip
+              variant="primary"
+              label={value.address}
+              fontSize="sm"
+              placement="right"
+            >
+              <Text whiteSpace="normal">{displayMemberName}</Text>
+            </Tooltip>
+          ) : (
+            <Text whiteSpace="normal">{displayMemberName}</Text>
+          );
+        },
       },
     ];
   }, [userData?.id]);

--- a/apps/protocol-frontend/src/components/MyAttestationsTable.tsx
+++ b/apps/protocol-frontend/src/components/MyAttestationsTable.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
 
-import { Box, Flex, Stack, Text, Tooltip } from '@chakra-ui/react';
+import { Box, Flex, Stack, Text } from '@chakra-ui/react';
 import {
   ColumnDef,
   getCoreRowModel,
@@ -19,8 +19,8 @@ import { GovrnSpinner } from '@govrn/protocol-ui';
 import { Link } from 'react-router-dom';
 import { useUser } from '../contexts/UserContext';
 import { statusEmojiSelect } from '../utils/statusEmojiSelect';
-import { displayAddress } from '../utils/web3';
 import GovrnTable from './GovrnTable';
+import MemberDisplayName from './MemberDisplayName';
 
 const MyAttestationsTable = ({
   data,
@@ -104,22 +104,7 @@ const MyAttestationsTable = ({
 
         cell: ({ getValue }: { getValue: Getter<UIContribution['user']> }) => {
           const value = getValue();
-
-          const hasMemberName = value.name || value.display_name;
-          const displayMemberName =
-            value.name || value.display_name || displayAddress(value.address);
-          return hasMemberName ? (
-            <Tooltip
-              variant="primary"
-              label={value.address}
-              fontSize="sm"
-              placement="right"
-            >
-              <Text whiteSpace="normal">{displayMemberName}</Text>
-            </Tooltip>
-          ) : (
-            <Text whiteSpace="normal">{displayMemberName}</Text>
-          );
+          return <MemberDisplayName memberValue={value} />;
         },
       },
     ];

--- a/apps/protocol-frontend/src/components/RecentContributionsTable.tsx
+++ b/apps/protocol-frontend/src/components/RecentContributionsTable.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import { Box, Flex, Heading, Stack, Text, Tooltip } from '@chakra-ui/react';
 import {
   ColumnDef,
@@ -14,7 +14,6 @@ import { Link } from 'react-router-dom';
 import { GovrnSpinner } from '@govrn/protocol-ui';
 import { UIContribution } from '@govrn/ui-types';
 import { formatDate, toDate } from '../utils/date';
-import { mergePages } from '../utils/arrays';
 import { displayAddress } from '../utils/web3';
 import GovrnTable from './GovrnTable';
 

--- a/apps/protocol-frontend/src/components/RecentContributionsTable.tsx
+++ b/apps/protocol-frontend/src/components/RecentContributionsTable.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { Box, Flex, Heading, Stack, Text } from '@chakra-ui/react';
+import { Box, Flex, Heading, Stack, Text, Tooltip } from '@chakra-ui/react';
 import {
   ColumnDef,
   getCoreRowModel,
@@ -15,6 +15,7 @@ import { GovrnSpinner } from '@govrn/protocol-ui';
 import { UIContribution } from '@govrn/ui-types';
 import { formatDate, toDate } from '../utils/date';
 import { mergePages } from '../utils/arrays';
+import { displayAddress } from '../utils/web3';
 import GovrnTable from './GovrnTable';
 
 const columnsDef: ColumnDef<UIContribution>[] = [
@@ -75,9 +76,26 @@ const columnsDef: ColumnDef<UIContribution>[] = [
   },
   {
     header: 'Contributor',
-    accessorFn: contribution => contribution.user.name,
-    cell: ({ getValue }: { getValue: Getter<string> }) => {
-      return <Text>{getValue()} </Text>;
+    accessorKey: 'user',
+
+    cell: ({ getValue }: { getValue: Getter<UIContribution['user']> }) => {
+      const value = getValue();
+
+      const hasMemberName = value.name || value.display_name;
+      const displayMemberName =
+        value.name || value.display_name || displayAddress(value.address);
+      return hasMemberName ? (
+        <Tooltip
+          variant="primary"
+          label={value.address}
+          fontSize="sm"
+          placement="right"
+        >
+          <Text whiteSpace="normal">{displayMemberName}</Text>
+        </Tooltip>
+      ) : (
+        <Text whiteSpace="normal">{displayMemberName}</Text>
+      );
     },
   },
 ];

--- a/apps/protocol-frontend/src/components/RecentContributionsTable.tsx
+++ b/apps/protocol-frontend/src/components/RecentContributionsTable.tsx
@@ -16,6 +16,7 @@ import { UIContribution } from '@govrn/ui-types';
 import { formatDate, toDate } from '../utils/date';
 import { displayAddress } from '../utils/web3';
 import GovrnTable from './GovrnTable';
+import MemberDisplayName from './MemberDisplayName';
 
 const columnsDef: ColumnDef<UIContribution>[] = [
   {
@@ -79,22 +80,7 @@ const columnsDef: ColumnDef<UIContribution>[] = [
 
     cell: ({ getValue }: { getValue: Getter<UIContribution['user']> }) => {
       const value = getValue();
-
-      const hasMemberName = value.name || value.display_name;
-      const displayMemberName =
-        value.name || value.display_name || displayAddress(value.address);
-      return hasMemberName ? (
-        <Tooltip
-          variant="primary"
-          label={value.address}
-          fontSize="sm"
-          placement="right"
-        >
-          <Text whiteSpace="normal">{displayMemberName}</Text>
-        </Tooltip>
-      ) : (
-        <Text whiteSpace="normal">{displayMemberName}</Text>
-      );
+      return <MemberDisplayName memberValue={value} />;
     },
   },
 ];

--- a/apps/protocol-frontend/src/components/RecentContributionsTable.tsx
+++ b/apps/protocol-frontend/src/components/RecentContributionsTable.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Box, Flex, Heading, Stack, Text, Tooltip } from '@chakra-ui/react';
+import { Box, Flex, Heading, Stack, Text } from '@chakra-ui/react';
 import {
   ColumnDef,
   getCoreRowModel,
@@ -14,7 +14,6 @@ import { Link } from 'react-router-dom';
 import { GovrnSpinner } from '@govrn/protocol-ui';
 import { UIContribution } from '@govrn/ui-types';
 import { formatDate, toDate } from '../utils/date';
-import { displayAddress } from '../utils/web3';
 import GovrnTable from './GovrnTable';
 import MemberDisplayName from './MemberDisplayName';
 


### PR DESCRIPTION
## Linear Ticket

- [ENG-985](https://linear.app/govrn/issue/ENG-958/add-address-on-hover-on-the-contributor)
- [ENG-813](https://linear.app/govrn/issue/ENG-813/remove-dao-column-contribution-types-page)

## Description

- Shows address on hover on Attestations, My Attestations, and Recent Contributions (DAO Dashboard) tables. This only shows when the contributor has a display name set (similar to the DAO Settings Member table)
- Removed the 'DAO' column and name from the Contribution Types table
- Added a link to Contribution Details via the _Last Occurrence_ column

## Screencaptures

Address on hover:

![address-hover-attestations](https://user-images.githubusercontent.com/9438776/221294016-30c47b19-df40-4085-a98a-1a16379910c5.gif)
![address-hover-recent-contributions](https://user-images.githubusercontent.com/9438776/221294017-02663b4a-0a05-4fea-8587-dd7df05e562a.gif)

Contribution Types table:

![contribution-types-link](https://user-images.githubusercontent.com/9438776/221293994-cf565488-fe59-47bb-bd32-3fd779ab5efb.gif)


