### PR TITLE
feature/empty-states-contributions (ENG-947)

### DIFF
--- a/apps/protocol-frontend/src/components/ContributionTypesTable.tsx
+++ b/apps/protocol-frontend/src/components/ContributionTypesTable.tsx
@@ -1,7 +1,14 @@
 import { useMemo, useState } from 'react';
 import { isAfter } from 'date-fns';
 import { Link } from 'react-router-dom';
-import { Box, Flex, HStack, Text } from '@chakra-ui/react';
+import {
+  Box,
+  Button,
+  Flex,
+  Link as ChakraLink,
+  HStack,
+  Text,
+} from '@chakra-ui/react';
 
 import {
   ColumnDef,
@@ -14,6 +21,7 @@ import {
   Row,
 } from '@tanstack/react-table';
 import { UIContribution } from '@govrn/ui-types';
+import { GovrnCta } from '@govrn/protocol-ui';
 import { formatDate, toDate } from '../utils/date';
 import GovrnTable from './GovrnTable';
 
@@ -137,7 +145,47 @@ const ContributionTypesTable = ({
     getFilteredRowModel: getFilteredRowModel(),
   });
 
-  return <GovrnTable controller={table} maxWidth="100vw" overflowX="auto" />;
+  const CopyChildren = () => (
+    <Flex direction="column" alignItems="center" justifyContent="center">
+      <Text as="span">
+        Record a contribution and then try attributing it to a DAO or minting it
+      </Text>
+      <span role="img" aria-labelledby="winking emoji">
+        😉
+      </span>
+    </Flex>
+  );
+
+  const ButtonChildren = () => (
+    <ChakraLink
+      as={Link}
+      to="/report"
+      _hover={{
+        textDecoration: 'none',
+      }}
+    >
+      <Button variant="primary" size="md" width={{ base: '100%', lg: 'auto' }}>
+        Report Your First Contribution
+      </Button>
+    </ChakraLink>
+  );
+
+  let component = (
+    <GovrnCta
+      heading={`It's new contribution time!`}
+      emoji="⚡"
+      copy={<CopyChildren />}
+      children={<ButtonChildren />}
+    />
+  );
+
+  if (uniqueContributions.length) {
+    component = (
+      <GovrnTable controller={table} maxWidth="100vw" overflowX="auto" />
+    );
+  }
+
+  return component;
 };
 
 export default ContributionTypesTable;

