### PR TITLE
qa/contribution-empty-state-improvement (ENG-1071)

### DIFF
--- a/apps/protocol-frontend/src/components/ContributionTypesTable.tsx
+++ b/apps/protocol-frontend/src/components/ContributionTypesTable.tsx
@@ -165,7 +165,7 @@ const ContributionTypesTable = ({
       }}
     >
       <Button variant="primary" size="md" width={{ base: '100%', lg: 'auto' }}>
-        Report Your First Contribution
+        Report a Contribution
       </Button>
     </ChakraLink>
   );

--- a/apps/protocol-frontend/src/components/ContributionsTable.tsx
+++ b/apps/protocol-frontend/src/components/ContributionsTable.tsx
@@ -293,7 +293,7 @@ const ContributionsTable = ({
       }}
     >
       <Button variant="primary" size="md" width={{ base: '100%', lg: 'auto' }}>
-        Report Your First Contribution
+        Report a Contribution
       </Button>
     </ChakraLink>
   );

--- a/apps/protocol-frontend/src/components/ContributionsTableShell.tsx
+++ b/apps/protocol-frontend/src/components/ContributionsTableShell.tsx
@@ -186,7 +186,10 @@ const ContributionsTableShell = () => {
                       <Text fontSize="lg" fontWeight="medium">
                         My Contributions
                       </Text>
-                      <SelectedContributions />
+                      {nonMintedContributions &&
+                      nonMintedContributions.length > 0 ? (
+                        <SelectedContributions />
+                      ) : null}
                     </Stack>
                   </Box>
                 ) : null}


### PR DESCRIPTION
## Linear Ticket

- [ENG-1071](https://linear.app/govrn/issue/ENG-1071/contributions-empty-state-improvement)

## Description

- Makes the empty state for contributions a bit more generic to reduce confusion 
- Removes the blue CTA box for attribution/minting since this is an empty state

## Screencaptures

<img width="1440" alt="contribution-empty-state-improvement" src="https://github.com/Govrn-HQ/govrn-monorepo/assets/9438776/8241d811-b510-4811-9d8a-eff5ef764d13">

