### PR TITLE
Add Guild Import Modal

### DIFF
--- a/apps/protocol-frontend/src/components/GuildImportModal.tsx
+++ b/apps/protocol-frontend/src/components/GuildImportModal.tsx
@@ -1,0 +1,75 @@
+import { Box, Button, Heading, Stack } from '@chakra-ui/react';
+import { ControlledSelect, SelectOption as Option } from '@govrn/protocol-ui';
+import { useMemo, useState } from 'react';
+import { useGuildXYZListGuilds } from '../hooks/useGuildXYZListGuilds';
+import { useOverlay } from '../contexts/OverlayContext';
+
+interface GuildImportProps {
+  onSuccess: (guildId: number) => void;
+}
+
+export const GuildImportModal = ({ onSuccess }: GuildImportProps) => {
+  const { setModals } = useOverlay();
+
+  const [selectedGuild, setSelectedGuild] = useState<Option<number> | null>(
+    null,
+  );
+
+  const { data: guildList, isLoading: isGuildListLoading } =
+    useGuildXYZListGuilds();
+
+  const daoListOptions = useMemo(() => {
+    return (
+      guildList?.map(guild => ({
+        value: guild.id,
+        label: guild.name,
+        image: guild.imageUrl,
+      })) || []
+    );
+  }, [guildList]);
+
+  function handleGuildImport() {
+    console.log(
+      `::: publish message ${guildList?.find(
+        g => g.id === (selectedGuild ?? -1),
+      )}`,
+    );
+    onSuccess(selectedGuild?.value ?? -1);
+    setModals({});
+  }
+
+  return (
+    <Stack direction="column" width="100%" height="100%" spacing={8} py={8}>
+      <Heading as="h5" size="sm" width="80%">
+        {'Success! You are connected to Guild.xyz and can import your DAO here'}
+      </Heading>
+      <Box width="50%" height="100%">
+        <ControlledSelect
+          isDisabled={isGuildListLoading}
+          label="Select a DAO to Join"
+          isMulti={false}
+          onChange={dao => {
+            if (dao instanceof Array || !dao) {
+              return;
+            }
+            setSelectedGuild(dao);
+          }}
+          value={selectedGuild ?? null}
+          options={daoListOptions}
+          isSearchable={false}
+          isClearable
+        />
+      </Box>
+
+      <Button
+        variant="primary"
+        onClick={handleGuildImport}
+        isLoading={isGuildListLoading}
+        disabled={selectedGuild === null}
+        width={{ base: '100%', lg: 'min-content' }}
+      >
+        Import
+      </Button>
+    </Stack>
+  );
+};

--- a/apps/protocol-frontend/src/components/ProfileForm.tsx
+++ b/apps/protocol-frontend/src/components/ProfileForm.tsx
@@ -20,6 +20,9 @@ import ProfileDaos from './ProfileDaos';
 import { CgLinear, SiDiscord } from 'react-icons/all';
 import useDiscordUserDisconnect from '../hooks/useDiscordUserDisconnect';
 import { UIUser } from '@govrn/ui-types';
+import ModalWrapper from './ModalWrapper';
+import { useOverlay } from '../contexts/OverlayContext';
+import { GuildImportModal } from './GuildImportModal';
 
 const isDiscordConnected = (userData?: UIUser | null) =>
   userData?.discord_users?.length && userData.discord_users[0].active_token;
@@ -28,7 +31,9 @@ const isLinearConnected = (userData?: UIUser | null) =>
   userData?.linear_users?.length && userData.linear_users[0].active_token;
 
 const ProfileForm = () => {
+  const localOverlay = useOverlay();
   const { userData } = useUser();
+
   const { mutateAsync: disconnectLinearUser } = useLinearUserDisconnect();
   const { mutateAsync: disconnectDiscordUser } = useDiscordUserDisconnect();
   const { displayName } = useDisplayName();
@@ -39,6 +44,10 @@ const ProfileForm = () => {
     resolver: yupResolver(profileFormValidation),
   });
   const { handleSubmit, setValue } = localForm;
