### PR TITLE
Reposition Personal Types in dropdown Menus for Report & Edit Contribution Forms

### DIFF
--- a/apps/protocol-frontend/src/components/EditContributionForm.tsx
+++ b/apps/protocol-frontend/src/components/EditContributionForm.tsx
@@ -153,7 +153,7 @@ const EditContributionForm = ({ contribution }: EditContributionFormProps) => {
       })),
     ];
     if (personalTypes) {
-      results.push(personalTypes);
+      return [personalTypes, ...results];
     }
     return results;
   }, [guildActivityTypeListData, userActivityListData]);

--- a/apps/protocol-frontend/src/components/EditContributionForm.tsx
+++ b/apps/protocol-frontend/src/components/EditContributionForm.tsx
@@ -143,7 +143,7 @@ const EditContributionForm = ({ contribution }: EditContributionFormProps) => {
       : null;
 
     const results = [
-      ...DEFAULT_ACTIVITY_TYPES_OPTIONS,
+      DEFAULT_ACTIVITY_TYPES_OPTIONS,
       ...Object.keys(groupedActivityTypes).map(key => ({
         label: key,
         options: groupedActivityTypes[key].map(item => ({

--- a/apps/protocol-frontend/src/components/ReportForm.tsx
+++ b/apps/protocol-frontend/src/components/ReportForm.tsx
@@ -265,8 +265,9 @@ const ReportForm = ({ onFinish }: { onFinish: () => void }) => {
       })),
     ];
     if (personalTypes) {
-      results.push(personalTypes);
+      return [personalTypes, ...results];
     }
+
     return results;
   }, [guildActivityTypeListData, userActivityListData]);
 

--- a/apps/protocol-frontend/src/components/ReportForm.tsx
+++ b/apps/protocol-frontend/src/components/ReportForm.tsx
@@ -255,7 +255,7 @@ const ReportForm = ({ onFinish }: { onFinish: () => void }) => {
         }
       : null;
     const results = [
-      ...DEFAULT_ACTIVITY_TYPES_OPTIONS,
+      DEFAULT_ACTIVITY_TYPES_OPTIONS,
       ...Object.keys(groupedActivityTypes).map(key => ({
         label: key,
         options: groupedActivityTypes[key].map(item => ({

--- a/apps/protocol-frontend/src/utils/constants.ts
+++ b/apps/protocol-frontend/src/utils/constants.ts
@@ -28,14 +28,16 @@ export const DEFAULT_ACTIVITY_TYPES = [
   'Other',
 ];
 
-export const DEFAULT_ACTIVITY_TYPES_OPTIONS = DEFAULT_ACTIVITY_TYPES.map(
-  activity => {
+export const DEFAULT_ACTIVITY_TYPES_OPTIONS = {
+  label: 'Default',
+  options: DEFAULT_ACTIVITY_TYPES.map(activity => {
     return {
       label: activity,
       value: activity,
     };
-  },
-);
+  }),
+};
+
 export const ADDRESS_IMPORT_MAX = 1000;
 
 export const ATTESTATION_VERIFIED_FILTER_OPTIONS = [


### PR DESCRIPTION
## Linear Ticket

[ENG-1058 - Move personal types to the top of the dropdown](https://linear.app/govrn/issue/ENG-1058/move-personal-types-to-the-top-of-the-dropdown)


## Description
This PR includes the following updates:
- In both Edit and Report Contribution Forms, personal types have been moved to the top of the dropdown menus for improved accessibility.
- A "Default" label has been added to the default options in the dropdowns to clearly distinguish them from other options.

## Screencaptures
![2023-05-01 14-41-35 2023-05-01 14_43_13](https://user-images.githubusercontent.com/12991700/235447264-f93adfaf-6e6d-4b8e-b71a-de1ef021a72b.gif)
