### PR TITLE
fix formatting for winston splat

### DIFF
--- a/apps/contract-sync-job/src/main.ts
+++ b/apps/contract-sync-job/src/main.ts
@@ -45,7 +45,7 @@ const main = async () => {
       ? new Date(lastRun[0].completedDate)
       : new Date(267285020000);
   const lookbackWindowStart = Math.ceil(
-    startDate.getTime() - OFFSET_DATE * 60 * 60,
+    startDate.getTime() / 1000 - OFFSET_DATE * 60 * 60,
   );
 
   logger.info(":: Last run's completed date: " + startDate.toISOString());

--- a/libs/utils/src/lib/logging.ts
+++ b/libs/utils/src/lib/logging.ts
@@ -1,12 +1,12 @@
 import { createLogger, format, transports } from 'winston';
 
-const { timestamp, json } = format;
+const { timestamp, json, splat } = format;
 
 // TODO: cust class appending appending more info per log
 export const getLogger = (source: string, tag: string) => {
   const logger = createLogger({
     level: 'info',
-    format: format.combine(timestamp(), json()),
+    format: format.combine(timestamp(), json(), splat()),
     defaultMeta: { source: source, tag: tag },
     transports: [new transports.Console()],
   });


### PR DESCRIPTION
## Linear Ticket

[1078](https://linear.app/govrn/issue/ENG-1078/logs-metrics-instrumentation-for-contract-sync-job)

## Description

Fixup format splat for winston %s %d etc logging

## Screencaptures

For frontend changes, considering adding a screenshot or screencapture of the changes.
Before/after screenshots may be helpful when relevant.
