### PR TITLE
fix/form-refocus-fetching (ENG-959)

### DIFF
--- a/apps/protocol-frontend/src/components/DashboardShell.tsx
+++ b/apps/protocol-frontend/src/components/DashboardShell.tsx
@@ -210,7 +210,7 @@ const DashboardShell = () => {
                 color="gray.800"
                 fontWeight="normal"
               >
-                {} Contribution Bar Chart
+                Contribution Bar Chart
               </Heading>
               {contributionsCount ? (
                 <>

--- a/apps/protocol-frontend/src/components/EditContributionForm.tsx
+++ b/apps/protocol-frontend/src/components/EditContributionForm.tsx
@@ -77,14 +77,17 @@ const EditContributionForm = ({ contribution }: EditContributionFormProps) => {
     isError: guildActivityTypeListIsError,
     isLoading: guildActivityTypeListIsLoading,
   } = useGuildActivityTypesList({
-    first: 10000,
-    where: {
-      guild: {
-        is: {
-          id: { in: userData?.guild_users.map(g => g.guild_id) || [] },
+    args: {
+      first: 10000,
+      where: {
+        guild: {
+          is: {
+            id: { in: userData?.guild_users.map(g => g.guild_id) || [] },
+          },
         },
       },
     },
+    refetchOnWindowFocus: false,
   });
 
   const daoReset = useMemo(() => ({ label: 'No DAO', value: 0 }), []);

--- a/apps/protocol-frontend/src/components/ReportForm.tsx
+++ b/apps/protocol-frontend/src/components/ReportForm.tsx
@@ -176,6 +176,7 @@ const ReportForm = ({ onFinish }: { onFinish: () => void }) => {
     isLoading: useUserLoading,
   } = useUserGet({
     userId: userData?.id,
+    refetchOnWindowFocus: false,
   });
   const daoListOptions = useMemo(() => {
     return (
@@ -197,14 +198,17 @@ const ReportForm = ({ onFinish }: { onFinish: () => void }) => {
     isError: guildActivityTypeListIsError,
     isLoading: guildActivityTypeListIsLoading,
   } = useGuildActivityTypesList({
-    first: 10000,
-    where: {
-      guild: {
-        is: {
-          id: { in: userData?.guild_users.map(g => g.guild_id) || [] },
+    args: {
+      first: 10000,
+      where: {
+        guild: {
+          is: {
+            id: { in: userData?.guild_users.map(g => g.guild_id) || [] },
+          },
         },
       },
     },
+    refetchOnWindowFocus: false,
   });
 
   const combinedActivityTypeOptions = useMemo(() => {

--- a/apps/protocol-frontend/src/hooks/useDaosList.ts
+++ b/apps/protocol-frontend/src/hooks/useDaosList.ts
@@ -1,15 +1,16 @@
 import { useUser } from '../contexts/UserContext';
 import { useQuery } from '@tanstack/react-query';
 
-export const useDaosList = ({ ...args }) => {
+export const useDaosList = ({ ...args }, refetchOnWindowFocus?: boolean) => {
   const { govrnProtocol: govrn } = useUser();
 
-  const { isLoading, isFetching, isError, error, data } = useQuery(
-    ['userDaos', args],
-    async () => {
+  const { isLoading, isFetching, isError, error, data } = useQuery({
+    queryKey: ['userDaos', args],
+    queryFn: async () => {
       const data = await govrn.guild.list({ ...args });
       return data;
     },
-  );
+    refetchOnWindowFocus,
+  });
   return { isLoading, isError, isFetching, error, data };
 };

--- a/apps/protocol-frontend/src/hooks/useGuildActivityTypesList.tsx
+++ b/apps/protocol-frontend/src/hooks/useGuildActivityTypesList.tsx
@@ -2,16 +2,21 @@ import { useUser } from '../contexts/UserContext';
 import { useQuery } from '@tanstack/react-query';
 import { ListGuildActivityTypesQueryVariables } from '@govrn/protocol-client';
 
-export const useGuildActivityTypesList = (
-  args: ListGuildActivityTypesQueryVariables,
-) => {
+export const useGuildActivityTypesList = ({
+  args,
+  refetchOnWindowFocus,
+}: {
+  args?: ListGuildActivityTypesQueryVariables;
+  refetchOnWindowFocus?: boolean;
+}) => {
   const { govrnProtocol: govrn } = useUser();
-  const { isLoading, isFetching, isError, error, data } = useQuery(
-    ['guildActivityTypesList', args],
-    async () => {
-      const data = await govrn.guild.activity_type.list(args);
+  const { isLoading, isFetching, isError, error, data } = useQuery({
+    queryKey: ['guildActivityTypesList', args],
+    queryFn: async () => {
+      const data = await govrn.guild.activity_type.list(args ? args : {});
       return data;
     },
-  );
+    refetchOnWindowFocus,
+  });
   return { isLoading, isError, isFetching, error, data };
 };

--- a/apps/protocol-frontend/src/hooks/useUserGet.ts
+++ b/apps/protocol-frontend/src/hooks/useUserGet.ts
@@ -2,12 +2,18 @@ import { GovrnProtocol } from '@govrn/protocol-client';
 import { useQuery } from '@tanstack/react-query';
 import { PROTOCOL_URL } from '../utils/constants';
 
-export const useUserGet = ({ userId }: { userId?: number }) => {
+export const useUserGet = ({
+  userId,
+  refetchOnWindowFocus,
+}: {
+  userId?: number;
+  refetchOnWindowFocus?: boolean;
+}) => {
   const govrn = new GovrnProtocol(PROTOCOL_URL, { credentials: 'include' });
 
-  const { isLoading, isFetching, isError, error, data } = useQuery(
-    ['userGet', userId],
-    async () => {
+  const { isLoading, isFetching, isError, error, data } = useQuery({
+    queryKey: ['userGet', userId],
+    queryFn: async () => {
       if (!userId) {
         return null;
       }
@@ -20,7 +26,8 @@ export const useUserGet = ({ userId }: { userId?: number }) => {
       }
       return { ...resp, userDaos };
     },
-  );
+    refetchOnWindowFocus,
+  });
   return { isLoading, isError, isFetching, error, data };
 };
 

--- a/apps/protocol-frontend/src/pages/Dashboard.tsx
+++ b/apps/protocol-frontend/src/pages/Dashboard.tsx
@@ -110,11 +110,14 @@ const Dashboard = () => {
     isLoading: userContributionsLoading,
     isFetching: userContributionsFetching,
     isError: userContributionsError,
-  } = useContributionList({
-    where: {
-      user_id: { equals: userData?.id },
+  } = useContributionList(
+    {
+      where: {
+        user_id: { equals: userData?.id },
+      },
     },
-  });
+    false,
+  );
 
   if (userContributionsLoading || userContributionsFetching) {
     return <GovrnSpinner />;


### PR DESCRIPTION
## Linear Ticket

- [ENG-959](https://linear.app/govrn/issue/ENG-959/the-reporting-form-refreshes-every-time-you-leave-the-page-makes-an)

## Description

- Added an option for `refetchOnWindowFocus` to our hooks that we can set as needed
- Fixed the re-render issue for the ReportForm on the Dashboard route (was caused by a background refresh)
- Checked all other routes and they are fine

Additional future opportunities:

- We can align on our hooks param structure a bit more as there's some difference across them
- We can add `refetchOnWindowFocus` to the other hooks so we can set it as needed instead of relying on the default value

## Screencaptures

![fix-refocus](https://user-images.githubusercontent.com/9438776/224147286-b7576ea0-247c-4280-be81-396b1fa3165d.gif)

