### PR TITLE
fix/show-all-daos-user-dashboard (ENG-992)

### DIFF
--- a/apps/protocol-frontend/src/components/AttestationsTable.tsx
+++ b/apps/protocol-frontend/src/components/AttestationsTable.tsx
@@ -150,6 +150,13 @@ const AttestationsTable = ({
         header: 'DAO',
         accessorFn: contribution =>
           contribution.guilds[0]?.guild?.name ?? '---',
+        cell: ({ getValue }: { getValue: Getter<string> }) => {
+          return (
+            <Flex direction="column" wrap="wrap" paddingRight={1}>
+              <Text whiteSpace="normal">{getValue()}</Text>
+            </Flex>
+          );
+        },
       },
     ];
   }, [userData?.id]);

--- a/apps/protocol-frontend/src/components/ContributionsTable.tsx
+++ b/apps/protocol-frontend/src/components/ContributionsTable.tsx
@@ -175,7 +175,11 @@ const ContributionsTable = ({
         accessorFn: contribution =>
           contribution.guilds.map(guildObj => guildObj.guild.name)[0] ?? '---',
         cell: ({ getValue }: { getValue: Getter<string> }) => {
-          return <Text>{getValue()}</Text>;
+          return (
+            <Flex direction="column" wrap="wrap" paddingRight={1}>
+              <Text whiteSpace="normal">{getValue()}</Text>
+            </Flex>
+          );
         },
       },
       {

--- a/apps/protocol-frontend/src/components/DashboardShell.tsx
+++ b/apps/protocol-frontend/src/components/DashboardShell.tsx
@@ -15,6 +15,7 @@ import { useDaosList } from '../hooks/useDaosList';
 import useContributionCountInRange from '../hooks/useContributionCount';
 import { endOfDay, startOfDay } from 'date-fns';
 import { DEFAULT_DATE_RANGES } from '../utils/constants';
+import { LEFT_MEMBERSHIP_NAME } from '../utils/constants';
 import pluralize from 'pluralize';
 import useDisplayName from '../hooks/useDisplayName';
 
@@ -45,7 +46,21 @@ const DashboardShell = () => {
     isError: userDaosListIsError,
     data: userDaosListData,
   } = useDaosList({
-    where: { users: { some: { user_id: { equals: userData?.id || 0 } } } }, // show only user's DAOs
+    where: {
+      users: {
+        some: {
+          AND: [
+            { user_id: { equals: userData?.id || 0 } },
+            {
+              membershipStatus: {
+                isNot: { name: { equals: LEFT_MEMBERSHIP_NAME } },
+              },
+            },
+          ],
+        },
+      },
+    },
+    first: 1000,
   });
 
   const userDaoListOptions =

--- a/apps/protocol-frontend/src/components/MintedContributionsTable.tsx
+++ b/apps/protocol-frontend/src/components/MintedContributionsTable.tsx
@@ -117,7 +117,11 @@ const MintedContributionsTable = ({
         accessorFn: contribution =>
           contribution.guilds.map(guildObj => guildObj.guild.name)[0] ?? '---',
         cell: ({ getValue }: { getValue: Getter<string> }) => {
-          return <Text>{getValue()}</Text>;
+          return (
+            <Flex direction="column" wrap="wrap" paddingRight={1}>
+              <Text whiteSpace="normal">{getValue()}</Text>
+            </Flex>
+          );
         },
         invertSorting: true,
       },


### PR DESCRIPTION
## Linear Ticket

- [ENG-987](https://linear.app/govrn/issue/ENG-987/user-home-dashboard-isnt-showing-all-contributions)

## Description

- Changes the query used on the User Dashboard to show all of a user's DAOs (not just first 10) and omits ones that they've left. This list now matches the Profile
- Added wrapping to the DAOs column on the Contributions and Attestations tables

## Screencaptures

![remove-limit-on-dashboard-daos](https://user-images.githubusercontent.com/9438776/224434476-d08e569e-d5fd-408f-974d-3b3ad9ba2e01.gif)
