### PR TITLE
[Eng-1050] Restrict DAO dashboard access to Members and Admins only

### DIFF
--- a/apps/protocol-frontend/src/Routes.tsx
+++ b/apps/protocol-frontend/src/Routes.tsx
@@ -26,7 +26,7 @@ import DiscordSignatureLayout from './components/DiscordSignatureLayout';
 import {
   CONTRIBUTION_NEW_DOMAIN,
   CONTRIBUTION_NEW_STAGING_DOMAIN,
-  LEFT_MEMBERSHIP_NAME,
+  MembershipStatusesNames,
 } from './utils/constants';
 
 const RequireActiveUser = ({ children }: { children: JSX.Element }) => {
@@ -51,7 +51,7 @@ const Routes = () => {
   const url = new URL(window.location.href);
   const userDaosFilter = new Map();
   userDaos?.forEach(dao => {
-    if (dao?.membershipStatus.name !== LEFT_MEMBERSHIP_NAME) {
+    if (dao?.membershipStatus.name !== MembershipStatusesNames.Left) {
       userDaosFilter.set(dao.guild_id, dao);
     }
   });

--- a/apps/protocol-frontend/src/components/AttestationsTableShell.tsx
+++ b/apps/protocol-frontend/src/components/AttestationsTableShell.tsx
@@ -28,7 +28,10 @@ const AttestationsTableShell = () => {
     useState('showAll');
   const guildIds = userData?.guild_users
     ? userData?.guild_users
-        .filter(guild => guild?.membershipStatus.name !== MembershipStatusesNames.Left)
+        .filter(
+          guild =>
+            guild?.membershipStatus.name !== MembershipStatusesNames.Left,
+        )
         .map(guild => guild.guild_id)
     : []; // filter out the daos a user has left
 

--- a/apps/protocol-frontend/src/components/AttestationsTableShell.tsx
+++ b/apps/protocol-frontend/src/components/AttestationsTableShell.tsx
@@ -17,7 +17,7 @@ import { useContributionInfiniteList } from '../hooks/useContributionList';
 import { mergePages } from '../utils/arrays';
 import { useUser } from '../contexts/UserContext';
 import {
-  LEFT_MEMBERSHIP_NAME,
+  MembershipStatusesNames,
   VERIFIED_CONTRIBUTION_NAME,
 } from '../utils/constants';
 
@@ -28,7 +28,7 @@ const AttestationsTableShell = () => {
     useState('showAll');
   const guildIds = userData?.guild_users
     ? userData?.guild_users
-        .filter(guild => guild?.membershipStatus.name !== LEFT_MEMBERSHIP_NAME)
+        .filter(guild => guild?.membershipStatus.name !== MembershipStatusesNames.Left)
         .map(guild => guild.guild_id)
     : []; // filter out the daos a user has left
 

--- a/apps/protocol-frontend/src/components/DaoDashboardShell.tsx
+++ b/apps/protocol-frontend/src/components/DaoDashboardShell.tsx
@@ -30,9 +30,9 @@ import useUserGet from '../hooks/useUserGet';
 import GovrnAlertDialog from './GovrnAlertDialog';
 import {
   TODAY_DATE,
-  LEFT_MEMBERSHIP_NAME,
   YEAR,
   DEFAULT_DATE_RANGES,
+  MembershipStatusesNames,
 } from '../utils/constants';
 
 const CUSTOM_VALUE = 0;
@@ -121,7 +121,7 @@ const DaoDashboardShell = ({
     await updateDaoMemberStatus({
       userId: userData?.id ?? -1,
       guildId: daoId,
-      membershipStatus: LEFT_MEMBERSHIP_NAME,
+      membershipStatus: MembershipStatusesNames.Left,
     });
 
     navigate('/dashboard');

--- a/apps/protocol-frontend/src/components/DaoSettingsMembersTable.tsx
+++ b/apps/protocol-frontend/src/components/DaoSettingsMembersTable.tsx
@@ -33,7 +33,7 @@ import { RowSelectionState } from '@tanstack/table-core';
 import { SortOrder } from '@govrn/protocol-client';
 import GovrnTable from './GovrnTable';
 import { displayAddress } from '../utils/web3';
-import { MembershipStatusesNames } from "../utils/constants";
+import { MembershipStatusesNames } from '../utils/constants';
 
 interface DaoSettingsMembersTableProps {
   daoId: number;
@@ -69,7 +69,9 @@ const DaoSettingsMembersTable = ({ daoId }: DaoSettingsMembersTableProps) => {
   } = useDaoUsersInfiniteList({
     where: {
       guild_id: { equals: daoId },
-      membershipStatus: { isNot: { name: { equals: MembershipStatusesNames.Left } } },
+      membershipStatus: {
+        isNot: { name: { equals: MembershipStatusesNames.Left } },
+      },
     },
 
     orderBy: [

--- a/apps/protocol-frontend/src/components/DaoSettingsMembersTable.tsx
+++ b/apps/protocol-frontend/src/components/DaoSettingsMembersTable.tsx
@@ -33,7 +33,7 @@ import { RowSelectionState } from '@tanstack/table-core';
 import { SortOrder } from '@govrn/protocol-client';
 import GovrnTable from './GovrnTable';
 import { displayAddress } from '../utils/web3';
-import { LEFT_MEMBERSHIP_NAME } from '../utils/constants';
+import { MembershipStatusesNames } from "../utils/constants";
 
 interface DaoSettingsMembersTableProps {
   daoId: number;
@@ -69,7 +69,7 @@ const DaoSettingsMembersTable = ({ daoId }: DaoSettingsMembersTableProps) => {
   } = useDaoUsersInfiniteList({
     where: {
       guild_id: { equals: daoId },
-      membershipStatus: { isNot: { name: { equals: LEFT_MEMBERSHIP_NAME } } },
+      membershipStatus: { isNot: { name: { equals: MembershipStatusesNames.Left } } },
     },
 
     orderBy: [

--- a/apps/protocol-frontend/src/components/DashboardShell.tsx
+++ b/apps/protocol-frontend/src/components/DashboardShell.tsx
@@ -10,7 +10,7 @@ import {
 import { subWeeks } from 'date-fns';
 import ContributionsHeatMap from './ContributionsHeatMap';
 import ContributionsBarChart from './ContributionsBarChart';
-import { MembershipStatusesNames, UNASSIGNED } from "../utils/constants";
+import { MembershipStatusesNames, UNASSIGNED } from '../utils/constants';
 import { useDaosList } from '../hooks/useDaosList';
 import useContributionCountInRange from '../hooks/useContributionCount';
 import { endOfDay, startOfDay } from 'date-fns';

--- a/apps/protocol-frontend/src/components/DashboardShell.tsx
+++ b/apps/protocol-frontend/src/components/DashboardShell.tsx
@@ -10,12 +10,11 @@ import {
 import { subWeeks } from 'date-fns';
 import ContributionsHeatMap from './ContributionsHeatMap';
 import ContributionsBarChart from './ContributionsBarChart';
-import { UNASSIGNED } from '../utils/constants';
+import { MembershipStatusesNames, UNASSIGNED } from "../utils/constants";
 import { useDaosList } from '../hooks/useDaosList';
 import useContributionCountInRange from '../hooks/useContributionCount';
 import { endOfDay, startOfDay } from 'date-fns';
 import { DEFAULT_DATE_RANGES } from '../utils/constants';
-import { LEFT_MEMBERSHIP_NAME } from '../utils/constants';
 import pluralize from 'pluralize';
 import useDisplayName from '../hooks/useDisplayName';
 
@@ -53,7 +52,7 @@ const DashboardShell = () => {
             { user_id: { equals: userData?.id || 0 } },
             {
               membershipStatus: {
-                isNot: { name: { equals: LEFT_MEMBERSHIP_NAME } },
+                isNot: { name: { equals: MembershipStatusesNames.Left } },
               },
             },
           ],

--- a/apps/protocol-frontend/src/components/ProfileDaos.tsx
+++ b/apps/protocol-frontend/src/components/ProfileDaos.tsx
@@ -22,7 +22,7 @@ import DaoCard from './DaoCard';
 import { SortOrder } from '@govrn/protocol-client';
 import { mergeMemberPages } from '../utils/arrays';
 import { UIGuildUsers } from '@govrn/ui-types';
-import { LEFT_MEMBERSHIP_NAME } from '../utils/constants';
+import { MembershipStatusesNames } from '../utils/constants';
 import useUserGet from '../hooks/useUserGet';
 
 interface ProfileDaoProps {
@@ -65,7 +65,7 @@ const ProfileDaos = ({ userId, userAddress }: ProfileDaoProps) => {
                   },
                   {
                     membershipStatus: {
-                      is: { name: { equals: LEFT_MEMBERSHIP_NAME } },
+                      is: { name: { equals: MembershipStatusesNames.Left } },
                     },
                   },
                 ],
@@ -90,7 +90,7 @@ const ProfileDaos = ({ userId, userAddress }: ProfileDaoProps) => {
     {
       where: {
         user_id: { equals: userId },
-        membershipStatus: { isNot: { name: { equals: LEFT_MEMBERSHIP_NAME } } },
+        membershipStatus: { isNot: { name: { equals: MembershipStatusesNames.Left } } },
       },
 
       orderBy: [

--- a/apps/protocol-frontend/src/components/ProfileDaos.tsx
+++ b/apps/protocol-frontend/src/components/ProfileDaos.tsx
@@ -90,7 +90,9 @@ const ProfileDaos = ({ userId, userAddress }: ProfileDaoProps) => {
     {
       where: {
         user_id: { equals: userId },
-        membershipStatus: { isNot: { name: { equals: MembershipStatusesNames.Left } } },
+        membershipStatus: {
+          isNot: { name: { equals: MembershipStatusesNames.Left } },
+        },
       },
 
       orderBy: [

--- a/apps/protocol-frontend/src/components/Sidebar.tsx
+++ b/apps/protocol-frontend/src/components/Sidebar.tsx
@@ -2,8 +2,8 @@ import {
   TWITTER_LINK,
   DISCORD_LINK,
   FEEDBACK_LINK,
-  LEFT_MEMBERSHIP_NAME,
   DOCS_LINK,
+  MembershipStatusesNames,
 } from '../utils/constants';
 import { Link, useLocation } from 'react-router-dom';
 import {
@@ -49,7 +49,7 @@ const Sidebar = () => {
   const { data: daosUsersListData } = useDaoUsersList({
     where: {
       user_id: { equals: userData?.id },
-      membershipStatus: { isNot: { name: { equals: LEFT_MEMBERSHIP_NAME } } },
+      membershipStatus: { isNot: { name: { equals: MembershipStatusesNames.Left } } },
     },
     orderBy: [{ membershipStatus: { name: 'asc' } }, { favorite: 'desc' }],
   });

--- a/apps/protocol-frontend/src/components/Sidebar.tsx
+++ b/apps/protocol-frontend/src/components/Sidebar.tsx
@@ -49,7 +49,9 @@ const Sidebar = () => {
   const { data: daosUsersListData } = useDaoUsersList({
     where: {
       user_id: { equals: userData?.id },
-      membershipStatus: { isNot: { name: { equals: MembershipStatusesNames.Left } } },
+      membershipStatus: {
+        isNot: { name: { equals: MembershipStatusesNames.Left } },
+      },
     },
     orderBy: [{ membershipStatus: { name: 'asc' } }, { favorite: 'desc' }],
   });

--- a/apps/protocol-frontend/src/hooks/useDaoUserUpdate.ts
+++ b/apps/protocol-frontend/src/hooks/useDaoUserUpdate.ts
@@ -1,7 +1,7 @@
 import { useUser } from '../contexts/UserContext';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useGovrnToast } from '@govrn/protocol-ui';
-import { LEFT_MEMBERSHIP_NAME } from '../utils/constants';
+import { MembershipStatusesNames } from '../utils/constants';
 
 interface DaoUserUpdateProps {
   userId: number;
@@ -48,7 +48,7 @@ export const useDaoUserUpdate = () => {
 
         const toastSuccessId = 'dao-user-create-success';
         if (!toast.isActive(toastSuccessId)) {
-          if (membershipStatus === LEFT_MEMBERSHIP_NAME) {
+          if (membershipStatus === MembershipStatusesNames.Left) {
             toast.success({
               id: toastSuccessId,
               title: 'Leaving DAO',

--- a/apps/protocol-frontend/src/hooks/useUserGet.ts
+++ b/apps/protocol-frontend/src/hooks/useUserGet.ts
@@ -1,6 +1,9 @@
 import { GovrnProtocol } from '@govrn/protocol-client';
 import { useQuery } from '@tanstack/react-query';
 import { PROTOCOL_URL } from '../utils/constants';
+import { UIUser } from '@govrn/ui-types';
+
+type Guild = UIUser['guild_users'][number];
 
 export const useUserGet = ({
   userId,
@@ -18,7 +21,7 @@ export const useUserGet = ({
         return null;
       }
       const resp = await govrn.user.get(userId);
-      const userDaos = new Map();
+      const userDaos = new Map<number, Guild>();
       if (resp?.guild_users) {
         resp?.guild_users.forEach(guildUser => {
           userDaos.set(guildUser.guild_id, guildUser);

--- a/apps/protocol-frontend/src/pages/DaoDashboard.tsx
+++ b/apps/protocol-frontend/src/pages/DaoDashboard.tsx
@@ -6,6 +6,7 @@ import SiteLayout from '../components/SiteLayout';
 import useUserGet from '../hooks/useUserGet';
 import DaoDashboardShell from '../components/DaoDashboardShell';
 import { LEFT_MEMBERSHIP_NAME } from '../utils/constants';
+import { useMemo } from 'react';
 
 const DaoDashboard = () => {
   const { isConnected } = useAccount();
@@ -15,13 +16,11 @@ const DaoDashboard = () => {
   const userDaos = data?.userDaos;
 
   const { guildId } = useParams();
-
   const currentDao = userDaos?.get(parseInt(guildId ? guildId : ''));
 
-  const isDaoMember =
-    userDaos?.has(parseInt(guildId ?? '')) === true &&
-    userDaos?.get(parseInt(guildId ?? ''))?.membershipStatus?.name !==
-      LEFT_MEMBERSHIP_NAME;
+  const isDaoMember = useMemo(() => {
+    return currentDao?.membershipStatus?.name !== LEFT_MEMBERSHIP_NAME;
+  }, [currentDao]);
 
   return (
     <SiteLayout>

--- a/apps/protocol-frontend/src/pages/DaoDashboard.tsx
+++ b/apps/protocol-frontend/src/pages/DaoDashboard.tsx
@@ -5,10 +5,7 @@ import { useAuth } from '../contexts/AuthContext';
 import SiteLayout from '../components/SiteLayout';
 import useUserGet from '../hooks/useUserGet';
 import DaoDashboardShell from '../components/DaoDashboardShell';
-import {
-  ADMIN_MEMBERSHIP_NAME,
-  MEMBER_MEMBERSHIP_NAME,
-} from '../utils/constants';
+import { MembershipStatusesNames } from '../utils/constants';
 import { useMemo } from 'react';
 
 const DaoDashboard = () => {
@@ -23,8 +20,8 @@ const DaoDashboard = () => {
 
   const isDaoMember = useMemo(() => {
     return (
-      currentDao?.membershipStatus?.name === MEMBER_MEMBERSHIP_NAME ||
-      currentDao?.membershipStatus?.name === ADMIN_MEMBERSHIP_NAME
+      currentDao?.membershipStatus?.name === MembershipStatusesNames.Member ||
+      currentDao?.membershipStatus?.name === MembershipStatusesNames.Admin
     );
   }, [currentDao]);
 

--- a/apps/protocol-frontend/src/pages/DaoDashboard.tsx
+++ b/apps/protocol-frontend/src/pages/DaoDashboard.tsx
@@ -5,7 +5,10 @@ import { useAuth } from '../contexts/AuthContext';
 import SiteLayout from '../components/SiteLayout';
 import useUserGet from '../hooks/useUserGet';
 import DaoDashboardShell from '../components/DaoDashboardShell';
-import { LEFT_MEMBERSHIP_NAME } from '../utils/constants';
+import {
+  ADMIN_MEMBERSHIP_NAME,
+  MEMBER_MEMBERSHIP_NAME,
+} from '../utils/constants';
 import { useMemo } from 'react';
 
 const DaoDashboard = () => {
@@ -19,7 +22,10 @@ const DaoDashboard = () => {
   const currentDao = userDaos?.get(parseInt(guildId ? guildId : ''));
 
   const isDaoMember = useMemo(() => {
-    return currentDao?.membershipStatus?.name !== LEFT_MEMBERSHIP_NAME;
+    return (
+      currentDao?.membershipStatus?.name === MEMBER_MEMBERSHIP_NAME ||
+      currentDao?.membershipStatus?.name === ADMIN_MEMBERSHIP_NAME
+    );
   }, [currentDao]);
 
   return (

--- a/apps/protocol-frontend/src/utils/constants.ts
+++ b/apps/protocol-frontend/src/utils/constants.ts
@@ -75,4 +75,7 @@ export const DOCS_LINK =
   'https://govrn.gitbook.io/govrn-docs/overview/welcome-to-govrn';
 
 export const LEFT_MEMBERSHIP_NAME = 'Left';
+export const ADMIN_MEMBERSHIP_NAME = 'Admin';
+export const MEMBER_MEMBERSHIP_NAME = 'Member';
+
 export const VERIFIED_CONTRIBUTION_NAME = 'Verified';

--- a/apps/protocol-frontend/src/utils/constants.ts
+++ b/apps/protocol-frontend/src/utils/constants.ts
@@ -74,8 +74,15 @@ export const FEEDBACK_LINK = 'https://forms.gle/uE8w3FgjAcWyqAN58';
 export const DOCS_LINK =
   'https://govrn.gitbook.io/govrn-docs/overview/welcome-to-govrn';
 
-export const LEFT_MEMBERSHIP_NAME = 'Left';
-export const ADMIN_MEMBERSHIP_NAME = 'Admin';
-export const MEMBER_MEMBERSHIP_NAME = 'Member';
+/**
+ * Membership Names that represents different membership statuses in a DAO.
+ */
+export enum MembershipStatusesNames {
+  // Indicates that the user has left the DAO.
+  Left = 'Left',
+  Admin = 'Admin',
+  // Indicates that the user is a regular member of the DAO.v
+  Member = 'Member',
+}
 
 export const VERIFIED_CONTRIBUTION_NAME = 'Verified';


### PR DESCRIPTION
## Linear Ticket

[Eng-1050 - Recruits should not be able to view dashboard (?)](https://linear.app/govrn/issue/ENG-1050/recruits-should-not-be-able-to-view-dashboard)

## Description
This PR refactors the DAO dashboard permissions to restrict access to only Admins and Members. Previously, Recruiters also had access to the dashboard. 
With this change, Recruiters will now be prompted to join the DAO before they can access it.

 