### PR TITLE
Handle empty attestation state for users with no contributions to attest

### DIFF
--- a/apps/protocol-frontend/src/components/AttestationsTable.tsx
+++ b/apps/protocol-frontend/src/components/AttestationsTable.tsx
@@ -31,6 +31,92 @@ import GovrnTable from './GovrnTable';
 import MemberDisplayName from './MemberDisplayName';
 import VerificationHover from './VerificationHover';
 import AttestationFilter from './AttestationFilter';
+import useUserGet from '../hooks/useUserGet';
+
+const AttestationsLearnMoreButton = () => (
+  <Link
+    href="https://govrn.gitbook.io/govrn-docs/attestations/attestations"
+    isExternal
+    textDecoration="none"
+    _hover={{
+      textDecoration: 'none',
+    }}
+  >
+    <Button variant="tertiary" size="md" leftIcon={<HiOutlineExternalLink />}>
+      Learn More About Attestations
+    </Button>
+  </Link>
+);
+const NoDAOsJoinedCta = () => (
+  <GovrnCta
+    heading={"You aren't in any DAOs yet"}
+    emoji="🙏"
+    copy={
+      <Flex direction="column" alignItems="center" justifyContent="center">
+        <Text>
+          You'll need other collaborators to be part of a DAO! There are no
+          contributions for you to attest to yet.
+        </Text>
+        <Text>
+          Make sure you're part of a DAO and attest to other people's minted
+          contributions.
+        </Text>
+      </Flex>
+    }
+    children={
+      <>
+        <Link
+          as={RouterLink}
+          to="/profile"
+          state={{ targetId: 'myDaos' }}
+          _hover={{
+            textDecoration: 'none',
+          }}
+        >
+          <Button
+            variant="primary"
+            size="md"
+            width={{ base: '100%', lg: 'auto' }}
+          >
+            Join a DAO From Your Profile
+          </Button>
+        </Link>
+        <Link
+          as={RouterLink}
+          to="/contributions"
+          _hover={{
+            textDecoration: 'none',
+          }}
+        >
+          <Button
+            variant="secondary"
+            size="md"
+            width={{ base: '100%', lg: 'auto' }}
+          >
+            Mint Your Contributions
+          </Button>
+        </Link>
+        <AttestationsLearnMoreButton />
+      </>
+    }
+  />
+);
+
+const NoContributionsToAttestCta = () => (
+  <GovrnCta
+    heading={'You are a super attestor'}
+    emoji="🎉"
+    copy={
+      <Flex direction="column" alignItems="center" justifyContent="center">
+        <Text>
+          You'll need other collaborators to be part of a DAO! There are no
+          contributions for you to attest to yet.
+        </Text>
+      </Flex>
+    }
+    children={<AttestationsLearnMoreButton />}
+  />
+);
 
 const AttestationsTable = ({
   data,
@@ -44,6 +130,14 @@ const AttestationsTable = ({
   attestationFilter: (filterValue: string) => void;
 }) => {
   const { userData } = useUser();
+  const { data: userGuildsData } = useUserGet({
+    userId: userData?.id,
+  });
+
+  const [hasUserJoinedAnyDao] = useState(
+    0 < (userGuildsData?.guild_users?.length ?? 0),
+  );
+
   const { setModals } = useOverlay();
   const localOverlay = useOverlay();
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
@@ -287,7 +381,7 @@ const AttestationsTable = ({
             <Flex direction="column" wrap="wrap" paddingRight={1}>
               <Pill
                 label={daoName}
-                icon={contributionVerifiedForDao === true ? 'checkmark' : null}
+                icon={contributionVerifiedForDao ? 'checkmark' : null}
                 status={contributionVerifiedForDao ? 'primary' : 'tertiary'}
               />
             </Flex>
@@ -332,79 +426,12 @@ const AttestationsTable = ({
     }
   }, [selectedRows, setModals]);
 
-  const CopyChildren = () => (
-    <Flex direction="column" alignItems="center" justifyContent="center">
-      <Text>
-        You'll need other collaborators to be part of a DAO! There are no
-        contributions for you to attest to yet.
-      </Text>
-      <Text>
-        Make sure you're part of a DAO and attest to other people's minted
-        contributions.
-      </Text>
-    </Flex>
+  let component = hasUserJoinedAnyDao ? (
+    <NoContributionsToAttestCta />
+  ) : (
+    <NoDAOsJoinedCta />
   );
 
-  const ButtonChildren = () => (
-    <>
-      <Link
-        as={RouterLink}
-        to="/profile"
-        state={{ targetId: 'myDaos' }}
-        _hover={{
-          textDecoration: 'none',
-        }}
-      >
-        <Button
-          variant="primary"
-          size="md"
-          width={{ base: '100%', lg: 'auto' }}
-        >
-          Join a DAO From Your Profile
-        </Button>
-      </Link>
-      <Link
-        as={RouterLink}
-        to="/contributions"
-        _hover={{
-          textDecoration: 'none',
-        }}
-      >
-        <Button
-          variant="secondary"
-          size="md"
-          width={{ base: '100%', lg: 'auto' }}
-        >
-          Mint Your Contributions
-        </Button>
-      </Link>
-      <Link
-        href="https://govrn.gitbook.io/govrn-docs/attestations/attestations"
-        isExternal
-        textDecoration="none"
-        _hover={{
-          textDecoration: 'none',
-        }}
-      >
-        <Button
-          variant="tertiary"
-          size="md"
-          leftIcon={<HiOutlineExternalLink />}
-        >
-          Learn More About Attestations
-        </Button>
-      </Link>
-    </>
-  );
-
-  let component = (
-    <GovrnCta
-      heading={`You aren't in any DAOs yet`}
-      emoji="🙏"
-      copy={<CopyChildren />}
-      children={<ButtonChildren />}
-    />
-  );
   if (data.length) {
     component = (
       <>

--- a/apps/protocol-frontend/src/components/AttestationsTable.tsx
+++ b/apps/protocol-frontend/src/components/AttestationsTable.tsx
@@ -109,8 +109,7 @@ const NoContributionsToAttestCta = () => (
     copy={
       <Flex direction="column" alignItems="center" justifyContent="center">
         <Text>
-          You'll need other collaborators to be part of a DAO! There are no
-          contributions for you to attest to yet.
+          Waiting for more minted contributions from your fellow DAO members.
         </Text>
       </Flex>
     }


### PR DESCRIPTION

## Linear Ticket

[ENG-1009 - Attestations Empty state is triggering](https://linear.app/govrn/issue/ENG-1009/attestations-empty-state-is-triggering)

## Description

Previously, an incorrect message was displayed when a user had joined one or more DAOs but had no contributions to attest. This PR fixes it by providing a clearer message and CTA for this case.


## Screencaptures
<img width="1612" alt="Screenshot 2023-05-01 at 5 58 22 PM" src="https://user-images.githubusercontent.com/12991700/235472386-7eaddc0a-cf4b-4e99-897a-0d2aa7d533e3.png">
