### PR TITLE
qa/dao dashboard recruit empty state (ENG-1103)

### DIFF
--- a/apps/protocol-frontend/src/components/DaoDashboardShell.tsx
+++ b/apps/protocol-frontend/src/components/DaoDashboardShell.tsx
@@ -40,14 +40,12 @@ const CUSTOM_VALUE = 0;
 interface DaoDashboardShellProps {
   daoName: string;
   daoId: number;
-  daoMember: boolean;
   daoMembershipStatus?: string;
 }
 
 const DaoDashboardShell = ({
   daoName,
   daoId,
-  daoMember,
   daoMembershipStatus,
 }: DaoDashboardShellProps) => {
   const navigate = useNavigate();
@@ -57,6 +55,9 @@ const DaoDashboardShell = ({
   const userDaos = userDaosData?.userDaos;
 
   const daoRecruit = daoMembershipStatus === MembershipStatusesNames.Recruit;
+  const daoMember =
+    daoMembershipStatus === MembershipStatusesNames.Member ||
+    daoMembershipStatus === MembershipStatusesNames.Admin;
 
   const userDaoIds = new Map();
   userDaos?.forEach(dao => {

--- a/apps/protocol-frontend/src/components/DaoDashboardShell.tsx
+++ b/apps/protocol-frontend/src/components/DaoDashboardShell.tsx
@@ -41,18 +41,25 @@ interface DaoDashboardShellProps {
   daoName: string;
   daoId: number;
   daoMember: boolean;
+  daoMembershipStatus?: string;
 }
 
 const DaoDashboardShell = ({
   daoName,
   daoId,
   daoMember,
+  daoMembershipStatus,
 }: DaoDashboardShellProps) => {
   const navigate = useNavigate();
   const { userData } = useUser();
 
   const { data: userDaosData } = useUserGet({ userId: userData?.id });
   const userDaos = userDaosData?.userDaos;
+
+  console.log('dao member', daoMember);
+  console.log('dao membership status', daoMembershipStatus);
+
+  const daoRecruit = daoMembershipStatus === MembershipStatusesNames.Recruit;
 
   const userDaoIds = new Map();
   userDaos?.forEach(dao => {
@@ -182,6 +189,18 @@ const DaoDashboardShell = ({
     </Flex>
   );
 
+  const CopyChildrenRecruit = () => (
+    <Flex direction="column" alignItems="center" justifyContent="center">
+      <Text as="span">
+        {' '}
+        <span role="img" aria-labelledby="pointing up emoji">
+          🌱
+        </span>{' '}
+        Reach out to the DAO Admin to become a Member.
+      </Text>
+    </Flex>
+  );
+
   const ButtonChildren = () => (
     <Link to="/report">
       <Button variant="primary" size="md">
@@ -208,7 +227,7 @@ const DaoDashboardShell = ({
     );
   };
 
-  if (daoMember === false)
+  if (daoMember === false && !daoRecruit)
     return (
       <Stack
         paddingY={{ base: '4', md: '8' }}
@@ -252,6 +271,29 @@ const DaoDashboardShell = ({
           heading={`Click "Join DAO" to join ${daoName}`}
           emoji="🙌"
           copy={<CopyChildrenNotMember />}
+        />
+      </Stack>
+    );
+
+  if (daoRecruit)
+    return (
+      <Stack
+        paddingY={{ base: '4', md: '8' }}
+        paddingX={{ base: '4', md: '8' }}
+        color="gray.700"
+        width="100%"
+      >
+        <Flex
+          direction={{ base: 'column', lg: 'row' }}
+          justifyContent="space-between"
+          alignItems="center"
+        >
+          <PageHeading>{daoName}</PageHeading>
+        </Flex>
+        <GovrnCta
+          heading={`Click "Join DAO" to join ${daoName}`}
+          emoji="👀"
+          copy={<CopyChildrenRecruit />}
         />
       </Stack>
     );

--- a/apps/protocol-frontend/src/components/DaoDashboardShell.tsx
+++ b/apps/protocol-frontend/src/components/DaoDashboardShell.tsx
@@ -315,7 +315,7 @@ const DaoDashboardShell = ({
         </Flex>
         <GovrnCta
           heading={`Recruits are unable to view the dashboard`}
-          emoji="👀"
+          emoji="😭"
           copy={<CopyChildrenRecruit />}
         />
         <GovrnAlertDialog

--- a/apps/protocol-frontend/src/components/DaoDashboardShell.tsx
+++ b/apps/protocol-frontend/src/components/DaoDashboardShell.tsx
@@ -56,9 +56,6 @@ const DaoDashboardShell = ({
   const { data: userDaosData } = useUserGet({ userId: userData?.id });
   const userDaos = userDaosData?.userDaos;
 
-  console.log('dao member', daoMember);
-  console.log('dao membership status', daoMembershipStatus);
-
   const daoRecruit = daoMembershipStatus === MembershipStatusesNames.Recruit;
 
   const userDaoIds = new Map();
@@ -193,10 +190,10 @@ const DaoDashboardShell = ({
     <Flex direction="column" alignItems="center" justifyContent="center">
       <Text as="span">
         {' '}
-        <span role="img" aria-labelledby="pointing up emoji">
-          🌱
+        <span role="img" aria-labelledby="handshake emoji">
+          🤝
         </span>{' '}
-        Reach out to the DAO Admin to become a Member.
+        Reach out to the DAO Admin to become a Member of {daoName}.
       </Text>
     </Flex>
   );
@@ -289,11 +286,43 @@ const DaoDashboardShell = ({
           alignItems="center"
         >
           <PageHeading>{daoName}</PageHeading>
+          <Flex
+            flexBasis={{ base: '100%', lg: '60%' }}
+            direction={{ base: 'column', lg: 'row' }}
+            alignItems="center"
+            justifyContent={{ base: 'flex-start', lg: 'flex-end' }}
+            gap={2}
+            width={{ base: '100%', lg: 'auto' }}
+          >
+            <Flex
+              direction={{ base: 'column', lg: 'row' }}
+              alignItems="center"
+              justifyContent={{ base: 'flex-start', lg: 'flex-end' }}
+              width="auto"
+              gap={{ base: 0, lg: 2 }}
+            >
+              <Button
+                variant="secondary"
+                width="min-content"
+                px={8}
+                onClick={() => showLeavingDialog(true)}
+              >
+                Leave
+              </Button>
+            </Flex>
+          </Flex>
         </Flex>
         <GovrnCta
-          heading={`Click "Join DAO" to join ${daoName}`}
+          heading={`Recruits are unable to view the dashboard`}
           emoji="👀"
           copy={<CopyChildrenRecruit />}
+        />
+        <GovrnAlertDialog
+          title={<LeaveDaoDialogCopy />}
+          isOpen={isLeavingDialogShown}
+          isLoading={isLeavingLoading}
+          onConfirm={handleLeavingDao}
+          onCancel={() => showLeavingDialog(false)}
         />
       </Stack>
     );

--- a/apps/protocol-frontend/src/pages/DaoDashboard.tsx
+++ b/apps/protocol-frontend/src/pages/DaoDashboard.tsx
@@ -22,20 +22,12 @@ const DaoDashboard = () => {
     return currentDao?.membershipStatus?.name;
   }, [currentDao]);
 
-  const isDaoMember = useMemo(() => {
-    return (
-      currentDao?.membershipStatus?.name === MembershipStatusesNames.Member ||
-      currentDao?.membershipStatus?.name === MembershipStatusesNames.Admin
-    );
-  }, [currentDao]);
-
   return (
     <SiteLayout>
       {isConnected && isAuthenticated && (
         <DaoDashboardShell
           daoName={currentDao?.guild.name ?? ''}
           daoId={parseInt(guildId ? guildId : '')}
-          daoMember={isDaoMember}
           daoMembershipStatus={daoMembershipStatus}
         />
       )}

--- a/apps/protocol-frontend/src/pages/DaoDashboard.tsx
+++ b/apps/protocol-frontend/src/pages/DaoDashboard.tsx
@@ -18,6 +18,10 @@ const DaoDashboard = () => {
   const { guildId } = useParams();
   const currentDao = userDaos?.get(parseInt(guildId ? guildId : ''));
 
+  const daoMembershipStatus = useMemo(() => {
+    return currentDao?.membershipStatus?.name;
+  }, [currentDao]);
+
   const isDaoMember = useMemo(() => {
     return (
       currentDao?.membershipStatus?.name === MembershipStatusesNames.Member ||
@@ -32,6 +36,7 @@ const DaoDashboard = () => {
           daoName={currentDao?.guild.name ?? ''}
           daoId={parseInt(guildId ? guildId : '')}
           daoMember={isDaoMember}
+          daoMembershipStatus={daoMembershipStatus}
         />
       )}
     </SiteLayout>

--- a/apps/protocol-frontend/src/pages/DaoDashboard.tsx
+++ b/apps/protocol-frontend/src/pages/DaoDashboard.tsx
@@ -5,7 +5,6 @@ import { useAuth } from '../contexts/AuthContext';
 import SiteLayout from '../components/SiteLayout';
 import useUserGet from '../hooks/useUserGet';
 import DaoDashboardShell from '../components/DaoDashboardShell';
-import { MembershipStatusesNames } from '../utils/constants';
 import { useMemo } from 'react';
 
 const DaoDashboard = () => {

--- a/apps/protocol-frontend/src/utils/constants.ts
+++ b/apps/protocol-frontend/src/utils/constants.ts
@@ -82,9 +82,12 @@ export const DOCS_LINK =
 export enum MembershipStatusesNames {
   // Indicates that the user has left the DAO.
   Left = 'Left',
+  // Indicates that the user is an Admin of the DAO.
   Admin = 'Admin',
-  // Indicates that the user is a regular member of the DAO.v
+  // Indicates that the user is a Member of the DAO.
   Member = 'Member',
+  // Indicates that the user is a Recruit of the DAO.
+  Recruit = 'Recruit',
 }
 
 export const VERIFIED_CONTRIBUTION_NAME = 'Verified';


### PR DESCRIPTION
## Linear Ticket

Note: This is a draft to allow a chance for copy review/feedback

- This resolves [ENG-1103](https://linear.app/govrn/issue/ENG-1103/qa-add-empty-state-for-dao-dashboard-if-someone-is-a-recruit)

## Description

- Adds an additional view if someone is a Recruit and adds the Leave button in instead of Join
- Switched the `daoMember` to `daoMembershipStatus` and checking for the status and conditionally rendering in DaoDashboardShell


## Screencaptures

Pending copy review, but here's the flow:

![dao-dashboard-recruit-view](https://github.com/Govrn-HQ/govrn-monorepo/assets/9438776/b262857c-1db2-4ebd-bd9f-223d31ee8cbc)

https://github.com/Govrn-HQ/govrn-monorepo/assets/9438776/bb4ec962-f021-427b-845f-6183b4543fc2