+
+  const showGuildImportModal = () => {
+    localOverlay.setModals({ guildImportModal: true });
+  };
 
   useEffect(() => {
     setValue('name', userData?.name ?? '');
@@ -140,6 +149,16 @@ const ProfileForm = () => {
         </Flex>
       </form>
       <ProfileDaos userId={userData?.id} userAddress={userData?.address} />
+
+      <Button
+        variant="primary"
+        onClick={() => {
+          showGuildImportModal();
+        }}
+      >
+        Guild Import
+      </Button>
+
       <form>
         <Flex
           justify="space-between"
@@ -248,6 +267,21 @@ const ProfileForm = () => {
           </Flex>
         </Flex>
       </form>
+      <ModalWrapper
+        name="guildImportModal"
+        title=""
+        localOverlay={localOverlay}
+        size="3xl"
+        content={
+          <GuildImportModal
+            onSuccess={guildId => {
+              // TODO: publish guild id to backend to import.
+              // TODO: maybe move this to the modal, and only reflect success here
+              console.log('TODO: publish guild id to backend to import');
+            }}
+          />
+        }
+      />
     </>
   );
 };

--- a/apps/protocol-frontend/src/contexts/OverlayContext.tsx
+++ b/apps/protocol-frontend/src/contexts/OverlayContext.tsx
@@ -1,30 +1,33 @@
 import React, { createContext, useState, useContext, ReactNode } from 'react';
 
 export type GovrnModals = {
-  bulkAttestationModal: boolean;
-  attestationModal: boolean;
-  bulkDaoAttributeModal: boolean;
-  mintModal: boolean;
-  editContributionFormModal: boolean;
   addAttestationFormModal: boolean;
-  storybookModal: boolean;
-  reportingFormModal: boolean;
+  attestationModal: boolean;
+  bulkAttestationModal: boolean;
+  bulkDaoAttributeModal: boolean;
   createDaoModal: boolean;
-  guildImportModal: boolean;
   csvImportModal: boolean;
+  editContributionFormModal: boolean;
+  guildImportModal: boolean;
+  importGuildModal: boolean;
+  mintModal: boolean;
+  reportingFormModal: boolean;
+  storybookModal: boolean;
 };
+
 const defaults: GovrnModals = {
   addAttestationFormModal: false,
   attestationModal: false,
   bulkAttestationModal: false,
   bulkDaoAttributeModal: false,
+  createDaoModal: false,
+  csvImportModal: false,
   editContributionFormModal: false,
+  guildImportModal: false,
+  importGuildModal: false,
   mintModal: false,
   reportingFormModal: false,
   storybookModal: false,
-  createDaoModal: false,
-  guildImportModal: false,
-  csvImportModal: false,
 };
 
 export type OverlayContextType = {

--- a/apps/protocol-frontend/src/hooks/useGuildXYZListGuilds.ts
+++ b/apps/protocol-frontend/src/hooks/useGuildXYZListGuilds.ts
@@ -1,0 +1,52 @@
+import { useQuery } from '@tanstack/react-query';
+import {
+  fetchGuild,
+  fetchGuildMemberships,
+  Guild,
+  GuildMembership,
+} from '../utils/guild-xyz';
+import { useUser } from '../contexts/UserContext';
+
+/**
+ * Fetch guilds the user has joined.
+ *
+ * Note: This hook is only using guild.xyz's API endpoint not `@guild/sdk`.
+ *       The reason is that `@guild/sdk` doesn't support fetching guilds joined
+ *       by a user.
+ */
+export const useGuildXYZListGuilds = () => {
+  const { userData } = useUser();
+
+  const { isLoading, isFetching, isError, error, data } = useQuery({
+    queryKey: ['guildXYZListGuilds'],
+    queryFn: async () => {
+      if (userData?.address === undefined) {
+        throw new Error('User not found');
+      }
+      // fetch user joined guilds' ids.
+      let guildMembership: GuildMembership[] = [];
+      try {
+        guildMembership = await fetchGuildMemberships(userData?.address);
+      } catch (error) {
+        throw new Error('Failed to get user joined guilds');
+      }
+
+      // fetch & map guilds' ids to guilds' basic info.
+      let guilds: Guild[] = [];
+      try {
+        guilds = await Promise.all(
+          guildMembership
+            // TODO: which guilds to show? all or only admin/owner?
+            .filter(guild => true /*guild.isAdmin  || guild.isOwner*/)
+            .map(async guild => await fetchGuild(guild.guildId)),
+        );
+      } catch (error) {
+        throw new Error('Failed to get guilds info');
+      }
+
+      return guilds;
+    },
+  });
+
+  return { isLoading, isError, isFetching, error, data };
+};

--- a/apps/protocol-frontend/src/utils/guild-xyz.ts
+++ b/apps/protocol-frontend/src/utils/guild-xyz.ts
@@ -1,0 +1,51 @@
+import axios from 'axios';
+
+export type GuildMembership = {
+  guildId: number;
+  roleIds: number[];
+  isAdmin: boolean;
+  isOwner: boolean;
+};
+
+export type Guild = {
+  id: number;
+  name: string;
+  urlName: string;
+  description: string;
+  imageUrl: string;
+};
+
+/**
+ * Fetches the guilds the user has joined. The response is an array of guild IDs,
+ * along with information on whether the user is an admin or owner of the guild.
+ *
+ * @param address The user's address associated with their guild.xyz account.
+ * @see {@link https://docs.guild.xyz/guild/guides/guild-api-alpha#get-guilds-joined-by-a-user Guild.xyz API docs}
+ */
+export const fetchGuildMemberships = async (
+  address: string,
+): Promise<GuildMembership[]> => {
+  const response = await axios.get(
+    `https://api.guild.xyz/v1/user/membership/${address}`,
+  );
+
+  if (response.status !== 200) {
+    throw new Error(`Failed to get user joined guilds.`);
+  }
+  return response.data as GuildMembership[];
+};
+
+/**
+ * Fetches basic information about a guild.
+ *
+ * @param guildId The guild's ID.
+ * @see {@link https://docs.guild.xyz/guild/guides/guild-api-alpha#get-a-guild-by-id Guild.xyz API docs}
+ */
+export const fetchGuild = async (guildId: number): Promise<Guild> => {
+  const response = await axios.get(`https://api.guild.xyz/v1/guild/${guildId}`);
+
+  if (response.status !== 200) {
+    throw new Error(`Failed to get guild.`);
+  }
+  return response.data as Guild;
+};


### PR DESCRIPTION
## Linear Ticket

- [ENG-716 - Guild Import modal](https://linear.app/govrn/issue/ENG-716/guild-import-modal)

## Description
This PR adds a Guild Import modal that loads associated joined guilds using the user's signed-in address. Unfortunately, as of this PR, the `@guild/sdk` does not support fetching guilds joined by the user, so an alternative approach has been taken.

### Considerations: 
There is an ongoing discussion regarding whether we should continue using NATS servers or switch to a Database SQL approach. This decision requires a collective assessment of the costs and benefits of continuing with NATS or opting for a readily conventional method.

It's recommended to monitor PR #364 to ensure its alignment with this job addition.

## Screencaptures

**TODO**
