### PR TITLE
Change attestations to singular

### DIFF
--- a/apps/protocol-frontend/src/components/ContributionDetailShell.tsx
+++ b/apps/protocol-frontend/src/components/ContributionDetailShell.tsx
@@ -119,7 +119,10 @@ const ContributionDetailShell = ({
           <Flex paddingY={4}>
             <Stack spacing={2} width="full">
               <Heading as="h4" fontSize="lg" fontWeight="normal">
-                {contribution?.attestations.length} Attestations
+                {contribution?.attestations.length}
+                {contribution?.attestations.length > 1
+                  ? 'Attestations'
+                  : 'Attestation'}
               </Heading>
               <List listStyleType="none">
                 {contribution?.attestations.map(attestation => (


### PR DESCRIPTION
## Linear Ticket
https://linear.app/govrn/issue/ENG-956/attestations-is-plural-even-if-its-1-attestation