--- a/apps/protocol-frontend/src/components/ContributionsTable.tsx
+++ b/apps/protocol-frontend/src/components/ContributionsTable.tsx
@@ -51,7 +51,6 @@ export type DialogProps = {
 const ContributionsTable = ({
   data,
   setSelectedContributions,
-  selectedContributions,
   hasMoreItems,
   nextPage,
 }: {

--- a/apps/protocol-frontend/src/components/ContributionsTable.tsx
+++ b/apps/protocol-frontend/src/components/ContributionsTable.tsx
@@ -11,7 +11,6 @@ import {
   Tooltip,
 } from '@chakra-ui/react';
 import { HiOutlineLink } from 'react-icons/hi';
-import { HiOutlineExternalLink } from 'react-icons/hi';
 import { FiEdit2, FiTrash2 } from 'react-icons/fi';
 import { Link } from 'react-router-dom';
 import { useUser } from '../contexts/UserContext';

--- a/apps/protocol-frontend/src/components/ContributionsTable.tsx
+++ b/apps/protocol-frontend/src/components/ContributionsTable.tsx
@@ -51,6 +51,7 @@ export type DialogProps = {
 const ContributionsTable = ({
   data,
   setSelectedContributions,
+  selectedContributions,
   hasMoreItems,
   nextPage,
 }: {
@@ -284,16 +285,12 @@ const ContributionsTable = ({
   const ButtonChildren = () => (
     <ChakraLink
       as={Link}
-      to="/contributions"
+      to="/report"
       _hover={{
         textDecoration: 'none',
       }}
     >
-      <Button
-        variant="secondary"
-        size="md"
-        width={{ base: '100%', lg: 'auto' }}
-      >
+      <Button variant="primary" size="md" width={{ base: '100%', lg: 'auto' }}>
         Report Your First Contribution
       </Button>
     </ChakraLink>
@@ -308,58 +305,66 @@ const ContributionsTable = ({
     />
   );
 
+  if (data.length) {
+    component = (
+      <Stack>
+        <GlobalFilter
+          preGlobalFilteredRows={table.getPreFilteredRowModel().rows}
+          globalFilter={globalFilter}
+          setGlobalFilter={setGlobalFilter}
+        />
+        <Box width="100%" maxWidth="100vw" overflowX="auto">
+          <InfiniteScroll
+            dataLength={table.getRowModel().rows.length}
+            next={nextPage}
+            scrollThreshold={0.8}
+            hasMore={hasMoreItems}
+            loader={<GovrnSpinner />}
+          >
+            <GovrnTable controller={table} maxWidth="100vw" overflowX="auto" />
+          </InfiniteScroll>
+        </Box>
+      </Stack>
+    );
+  }
+
   return (
-    <Stack>
-      <GlobalFilter
-        preGlobalFilteredRows={table.getPreFilteredRowModel().rows}
-        globalFilter={globalFilter}
-        setGlobalFilter={setGlobalFilter}
+    <>
+      {component}
+      <ModalWrapper
+        name="editContributionFormModal"
+        title="Update Contribution Activity"
+        localOverlay={localOverlay}
+        size="3xl"
+        content={
+          <EditContributionForm
+            contribution={
+              data.find(
+                localContribution =>
+                  localContribution.id === selectedContribution,
+              )!
+            }
+          />
+        }
       />
-      <Box width="100%" maxWidth="100vw" overflowX="auto">
-        <InfiniteScroll
-          dataLength={table.getRowModel().rows.length}
-          next={nextPage}
-          scrollThreshold={0.8}
-          hasMore={hasMoreItems}
-          loader={<GovrnSpinner />}
-        >
-          <GovrnTable controller={table} maxWidth="100vw" overflowX="auto" />
-        </InfiniteScroll>
-        <ModalWrapper
-          name="editContributionFormModal"
-          title="Update Contribution Activity"
-          localOverlay={localOverlay}
-          size="3xl"
-          content={
-            <EditContributionForm
-              contribution={
-                data.find(
-                  localContribution =>
-                    localContribution.id === selectedContribution,
-                )!
-              }
-            />
-          }
-        />
-        <DeleteContributionDialog dialog={dialog} setDialog={setDialog} />
-        <ModalWrapper
-          name="mintModal"
-          title="Mint Your DAO Contributions"
-          localOverlay={localOverlay}
-          size="3xl"
-          content={
-            <MintModal contributions={selectedRows} onFinish={deselectAll} />
-          }
-        />
-        <ModalWrapper
-          name="bulkDaoAttributeModal"
-          title="Attribute Contributions to a DAO"
-          localOverlay={localOverlay}
-          size="3xl"
-          content={<BulkDaoAttributeModal contributions={selectedRows} />}
-        />
-      </Box>
-    </Stack>
+      <DeleteContributionDialog dialog={dialog} setDialog={setDialog} />
+      <ModalWrapper
+        name="mintModal"
+        title="Mint Your DAO Contributions"
+        localOverlay={localOverlay}
+        size="3xl"
+        content={
+          <MintModal contributions={selectedRows} onFinish={deselectAll} />
+        }
+      />
+      <ModalWrapper
+        name="bulkDaoAttributeModal"
+        title="Attribute Contributions to a DAO"
+        localOverlay={localOverlay}
+        size="3xl"
+        content={<BulkDaoAttributeModal contributions={selectedRows} />}
+      />
+    </>
   );
 };
 

--- a/apps/protocol-frontend/src/components/ContributionsTable.tsx
+++ b/apps/protocol-frontend/src/components/ContributionsTable.tsx
@@ -299,72 +299,68 @@ const ContributionsTable = ({
     </ChakraLink>
   );
 
-  console.log('data', data);
-  console.log('length', data.length);
-  if (!data.length)
-    return (
-      <GovrnCta
-        heading={`It's new contribution time!`}
-        emoji="⚡"
-        copy={<CopyChildren />}
-        children={<ButtonChildren />}
-      />
-    );
+  let component = (
+    <GovrnCta
+      heading={`It's new contribution time!`}
+      emoji="⚡"
+      copy={<CopyChildren />}
+      children={<ButtonChildren />}
+    />
+  );
 
-  if (data.length)
-    return (
-      <Stack>
-        <GlobalFilter
-          preGlobalFilteredRows={table.getPreFilteredRowModel().rows}
-          globalFilter={globalFilter}
-          setGlobalFilter={setGlobalFilter}
+  return (
+    <Stack>
+      <GlobalFilter
+        preGlobalFilteredRows={table.getPreFilteredRowModel().rows}
+        globalFilter={globalFilter}
+        setGlobalFilter={setGlobalFilter}
+      />
+      <Box width="100%" maxWidth="100vw" overflowX="auto">
+        <InfiniteScroll
+          dataLength={table.getRowModel().rows.length}
+          next={nextPage}
+          scrollThreshold={0.8}
+          hasMore={hasMoreItems}
+          loader={<GovrnSpinner />}
+        >
+          <GovrnTable controller={table} maxWidth="100vw" overflowX="auto" />
+        </InfiniteScroll>
+        <ModalWrapper
+          name="editContributionFormModal"
+          title="Update Contribution Activity"
+          localOverlay={localOverlay}
+          size="3xl"
+          content={
+            <EditContributionForm
+              contribution={
+                data.find(
+                  localContribution =>
+                    localContribution.id === selectedContribution,
+                )!
+              }
+            />
+          }
         />
-        <Box width="100%" maxWidth="100vw" overflowX="auto">
-          <InfiniteScroll
-            dataLength={table.getRowModel().rows.length}
-            next={nextPage}
-            scrollThreshold={0.8}
-            hasMore={hasMoreItems}
-            loader={<GovrnSpinner />}
-          >
-            <GovrnTable controller={table} maxWidth="100vw" overflowX="auto" />
-          </InfiniteScroll>
-          <ModalWrapper
-            name="editContributionFormModal"
-            title="Update Contribution Activity"
-            localOverlay={localOverlay}
-            size="3xl"
-            content={
-              <EditContributionForm
-                contribution={
-                  data.find(
-                    localContribution =>
-                      localContribution.id === selectedContribution,
-                  )!
-                }
-              />
-            }
-          />
-          <DeleteContributionDialog dialog={dialog} setDialog={setDialog} />
-          <ModalWrapper
-            name="mintModal"
-            title="Mint Your DAO Contributions"
-            localOverlay={localOverlay}
-            size="3xl"
-            content={
-              <MintModal contributions={selectedRows} onFinish={deselectAll} />
-            }
-          />
-          <ModalWrapper
-            name="bulkDaoAttributeModal"
-            title="Attribute Contributions to a DAO"
-            localOverlay={localOverlay}
-            size="3xl"
-            content={<BulkDaoAttributeModal contributions={selectedRows} />}
-          />
-        </Box>
-      </Stack>
-    );
+        <DeleteContributionDialog dialog={dialog} setDialog={setDialog} />
+        <ModalWrapper
+          name="mintModal"
+          title="Mint Your DAO Contributions"
+          localOverlay={localOverlay}
+          size="3xl"
+          content={
+            <MintModal contributions={selectedRows} onFinish={deselectAll} />
+          }
+        />
+        <ModalWrapper
+          name="bulkDaoAttributeModal"
+          title="Attribute Contributions to a DAO"
+          localOverlay={localOverlay}
+          size="3xl"
+          content={<BulkDaoAttributeModal contributions={selectedRows} />}
+        />
+      </Box>
+    </Stack>
+  );
 };
 
 export default ContributionsTable;

--- a/apps/protocol-frontend/src/components/ContributionsTable.tsx
+++ b/apps/protocol-frontend/src/components/ContributionsTable.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Box,
+  Button,
   Flex,
   Link as ChakraLink,
   HStack,
@@ -10,6 +11,9 @@ import {
   Tooltip,
 } from '@chakra-ui/react';
 import { HiOutlineLink } from 'react-icons/hi';
+import { HiOutlineExternalLink } from 'react-icons/hi';
+import { FiEdit2, FiTrash2 } from 'react-icons/fi';
+import { Link } from 'react-router-dom';
 import { useUser } from '../contexts/UserContext';
 import {
   ColumnDef,
@@ -21,8 +25,6 @@ import {
   Getter,
   Row,
 } from '@tanstack/react-table';
-import { Link } from 'react-router-dom';
-import { FiEdit2, FiTrash2 } from 'react-icons/fi';
 import ModalWrapper from './ModalWrapper';
 import MintModal from './MintModal';
 import BulkDaoAttributeModal from './BulkDaoAttributeModal';
@@ -33,7 +35,7 @@ import EditContributionForm from './EditContributionForm';
 import { UIContribution } from '@govrn/ui-types';
 import DeleteContributionDialog from './DeleteContributionDialog';
 import { BLOCK_EXPLORER_URLS } from '../utils/constants';
-import { GovrnSpinner } from '@govrn/protocol-ui';
+import { GovrnCta, GovrnSpinner } from '@govrn/protocol-ui';
 import InfiniteScroll from 'react-infinite-scroll-component';
 import { formatDate, toDate } from '../utils/date';
 import { RowSelectionState } from '@tanstack/table-core';
@@ -268,59 +270,101 @@ const ContributionsTable = ({
     setSelectedRows(selectedContributions);
   }, [rowSelection, table]);
 
-  return (
-    <Stack>
-      <GlobalFilter
-        preGlobalFilteredRows={table.getPreFilteredRowModel().rows}
-        globalFilter={globalFilter}
-        setGlobalFilter={setGlobalFilter}
-      />
-      <Box width="100%" maxWidth="100vw" overflowX="auto">
-        <InfiniteScroll
-          dataLength={table.getRowModel().rows.length}
-          next={nextPage}
-          scrollThreshold={0.8}
-          hasMore={hasMoreItems}
-          loader={<GovrnSpinner />}
-        >
-          <GovrnTable controller={table} maxWidth="100vw" overflowX="auto" />
-        </InfiniteScroll>
-        <ModalWrapper
-          name="editContributionFormModal"
-          title="Update Contribution Activity"
-          localOverlay={localOverlay}
-          size="3xl"
-          content={
-            <EditContributionForm
-              contribution={
-                data.find(
-                  localContribution =>
-                    localContribution.id === selectedContribution,
-                )!
-              }
-            />
-          }
-        />
-        <DeleteContributionDialog dialog={dialog} setDialog={setDialog} />
-        <ModalWrapper
-          name="mintModal"
-          title="Mint Your DAO Contributions"
-          localOverlay={localOverlay}
-          size="3xl"
-          content={
-            <MintModal contributions={selectedRows} onFinish={deselectAll} />
-          }
-        />
-        <ModalWrapper
-          name="bulkDaoAttributeModal"
-          title="Attribute Contributions to a DAO"
-          localOverlay={localOverlay}
-          size="3xl"
-          content={<BulkDaoAttributeModal contributions={selectedRows} />}
-        />
-      </Box>
-    </Stack>
+  const CopyChildren = () => (
+    <Flex direction="column" alignItems="center" justifyContent="center">
+      <Text as="span">
+        Record a contribution and then try attributing it to a DAO or minting it
+      </Text>
+      <span role="img" aria-labelledby="winking emoji">
+        😉
+      </span>
+    </Flex>
   );
+
+  const ButtonChildren = () => (
+    <ChakraLink
+      as={Link}
+      to="/contributions"
+      _hover={{
+        textDecoration: 'none',
+      }}
+    >
+      <Button
+        variant="secondary"
+        size="md"
+        width={{ base: '100%', lg: 'auto' }}
+      >
+        Report Your First Contribution
+      </Button>
+    </ChakraLink>
+  );
+
+  console.log('data', data);
+  console.log('length', data.length);
+  if (!data.length)
+    return (
+      <GovrnCta
+        heading={`It's new contribution time!`}
+        emoji="⚡"
+        copy={<CopyChildren />}
+        children={<ButtonChildren />}
+      />
+    );
+
+  if (data.length)
+    return (
+      <Stack>
+        <GlobalFilter
+          preGlobalFilteredRows={table.getPreFilteredRowModel().rows}
+          globalFilter={globalFilter}
+          setGlobalFilter={setGlobalFilter}
+        />
+        <Box width="100%" maxWidth="100vw" overflowX="auto">
+          <InfiniteScroll
+            dataLength={table.getRowModel().rows.length}
+            next={nextPage}
+            scrollThreshold={0.8}
+            hasMore={hasMoreItems}
+            loader={<GovrnSpinner />}
+          >
+            <GovrnTable controller={table} maxWidth="100vw" overflowX="auto" />
+          </InfiniteScroll>
+          <ModalWrapper
+            name="editContributionFormModal"
+            title="Update Contribution Activity"
+            localOverlay={localOverlay}
+            size="3xl"
+            content={
+              <EditContributionForm
+                contribution={
+                  data.find(
+                    localContribution =>
+                      localContribution.id === selectedContribution,
+                  )!
+                }
+              />
+            }
+          />
+          <DeleteContributionDialog dialog={dialog} setDialog={setDialog} />
+          <ModalWrapper
+            name="mintModal"
+            title="Mint Your DAO Contributions"
+            localOverlay={localOverlay}
+            size="3xl"
+            content={
+              <MintModal contributions={selectedRows} onFinish={deselectAll} />
+            }
+          />
+          <ModalWrapper
+            name="bulkDaoAttributeModal"
+            title="Attribute Contributions to a DAO"
+            localOverlay={localOverlay}
+            size="3xl"
+            content={<BulkDaoAttributeModal contributions={selectedRows} />}
+          />
+        </Box>
+      </Stack>
+    );
 };
 
 export default ContributionsTable;

--- a/apps/protocol-frontend/src/components/ContributionsTableShell.tsx
+++ b/apps/protocol-frontend/src/components/ContributionsTableShell.tsx
@@ -190,14 +190,16 @@ const ContributionsTableShell = () => {
               borderRadius={{ base: 'none', md: 'lg' }}
             >
               <Stack spacing="5">
-                <Box paddingX={{ base: '4', md: '6' }} paddingTop={4}>
-                  <Text fontSize="lg" fontWeight="medium">
-                    My Minted Contributions{' '}
-                    <span role="img" aria-label="Sun emoji for Minted">
-                      🌞
-                    </span>
-                  </Text>
-                </Box>
+                {mintedContributions && mintedContributions.length > 0 ? (
+                  <Box paddingX={{ base: '4', md: '6' }} paddingTop={4}>
+                    <Text fontSize="lg" fontWeight="medium">
+                      My Minted Contributions{' '}
+                      <span role="img" aria-label="Sun emoji for Minted">
+                        🌞
+                      </span>
+                    </Text>
+                  </Box>
+                ) : null}
                 <Box width="100%" maxWidth="100vw" overflowX="auto">
                   <MintedContributionsTable
                     data={mintedContributions}
@@ -215,16 +217,18 @@ const ContributionsTableShell = () => {
               borderRadius={{ base: 'none', md: 'lg' }}
             >
               <Stack spacing="5">
-                <Box paddingX={{ base: '4', md: '6' }} paddingTop={4}>
-                  <Stack
-                    direction={{ base: 'column', md: 'row' }}
-                    justify="space-between"
-                  >
-                    <Text fontSize="lg" fontWeight="medium">
-                      Contribution Types
-                    </Text>
-                  </Stack>
-                </Box>
+                {allContributions && allContributions.length > 0 ? (
+                  <Box paddingX={{ base: '4', md: '6' }} paddingTop={4}>
+                    <Stack
+                      direction={{ base: 'column', md: 'row' }}
+                      justify="space-between"
+                    >
+                      <Text fontSize="lg" fontWeight="medium">
+                        Contribution Types
+                      </Text>
+                    </Stack>
+                  </Box>
+                ) : null}
                 <Box width="100%" maxWidth="100vw" overflowX="auto">
                   <ContributionTypesTable
                     contributionTypesData={allContributions}

--- a/apps/protocol-frontend/src/components/ContributionsTableShell.tsx
+++ b/apps/protocol-frontend/src/components/ContributionsTableShell.tsx
@@ -18,7 +18,6 @@ import { GovrnSpinner } from '@govrn/protocol-ui';
 import PageHeading from './PageHeading';
 import ContributionsTable from './ContributionsTable';
 import ContributionTypesTable from './ContributionTypesTable';
-import EmptyContributions from './EmptyContributions';
 import { useUser } from '../contexts/UserContext';
 import { useContributionInfiniteList } from '../hooks/useContributionList';
 import { UIContribution } from '@govrn/ui-types';
@@ -136,7 +135,6 @@ const ContributionsTableShell = () => {
       maxWidth="1200px"
     >
       <PageHeading>Contributions</PageHeading>
-      {/* {allContributions && allContributions.length > 0 ? ( */}
       <Tabs
         variant="soft-rounded"
         width="100%"

--- a/apps/protocol-frontend/src/components/ContributionsTableShell.tsx
+++ b/apps/protocol-frontend/src/components/ContributionsTableShell.tsx
@@ -85,6 +85,49 @@ const ContributionsTableShell = () => {
     setModals({ bulkDaoAttributeModal: true });
   };
 
+  if (isFetching && isMintedFetching && allContributions.length === 0) {
+    return <GovrnSpinner />;
+  }
+
+  const SelectedContributions = () =>
+    selectedContributions?.length === 0 ? (
+      <Alert
+        status="info"
+        width={{ base: '100%', lg: '60%' }}
+        borderRadius="md"
+      >
+        <AlertDescription>
+          <span
+            role="img"
+            aria-labelledby="Sun emoji for alert to select at least one contribution to attribute to a DAO or mint."
+          >
+            🌞
+          </span>{' '}
+          Please select at least one contribution to attribute to a DAO or mint.
+        </AlertDescription>
+      </Alert>
+    ) : (
+      <Stack direction="row" spacing={5}>
+        <Button
+          variant="primary"
+          size="md"
+          onClick={bulkDaoAttributeHandler}
+          disabled={selectedContributions?.length === 0}
+        >
+          Attribute to DAO
+        </Button>
+        <Button
+          variant="secondary"
+          size="md"
+          onClick={mintModalHandler}
+          disabled={selectedContributions?.length === 0}
+          data-testid="mint-btn-test"
+        >
+          {selectedContributions?.length > 1 ? 'Bulk Mint' : 'Mint'}
+        </Button>
+      </Stack>
+    );
+
   return (
     <Container
       paddingY={{ base: '4', md: '8' }}
@@ -93,159 +136,105 @@ const ContributionsTableShell = () => {
       maxWidth="1200px"
     >
       <PageHeading>Contributions</PageHeading>
-      {isFetching && isMintedFetching && allContributions.length === 0 ? (
-        <GovrnSpinner />
-      ) : allContributions && allContributions.length > 0 ? (
-        <Tabs
-          variant="soft-rounded"
-          width="100%"
-          maxWidth="100vw"
-          paddingX={{ base: 4, lg: 0 }}
-        >
-          <TabList>
-            <Tab>Staged</Tab>
-            <Tab isDisabled={mintedContributions.length === 0}>Minted</Tab>
-            <Tab> Types</Tab>
-          </TabList>
-          <TabPanels>
-            <TabPanel paddingX="0">
-              <Box
-                background="white"
-                boxShadow="sm"
-                borderRadius={{ base: 'none', md: 'lg' }}
-              >
-                {nonMintedContributions.length > 0 ? (
-                  <Stack spacing="5">
-                    <Box paddingX={{ base: '4', md: '6' }} paddingTop={4}>
-                      <Stack
-                        direction={{ base: 'column', md: 'row' }}
-                        justifyContent={{ base: 'center', lg: 'space-between' }}
-                        alignItems={{ base: 'flex-start', lg: 'center' }}
-                        width={{ base: '100%' }}
-                        maxWidth="100vw"
-                      >
-                        <Text fontSize="lg" fontWeight="medium">
-                          My Contributions
-                        </Text>
-                        {selectedContributions?.length === 0 ? (
-                          <Alert
-                            status="info"
-                            width={{ base: '100%', lg: '60%' }}
-                            borderRadius="md"
-                          >
-                            <AlertDescription>
-                              <span
-                                role="img"
-                                aria-labelledby="Sun emoji for alert to select at least one contribution to attribute to a DAO or mint."
-                              >
-                                🌞
-                              </span>{' '}
-                              Please select at least one contribution to
-                              attribute to a DAO or mint.
-                            </AlertDescription>
-                          </Alert>
-                        ) : (
-                          <Stack direction="row" spacing={5}>
-                            <Button
-                              variant="primary"
-                              size="md"
-                              onClick={bulkDaoAttributeHandler}
-                              disabled={selectedContributions?.length === 0}
-                            >
-                              Attribute to DAO
-                            </Button>
-                            <Button
-                              variant="secondary"
-                              size="md"
-                              onClick={mintModalHandler}
-                              disabled={selectedContributions?.length === 0}
-                              data-testid="mint-btn-test"
-                            >
-                              {selectedContributions?.length > 1
-                                ? 'Bulk Mint'
-                                : 'Mint'}
-                            </Button>
-                          </Stack>
-                        )}
-                      </Stack>
-                    </Box>
-                    <Box width="100%" maxWidth="100vw" overflowX="auto">
-                      <ContributionsTable
-                        data={nonMintedContributions}
-                        setSelectedContributions={setSelectedContributions}
-                        nextPage={fetchNextPage}
-                        hasMoreItems={hasNextPage || false}
-                      />
-                    </Box>
-                  </Stack>
-                ) : (
-                  <Stack
-                    direction={{ base: 'column', md: 'row' }}
-                    justifyContent={{ base: 'center', lg: 'space-between' }}
-                    alignItems={{ base: 'flex-start', lg: 'center' }}
-                    width={{ base: '100%' }}
-                    maxWidth="100vw"
-                  >
-                    <EmptyContributions />
-                  </Stack>
-                )}
-              </Box>
-            </TabPanel>
-            <TabPanel paddingX="0">
-              <Box
-                background="white"
-                boxShadow="sm"
-                borderRadius={{ base: 'none', md: 'lg' }}
-              >
-                <Stack spacing="5">
-                  <Box paddingX={{ base: '4', md: '6' }} paddingTop={4}>
-                    <Text fontSize="lg" fontWeight="medium">
-                      My Minted Contributions{' '}
-                      <span role="img" aria-label="Sun emoji for Minted">
-                        🌞
-                      </span>
-                    </Text>
-                  </Box>
-                  <Box width="100%" maxWidth="100vw" overflowX="auto">
-                    <MintedContributionsTable
-                      data={mintedContributions}
-                      nextPage={fetchMintedNextPage}
-                      hasMoreItems={hasMintedNextPage || false}
-                    />
-                  </Box>
-                </Stack>
-              </Box>
-            </TabPanel>
-            <TabPanel paddingX="0">
-              <Box
-                background="white"
-                boxShadow="sm"
-                borderRadius={{ base: 'none', md: 'lg' }}
-              >
-                <Stack spacing="5">
+      {/* {allContributions && allContributions.length > 0 ? ( */}
+      <Tabs
+        variant="soft-rounded"
+        width="100%"
+        maxWidth="100vw"
+        paddingX={{ base: 4, lg: 0 }}
+      >
+        <TabList>
+          <Tab>Staged</Tab>
+          <Tab>Minted</Tab>
+          <Tab>Types</Tab>
+        </TabList>
+        <TabPanels>
+          <TabPanel paddingX="0">
+            <Box
+              background="white"
+              boxShadow="sm"
+              borderRadius={{ base: 'none', md: 'lg' }}
+            >
+              <Stack spacing="5">
+                {allContributions && allContributions.length > 0 ? (
                   <Box paddingX={{ base: '4', md: '6' }} paddingTop={4}>
                     <Stack
                       direction={{ base: 'column', md: 'row' }}
-                      justify="space-between"
+                      justifyContent={{ base: 'center', lg: 'space-between' }}
+                      alignItems={{ base: 'flex-start', lg: 'center' }}
+                      width={{ base: '100%' }}
+                      maxWidth="100vw"
                     >
                       <Text fontSize="lg" fontWeight="medium">
-                        Contribution Types
+                        My Contributions
                       </Text>
+                      <SelectedContributions />
                     </Stack>
                   </Box>
-                  <Box width="100%" maxWidth="100vw" overflowX="auto">
-                    <ContributionTypesTable
-                      contributionTypesData={allContributions}
-                    />
-                  </Box>
-                </Stack>
-              </Box>
-            </TabPanel>
-          </TabPanels>
-        </Tabs>
-      ) : (
-        <EmptyContributions />
-      )}
+                ) : null}
+                <Box width="100%" maxWidth="100vw" overflowX="auto">
+                  <ContributionsTable
+                    data={nonMintedContributions}
+                    setSelectedContributions={setSelectedContributions}
+                    nextPage={fetchNextPage}
+                    hasMoreItems={hasNextPage || false}
+                  />
+                </Box>
+              </Stack>
+            </Box>
+          </TabPanel>
+          <TabPanel paddingX="0">
+            <Box
+              background="white"
+              boxShadow="sm"
+              borderRadius={{ base: 'none', md: 'lg' }}
+            >
+              <Stack spacing="5">
+                <Box paddingX={{ base: '4', md: '6' }} paddingTop={4}>
+                  <Text fontSize="lg" fontWeight="medium">
+                    My Minted Contributions{' '}
+                    <span role="img" aria-label="Sun emoji for Minted">
+                      🌞
+                    </span>
+                  </Text>
+                </Box>
+                <Box width="100%" maxWidth="100vw" overflowX="auto">
+                  <MintedContributionsTable
+                    data={mintedContributions}
+                    nextPage={fetchMintedNextPage}
+                    hasMoreItems={hasMintedNextPage || false}
+                  />
+                </Box>
+              </Stack>
+            </Box>
+          </TabPanel>
+          <TabPanel paddingX="0">
+            <Box
+              background="white"
+              boxShadow="sm"
+              borderRadius={{ base: 'none', md: 'lg' }}
+            >
+              <Stack spacing="5">
+                <Box paddingX={{ base: '4', md: '6' }} paddingTop={4}>
+                  <Stack
+                    direction={{ base: 'column', md: 'row' }}
+                    justify="space-between"
+                  >
+                    <Text fontSize="lg" fontWeight="medium">
+                      Contribution Types
+                    </Text>
+                  </Stack>
+                </Box>
+                <Box width="100%" maxWidth="100vw" overflowX="auto">
+                  <ContributionTypesTable
+                    contributionTypesData={allContributions}
+                  />
+                </Box>
+              </Stack>
+            </Box>
+          </TabPanel>
+        </TabPanels>
+      </Tabs>
     </Container>
   );
 };

--- a/apps/protocol-frontend/src/components/MintedContributionsTable.tsx
+++ b/apps/protocol-frontend/src/components/MintedContributionsTable.tsx
@@ -1,14 +1,5 @@
 import { useCallback, useMemo, useState } from 'react';
-import {
-  Box,
-  Button,
-  Flex,
-  Link as ChakraLink,
-  HStack,
-  IconButton,
-  Stack,
-  Text,
-} from '@chakra-ui/react';
+import { Box, Flex, HStack, IconButton, Stack, Text } from '@chakra-ui/react';
 import { useUser } from '../contexts/UserContext';
 import {
   ColumnDef,

--- a/apps/protocol-frontend/src/components/MintedContributionsTable.tsx
+++ b/apps/protocol-frontend/src/components/MintedContributionsTable.tsx
@@ -1,5 +1,14 @@
 import { useCallback, useMemo, useState } from 'react';
-import { Box, Flex, HStack, IconButton, Stack, Text } from '@chakra-ui/react';
+import {
+  Box,
+  Button,
+  Flex,
+  Link as ChakraLink,
+  HStack,
+  IconButton,
+  Stack,
+  Text,
+} from '@chakra-ui/react';
 import { useUser } from '../contexts/UserContext';
 import {
   ColumnDef,
@@ -15,7 +24,7 @@ import { Link } from 'react-router-dom';
 import GlobalFilter from './GlobalFilter';
 import { UIContribution } from '@govrn/ui-types';
 import DeleteContributionDialog from './DeleteContributionDialog';
-import { GovrnSpinner } from '@govrn/protocol-ui';
+import { GovrnCta, GovrnSpinner } from '@govrn/protocol-ui';
 import InfiniteScroll from 'react-infinite-scroll-component';
 import { formatDate, toDate } from '../utils/date';
 import { FiTrash2 } from 'react-icons/fi';
@@ -157,28 +166,56 @@ const MintedContributionsTable = ({
     debugAll: false,
   });
 
+  const CopyChildren = () => (
+    <Flex direction="column" alignItems="center" justifyContent="center">
+      <Text as="span">
+        Record a contribution and then attribute it to a DAO or minting it on
+        the Staged tab
+      </Text>
+      <span role="img" aria-labelledby="winking emoji">
+        😉
+      </span>
+    </Flex>
+  );
+
+  let component = (
+    <GovrnCta
+      heading={`It's minting time!`}
+      emoji="🔭"
+      copy={<CopyChildren />}
+    />
+  );
+
+  if (data.length) {
+    component = (
+      <Stack>
+        <GlobalFilter
+          preGlobalFilteredRows={table
+            .getPreFilteredRowModel()
+            .rows.map(r => r.original)}
+          globalFilter={globalFilter}
+          setGlobalFilter={setGlobalFilter}
+        />
+        <Box width="100%" maxWidth="100vw" overflowX="auto">
+          <InfiniteScroll
+            dataLength={table.getRowModel().rows.length}
+            next={nextPage}
+            scrollThreshold={0.8}
+            hasMore={hasMoreItems}
+            loader={<GovrnSpinner />}
+          >
+            <GovrnTable controller={table} maxWidth="100vw" overflowX="auto" />{' '}
+          </InfiniteScroll>
+        </Box>
+      </Stack>
+    );
+  }
+
   return (
-    <Stack>
-      <GlobalFilter
-        preGlobalFilteredRows={table
-          .getPreFilteredRowModel()
-          .rows.map(r => r.original)}
-        globalFilter={globalFilter}
-        setGlobalFilter={setGlobalFilter}
-      />
-      <Box width="100%" maxWidth="100vw" overflowX="auto">
-        <InfiniteScroll
-          dataLength={table.getRowModel().rows.length}
-          next={nextPage}
-          scrollThreshold={0.8}
-          hasMore={hasMoreItems}
-          loader={<GovrnSpinner />}
-        >
-          <GovrnTable controller={table} maxWidth="100vw" overflowX="auto" />{' '}
-        </InfiniteScroll>
-        <DeleteContributionDialog dialog={dialog} setDialog={setDialog} />
-      </Box>
-    </Stack>
+    <>
+      {component}
+      <DeleteContributionDialog dialog={dialog} setDialog={setDialog} />
+    </>
   );
 };
 


### PR DESCRIPTION
## Linear Ticket

- [ENG-947](https://linear.app/govrn/issue/ENG-947/empty-state-contributions)
- [ENG-949](https://linear.app/govrn/issue/ENG-949/empty-state-staged-contributions)
- [ENG-948](https://linear.app/govrn/issue/ENG-948/empty-state-minted-contributions)
- [ENG-970](https://linear.app/govrn/issue/ENG-970/empty-state-contribution-types)

## Description

- Adds in empty states for all tab views of the Contributions page (staged, minted, types) -- Types looks the same as Staged
- Moved the logic for empty states to the tables so we can preserve use of the tabs as they can be unique. Previously, our empty state hid _all_ of the UI, including tabs. This is more granular
- Added some conditional rendering logic to the ContributionsTableShell to display/hide some of the text based on the empty state since we're more granular about it now instead of an empty state for the page

## Screencaptures

Empty state:

https://user-images.githubusercontent.com/9438776/222509033-27ed024a-0887-468b-896a-241d127573d2.mp4




Non-empty state:

![contributions-non-empty-state](https://user-images.githubusercontent.com/9438776/222509012-0ab09087-b5d8-44fa-bcf2-5862378dd26a.gif)


